### PR TITLE
Remove @grafana/* devDependencies when migrating

### DIFF
--- a/src/commands/migrate.command.ts
+++ b/src/commands/migrate.command.ts
@@ -69,9 +69,11 @@ export const migrate = async () => {
     // (skipped automatically if there is nothing to be removed)
     // ------------------------------------------------
     const dependenciesToRemove = getRemovableNpmDependencies(MIGRATION_CONFIG.npmDependenciesToRemove);
+    const devDependenciesToRemove = getRemovableNpmDependencies(MIGRATION_CONFIG.devNpmDependenciesToRemove);
     if (dependenciesToRemove.length) {
       if (await confirmPrompt(TEXT.removeNpmDependenciesPrompt + '\n' + displayArrayAsList(dependenciesToRemove))) {
         removeNpmDependencies(dependenciesToRemove);
+        removeNpmDependencies(devDependenciesToRemove, { devOnly: true });
         printSuccessMessage(TEXT.removeNpmDependenciesSuccess);
       } else {
         printMessage(TEXT.removeNpmDependenciesAborted);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,6 +57,7 @@ export const MIGRATION_CONFIG = {
   filesToRemove: ['Dockerfile', 'docker-compose.yml', 'webpack/', '.webpack/', '.prettierrc'],
   // NPM dependencies that are no longer needed for the project and possibly can be removed.
   npmDependenciesToRemove: ['ts-loader', 'babel-loader', '@grafana/toolkit'],
+  devNpmDependenciesToRemove: ['@grafana/toolkit', '@grafana/runtime', '@grafana/data', '@grafana/ui'],
 };
 
 export const UDPATE_CONFIG = {

--- a/src/utils/utils.npm.ts
+++ b/src/utils/utils.npm.ts
@@ -163,11 +163,13 @@ export function getRemovableNpmDependencies(packageNames: string[]) {
   return packageNames.filter((packageName) => dependencies[packageName] || devDependencies[packageName]);
 }
 
-export function removeNpmDependencies(packageNames: string[]) {
+export function removeNpmDependencies(packageNames: string[], { devOnly = false } = {}) {
   const packageJson = getPackageJson();
 
   for (const packageName of packageNames) {
-    delete packageJson.dependencies[packageName];
+    if (!devOnly) {
+      delete packageJson.dependencies[packageName];
+    }
     delete packageJson.devDependencies[packageName];
   }
 


### PR DESCRIPTION
* Some plugins use the grafana packages as `devDependencies`. They should live inside `dependencies`. this introduces a change to remove them from devDependencies.
* Upgrades grafana version to 9.1.2