### PR TITLE
Readme: add migration and update guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ yarn dlx @grafana/create-plugin
 
 ## Migrate your existing plugin
 
-In case you have an existing plugin previously created using the `@grafana/toolkit`, then you can use the
+In case you have an existing plugin previously created using the `@grafana/toolkit` you can use the
 following command to migrate it to the new build tooling:
 
 ```bash
@@ -75,6 +75,8 @@ npx @grafana/create-plugin migrate
 ---
 
 ## Update your plugin build config
+
+**In case your plugin was using `@grafana/toolkit` before make sure to migrate it first using `npx @grafana/create-plugin migrate`.**
 
 As new Grafana versions come out we keep updating our plugin build tooling as well to stay compatible and to make it more performant.
 In order to receive these changes and to make sure your plugin is compatible with the most recent Grafana versions you can use the `update` command,


### PR DESCRIPTION
### What changed?

Updated the README to have some information about the new `update` and `migrate` commands.

[Link to the updated README](https://github.com/grafana/create-plugin/tree/leventebalogh/update-readme/#readme)

|  **Before**  |    **After**    |
|--------------|-----------------|
|![Screenshot 2022-05-30 at 7 57 47](https://user-images.githubusercontent.com/9974811/170927209-6e586ebf-8554-4dba-8775-cbce2ab726c6.png)|![Screenshot 2022-05-30 at 8 03 08](https://user-images.githubusercontent.com/9974811/170927220-d46ff5f3-fba8-4a8e-b055-5cc4d3045839.png)|