### PR TITLE
App: disable backend by default in yarn generate-app

### DIFF
--- a/packages/create-plugin/scripts/generate-app.js
+++ b/packages/create-plugin/scripts/generate-app.js
@@ -15,7 +15,7 @@ async function generatePanel() {
     orgName: 'my-org',
     pluginDescription: 'Auto-generated app',
     pluginType: 'app',
-    hasBackend: true,
+    hasBackend: false,
     hasGithubWorkflows: true,
     hasGithubLevitateWorkflow: true,
   });


### PR DESCRIPTION
Adjusts the script that is run when calling `yarn generate-app` to **not** include the backend by default. I think this case needs a bit more love. 