### PR TITLE
Fix: replace all occurrences of strings in files (webpack)

### DIFF
--- a/templates/common/webpack/webpack.dev.conf.js
+++ b/templates/common/webpack/webpack.dev.conf.js
@@ -102,15 +102,15 @@ module.exports = {
         files: ['plugin.json', 'README.md'],
         rules: [
           {
-            search: '%VERSION%',
+            search: /\%VERSION\%/g,
             replace: getPackageJson().version,
           },
           {
-            search: '%TODAY%',
+            search: /\%TODAY\%/g,
             replace: new Date().toISOString().substring(0, 10),
           },
           {
-            search: '%PLUGIN_ID%',
+            search: /\%PLUGIN_ID\%/g,
             replace: getPluginId(),
           },
         ],

--- a/templates/common/webpack/webpack.prod.conf.js
+++ b/templates/common/webpack/webpack.prod.conf.js
@@ -102,15 +102,15 @@ module.exports = {
         files: ['plugin.json', 'README.md'],
         rules: [
           {
-            search: '%VERSION%',
+            search: /\%VERSION\%/g,
             replace: getPackageJson().version,
           },
           {
-            search: '%TODAY%',
+            search: /\%TODAY\%/g,
             replace: new Date().toISOString().substring(0, 10),
           },
           {
-            search: '%PLUGIN_ID%',
+            search: /\%PLUGIN_ID\%/g,
             replace: getPluginId(),
           },
         ],


### PR DESCRIPTION
### What changed?

Unfortunately the current Webpack config only replaces the first occurrences of the template strings in files like `plugin.json` (e.g. `%PLUGIN_ID%`), which can be problematic. This PR fixes that.