### PR TITLE
Feature: Add signPlugin.version to manifest to sign-plugin

### DIFF
--- a/packages/sign-plugin/src/commands/sign.command.ts
+++ b/packages/sign-plugin/src/commands/sign.command.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import minimist from 'minimist';
 import { assertRootUrlIsValid } from '../utils/pluginValidation';
 import { buildManifest, signManifest, saveManifest } from '../utils/manifest';
+import { getVersion } from '../utils/getVersion';
 
 export const sign = async (argv: minimist.ParsedArgs) => {
   const pluginDistDir = path.resolve('dist');
@@ -22,7 +23,7 @@ export const sign = async (argv: minimist.ParsedArgs) => {
       manifest.rootUrls = rootUrls;
     }
 
-    manifest.toolkit = { version: '' };
+    manifest.signPlugin = { version: getVersion() };
     const signedManifest = await signManifest(manifest);
 
     console.log('Saving signed manifest...');

--- a/packages/sign-plugin/src/utils/getVersion.ts
+++ b/packages/sign-plugin/src/utils/getVersion.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+
+export const getVersion = () => {
+  const pkg = readFileSync(`${__dirname}/../../package.json`, 'utf8');
+  const { version } = JSON.parse(pkg);
+  if (!version) {
+    throw `Could not find the version of sign-plugin`;
+  }
+  return version;
+};

--- a/packages/sign-plugin/src/utils/manifest.ts
+++ b/packages/sign-plugin/src/utils/manifest.ts
@@ -15,7 +15,7 @@ export interface ManifestInfo {
   plugin: string;
   version: string;
   files: Record<string, string>;
-  toolkit?: {
+  signPlugin?: {
     version: string;
   };
 }


### PR DESCRIPTION
This PR adds `signPlugin.version` to manifest calls to gcom. Previously this field was called toolkit. This PR will cause signing attempts to fail until gcom is updated to cater for this new field. ✌️ 

