### PR TITLE
Templates: use pinned version numbers 

### DIFF
--- a/templates/common/package.json
+++ b/templates/common/package.json
@@ -19,8 +19,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "^7.16.7",
-    "@grafana/e2e": "latest",
-    "@grafana/e2e-selectors": "latest",
+    "@grafana/e2e": "8.4.5",
+    "@grafana/e2e-selectors": "8.4.5",
     "@grafana/eslint-config": "^2.5.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@swc/core": "^1.2.144",
@@ -58,9 +58,9 @@
   },
   "dependencies": {
     "@emotion/css": "^11.1.3",
-    "@grafana/data": "latest",
-    "@grafana/runtime": "latest",
-    "@grafana/ui": "latest",
+    "@grafana/data": "8.4.5",
+    "@grafana/runtime": "8.4.5",
+    "@grafana/ui": "8.4.5",
     "@types/lodash": "latest"{{#if_eq pluginType "app"}},
     "react-router-dom": "^5.2.0"
     {{/if_eq}}


### PR DESCRIPTION
### What changed?

The reason for the change came from @jackw's [review comment](https://github.com/grafana/grafana-plugin-examples/pull/67#discussion_r843946661). (It is much easier for us to oversee what Grafana version a plugin actually depends on, as like this we don't need to scan through the `yarn.lock` every time.