### PR TITLE
Add e2e to CI workflow

### DIFF
--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -47,8 +47,14 @@ jobs:
       - name: Build and test frontend
         run: yarn build
 
+      - name: Start grafana docker
+        run: yarn server
+
       - name: Run e2e tests
         run: yarn e2e
+
+      - name: stop grafana docker
+        run: docker-compose down
 
       - name: Check for backend
         id: check-for-backend

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: yarn build
 
       - name: Start grafana docker
-        run: yarn server
+        run: yarn server -d
 
       - name: Run e2e tests
         run: yarn e2e

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Build and test frontend
         run: yarn build
 
+      - name: Run e2e tests
+        run: yarn e2e
+
       - name: Check for backend
         id: check-for-backend
         run: |


### PR DESCRIPTION
Fixes https://github.com/grafana/plugin-tools/issues/41

We generate the e2e script by default with valid e2e tests by default. We can add the e2e step into the workflow
