### PR TITLE
Feat: allow resolving json modules in TypeScript

### DIFF
--- a/templates/common/tsconfig.json
+++ b/templates/common/tsconfig.json
@@ -4,7 +4,8 @@
     "declaration": false,
     "rootDir": "./src",
     "baseUrl": "./src",
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "resolveJsonModule": true
   },
   "include": ["src", "types"],
   "extends": "@grafana/tsconfig"


### PR DESCRIPTION
**What changed?**

Added the `resolveJsonModule: true` to the `tsconfig.json` to be able to import json modules, e.g. the `plugin.json` in scaffolded plugins.