### PR TITLE
Use normalize_id for docker-compose.yml instead of only pluginName

### DIFF
--- a/packages/create-plugin/src/utils/utils.handlebars.ts
+++ b/packages/create-plugin/src/utils/utils.handlebars.ts
@@ -37,6 +37,7 @@ export function registerHandlebarsHelpers() {
     properCase: changeCase.pascalCase,
     pascalCase: changeCase.pascalCase,
     if_eq: ifEq,
+    normalize_id: normalizeId,
   };
 
   Object.keys(helpers).forEach((helperName) =>

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.0'
 
 services:
   grafana:
-    container_name: '{{ kebabCase pluginName }}'
+    container_name: '{{ normalize_id pluginName orgName pluginType }}'
     build:
       context: ./.config
       args:
@@ -10,5 +10,5 @@ services:
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/{{ kebabCase pluginName }}
+      - ./dist:/var/lib/grafana/plugins/{{ normalize_id pluginName orgName pluginType }}
       - ./provisioning:/etc/grafana/provisioning


### PR DESCRIPTION
Fixes: https://github.com/grafana/plugin-tools/issues/62

Using the pluginId instead of only the pluginName

Example of a newly generated docker-compose file:

```yml
version: '3.0'

services:
  grafana:
    container_name: 'myorg-myplugin-panel'
    build:
      context: ./.config
      args:
        grafana_version: ${GRAFANA_VERSION:-9.1.2}
    ports:
      - 3000:3000/tcp
    volumes:
      - ./dist:/var/lib/grafana/plugins/myorg-myplugin-panel
      - ./provisioning:/etc/grafana/provisioning
```