### PR TITLE
Do not use TS_NODE_PROJECT for webpack configuration

### DIFF
--- a/packages/create-plugin/templates/common/.config/README.md
+++ b/packages/create-plugin/templates/common/.config/README.md
@@ -109,12 +109,12 @@ We need to update the `scripts` in the `package.json` to use the extended Webpac
 
 **Update for `build`:**
 ```diff
--"build": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -c ./.config/webpack/webpack.config.ts --env production",
-+"build": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -c ./webpack.config.ts --env production",
+-"build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
++"build": "webpack -c ./webpack.config.ts --env production",
 ```
 
 **Update for `dev`:**
 ```diff
--"dev": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -w -c ./.config/webpack/webpack.config.ts --env development",
-+"dev": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -w -c ./webpack.config.ts --env development",
+-"dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
++"dev": "webpack -w -c ./webpack.config.ts --env development",
 ```

--- a/packages/create-plugin/templates/common/.config/tsconfig.json
+++ b/packages/create-plugin/templates/common/.config/tsconfig.json
@@ -12,6 +12,14 @@
     "typeRoots": ["../node_modules/@types"],
     "resolveJsonModule": true
   },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs",
+      "target": "es5",
+      "esModuleInterop": true
+    },
+    "transpileOnly": true
+  },
   "include": ["../src", "./types"],
   "extends": "@grafana/tsconfig"
 }

--- a/packages/create-plugin/templates/common/.config/webpack/tsconfig.webpack.json
+++ b/packages/create-plugin/templates/common/.config/webpack/tsconfig.webpack.json
@@ -1,9 +1,0 @@
-{
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es5",
-    "esModuleInterop": true
-  },
-  "transpileOnly": true,
-  "transpiler": "ts-node/transpilers/swc-experimental"
-}

--- a/packages/create-plugin/templates/common/package.json
+++ b/packages/create-plugin/templates/common/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "{{ sentenceCase pluginDescription }}",
   "scripts": {
-    "build": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "dev": "TS_NODE_PROJECT=\"./.config/webpack/tsconfig.webpack.json\" webpack -w -c ./.config/webpack/webpack.config.ts --env development",
+    "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
+    "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Fixes https://github.com/grafana/create-plugin/issues/71

Instead of using an environment variable it uses an overwrite in the tsconfig for ts-node (which transpiles the webpack config).

the transpiler `ts-node/transpilers/swc-experimental` was removed from the config as it was creating problems with ts-node and it is a minimal optimization in speed for this specific case.

With these changes the generated scripts run natively in windows. 

![image](https://user-images.githubusercontent.com/227916/196659709-e43ddb96-fff3-4338-97a1-b35204193d6e.png)

