### PR TITLE
Fix: Make sure webpack and jest can resolve "rootDir" paths

### DIFF
--- a/packages/create-plugin/templates/common/.config/jest.config.js
+++ b/packages/create-plugin/templates/common/.config/jest.config.js
@@ -5,6 +5,7 @@
  */
 
 module.exports = {
+  modulePaths: ['<rootDir>/src'],
   testEnvironment: 'jest-environment-jsdom',
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}',

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -181,6 +181,8 @@ const config = async (env): Promise<Configuration> => ({
 
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    // handle resolving "rootDir" paths
+    modules: [path.resolve(process.cwd(), 'src'), 'node_modules'],
     unsafeCache: true,
   },
 });


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Toolkit's webpack config adds `src` to the list of module lookups allowing devs to write paths in a similar fashion to typescript `rootDir` feature. This PR adds this to webpack and jest.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #101

**Special notes for your reviewer**:
