### PR TITLE
Add organization name and plugin type suffix

### DIFF
--- a/src/commands/generate.plopfile.ts
+++ b/src/commands/generate.plopfile.ts
@@ -2,7 +2,7 @@ import type { NodePlopAPI, ModifyActionConfig } from 'plop';
 import glob from 'glob';
 import path from 'path';
 import fs from 'fs';
-import { ifEq } from '../utils/utils.handlebars';
+import { ifEq, normalizeId } from '../utils/utils.handlebars';
 import {
   EXPORT_PATH_PREFIX,
   IS_DEV,
@@ -24,6 +24,7 @@ type CliArgs = {
 // Plopfile API documentation: https://plopjs.com/documentation/#plopfile-api
 export default function (plop: NodePlopAPI) {
   plop.setHelper('if_eq', ifEq);
+  plop.setHelper('normalize_id', normalizeId);
 
   plop.setGenerator('create-plugin', {
     description: 'used to scaffold a grafana plugin',

--- a/src/utils/tests/utils.handlebars.test.ts
+++ b/src/utils/tests/utils.handlebars.test.ts
@@ -1,0 +1,35 @@
+import { PLUGIN_TYPES } from '../../constants';
+import { normalizeId } from '../utils.handlebars';
+
+describe('Handlebars helpers', () => {
+  describe('normalize id', () => {
+    test.each([PLUGIN_TYPES.app, PLUGIN_TYPES.datasource, PLUGIN_TYPES.panel])(
+      'should return the id with the type appended',
+      (type: PLUGIN_TYPES) => {
+        const pluginName = 'my-plugin';
+        const orgName = 'my-org';
+        const actual = normalizeId(pluginName, orgName, type);
+        expect(actual).toEqual(`my-org-my-plugin-${type}`);
+      }
+    );
+    test.each([PLUGIN_TYPES.app, PLUGIN_TYPES.datasource, PLUGIN_TYPES.panel])(
+      'should not duplicate the type if it is already present',
+      (type: PLUGIN_TYPES) => {
+        const pluginName = `my-plugin-${type}`;
+        const orgName = 'my-org';
+        const actual = normalizeId(pluginName, orgName, type);
+        expect(actual).toEqual(`my-org-my-plugin-${type}`);
+      }
+    );
+
+    test.each([PLUGIN_TYPES.app, PLUGIN_TYPES.datasource, PLUGIN_TYPES.panel])(
+      'should not duplicate the type if it is already present (no dash before type)',
+      (type: PLUGIN_TYPES) => {
+        const pluginName = `my-plugin${type}`;
+        const orgName = 'my-org';
+        const actual = normalizeId(pluginName, orgName, type);
+        expect(actual).toEqual(`my-org-my-plugin-${type}`);
+      }
+    );
+  });
+});

--- a/src/utils/utils.handlebars.ts
+++ b/src/utils/utils.handlebars.ts
@@ -3,10 +3,17 @@ import * as changeCase from 'change-case';
 import titleCase from 'title-case';
 import upperCase from 'upper-case';
 import lowerCase from 'lower-case';
+import { PLUGIN_TYPES } from '../constants';
 
 // Why? The `{#if}` expression in Handlebars unfortunately only accepts a boolean, which makes it hard to compare values in templates.
 export const ifEq = (a: any, b: any, options: HelperOptions) => {
   return a === b ? options.fn(this) : options.inverse(this);
+};
+
+export const normalizeId = (pluginName: string, orgName: string, type: PLUGIN_TYPES) => {
+  const re = new RegExp(`-?${type}$`, 'i');
+  const newPluginName = pluginName.replace(re, '');
+  return changeCase.paramCase(orgName) + '-' + changeCase.paramCase(newPluginName) + `-${type}`;
 };
 
 // Needed when we are rendering the templates outside of the context of Plop but still would like to support the same helpers

--- a/templates/app/src/plugin.json
+++ b/templates/app/src/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "{{ titleCase pluginName }}",
-  "id": "{{ kebabCase pluginName }}",
+  "id": "{{ normalize_id pluginName orgName 'app' }}",
   "info": {
     "description": "{{ sentenceCase pluginDescription }}",
     "author": {

--- a/templates/datasource/src/plugin.json
+++ b/templates/datasource/src/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "{{ titleCase pluginName }}",
-  "id": "{{ kebabCase orgName }}-{{ kebabCase pluginName }}",
+  "id": "{{ normalize_id pluginName orgName 'datasource' }}",
   "metrics": true,
   "backend": true,
   "executable": "gpx_{{ snakeCase pluginName }}",
@@ -11,9 +11,7 @@
     "author": {
       "name": "{{ sentenceCase orgName }}"
     },
-    "keywords": [
-      "datasource"
-    ],
+    "keywords": ["datasource"],
     "logos": {
       "small": "img/logo.svg",
       "large": "img/logo.svg"

--- a/templates/panel/src/plugin.json
+++ b/templates/panel/src/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "panel",
   "name": "{{ titleCase pluginName }}",
-  "id": "{{ kebabCase pluginName }}",
+  "id": "{{ normalize_id pluginName orgName 'panel' }}",
   "info": {
     "description": "{{ sentenceCase pluginDescription }}",
     "author": {


### PR DESCRIPTION
closes https://github.com/grafana/create-plugin/issues/3

* Adds the missing organization name to the plugin id
* Adds the plugin type suffix to the plugin id