### PR TITLE
Change update prompt message to clarify what is updating

### DIFF
--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -16,7 +16,7 @@ export const update = async () => {
 
     // 1. Add / update configuration files
     // -----------------------------------
-    if (await confirmPrompt(TEXT.overrideFilesPrompt)) {
+    if (await confirmPrompt(TEXT.updateConfigPrompt)) {
       compileTemplateFiles(UDPATE_CONFIG.filesToOverride, getTemplateData());
       printSuccessMessage(TEXT.overrideFilesSuccess);
     } else {

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -89,6 +89,8 @@ export const TEXT = {
   removeNpmDependenciesSuccess: 'Unnecessary NPM dependencies removed successfully.',
   removeNpmDependenciesAborted: 'No NPM dependencies have been removed.',
 
+  updateConfigPrompt: "**Would you like to update the project's configuration?**",
+
   updateNpmScriptsPrompt: '**Would you like to update the `{ scripts }` in your `package.json`?**',
   updateNpmScriptsSuccess: 'NPM scripts updated successfully.',
   updateNpmScriptsAborted: 'No NPM scripts have been added or updated.',


### PR DESCRIPTION
Closes https://github.com/grafana/plugin-tools/issues/80

Create-plugin overwrites all the `.config` folder when `update` runs. This PR changes the prompt to confirm the update that was previously suggestion a list of files was to be displayed
