### PR TITLE
Migrate Command: fix a typo for the `jest.config.js` filename

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,7 +46,7 @@ export const MIGRATION_CONFIG = {
     '.prettierrc.js',
     'docker-compose.yaml',
     'jest-setup.js',
-    'jest-config.js',
+    'jest.config.js',
     'tsconfig.json',
   ],
   // Files that are mandatory for the plugins, but we don't want to ever override them. We are only creating the ones that don't exist.


### PR DESCRIPTION
### What changed?

There was a typo in one of the file names to override (`jest-config.js` instead of `jest.config.js`).
This resulted in the Jest config not being updated during migrations.