### PR TITLE
Utils: make it possible to delete folders with content

### DIFF
--- a/src/utils/utils.files.ts
+++ b/src/utils/utils.files.ts
@@ -46,7 +46,7 @@ export function getOnlyNotExistingInCwd(files: string[]) {
 
 export function removeFilesInCwd(files: string[]) {
   for (const file of files) {
-    fs.rmSync(path.join(process.cwd(), file));
+    fs.rmSync(path.join(process.cwd(), file), { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
### What changed?

Until now the `migrate` command was failing when it was trying to delete folders that became unnecessary in the plugin (e.g. `./webpack`) in case they were containing files. This pull request is fixing that by using the `-r` and `-f` flags in the utility function. 