### PR TITLE
Prevent webpack to clean binaries from go

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -117,7 +117,9 @@ const config = async (env): Promise<Configuration> => ({
   },
 
   output: {
-    clean: true,
+    clean: {
+      keep: /gpx_.*/,
+    },
     filename: '[name].js',
     libraryTarget: 'amd',
     path: path.resolve(process.cwd(), DIST_DIR),


### PR DESCRIPTION
Fixes https://github.com/grafana/plugin-tools/issues/54

Adds a condition for webpack to not clean built binaries
