### PR TITLE
Templates/Webpack: stop using SWC for bundle optimization

### DIFF
--- a/templates/common/.config/webpack/webpack.config.ts
+++ b/templates/common/.config/webpack/webpack.config.ts
@@ -88,10 +88,6 @@ const config = (env): Configuration => ({
                 decorators: false,
                 dynamicImport: true,
               },
-              minify: {
-                compress: Boolean(env.production),
-                mangle: Boolean(env.production),
-              },
             },
           },
         },


### PR DESCRIPTION
**Related issue** https://github.com/grafana/grafana-plugin-examples/issues/65

### What changed?
There were some issues with running both Terser (Webpack) and SWC to minimize and mangle the production bundle, it was causing some weird JS errors runtime in certain cases. 

To prevent this we are now only relying on Webpack's own optimization.