### PR TITLE
Migration Command: remove the `docker-compose.yml` file

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,7 +44,7 @@ export const MIGRATION_CONFIG = {
     '.eslintrc',
     '.nvmrc',
     '.prettierrc.js',
-    'docker-compose.yaml',
+    'docker-compose.yaml', // Using .yaml instead of .yml (https://yaml.org/faq.html)
     'jest-setup.js',
     'jest.config.js',
     'tsconfig.json',
@@ -53,7 +53,7 @@ export const MIGRATION_CONFIG = {
   // (paths are relative to the scaffolded projects root)
   filesToExist: ['CHANGELOG.md'],
   // Files that are no longer needed for the project and possibly can be removed.
-  filesToRemove: ['Dockerfile', 'webpack/', '.webpack/', '.prettierrc'],
+  filesToRemove: ['Dockerfile', 'docker-compose.yml', 'webpack/', '.webpack/', '.prettierrc'],
   // NPM dependencies that are no longer needed for the project and possibly can be removed.
   npmDependenciesToRemove: ['ts-loader', 'babel-loader', '@grafana/toolkit'],
 };


### PR DESCRIPTION
### What changed?
We opted to use the suggested `.yaml` file extension for our docker-compose config, however this can result in weird issues if the project was previously using a docker-compose config with a `.yml` extension.

This PR fixes that by removing the file with the "old extension" after generating the new version of the file.