### PR TITLE
Do not use docker to run cypress

### DIFF
--- a/templates/common/package.json
+++ b/templates/common/package.json
@@ -10,9 +10,9 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",
-    "e2e": "docker run --rm --add-host=host.docker.internal:host-gateway --volume $(pwd):/e2e --workdir /e2e --env='CYPRESS_HOST=host.docker.internal' --env='CYPRESS_BASE_URL=http://host.docker.internal:3000' --entrypoint '/bin/bash' cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97 -c './node_modules/.bin/cypress install && yarn grafana-e2e run'",
-    "e2e:update": "docker run --rm --add-host=host.docker.internal:host-gateway --volume $(pwd):/e2e --workdir /e2e --env='CYPRESS_HOST=host.docker.internal' --env='CYPRESS_BASE_URL=http://host.docker.internal:3000' --entrypoint '/bin/bash' cypress/included:9.5.1-node16.14.0-slim-chrome99-ff97 -c './node_modules/.bin/cypress install && yarn grafana-e2e run --update-screenshots'",
-    "server": "docker-compose up -d --build"
+    "e2e": "yarn cypress install && yarn grafana-e2e run",
+    "e2e:update": "yarn cypress install && yarn grafana-e2e run --update-screenshots",
+    "server": "docker-compose up --build"
   },
   "author": "{{ sentenceCase orgName }}",
   "license": "Apache-2.0",


### PR DESCRIPTION
* Changes `e2e` commands to not use docker
* Changes `server` command to not keep running in the background so it is easier to kill 