### PR TITLE
Updating app template to use compatible icon

### DIFF
--- a/packages/create-plugin/templates/app/src/module.ts
+++ b/packages/create-plugin/templates/app/src/module.ts
@@ -4,7 +4,7 @@ import { AppConfig } from './components/AppConfig';
 
 export const plugin = new AppPlugin<{}>().setRootPage(App).addConfigPage({
   title: 'Configuration',
-  icon: 'fa fa-cog',
+  icon: 'cog',
   // @ts-ignore - Would expect a Class component, however works absolutely fine with a functional one
   // Implementation: https://github.com/grafana/grafana/blob/fd44c01675e54973370969dfb9e78f173aff7910/public/app/features/plugins/PluginPage.tsx#L157
   body: AppConfig,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The current template will not build against canary release as it will fail with. This PR updates the icon to make it compatible.

```
TS2322: Type '"fa fa-cog"' is not assignable to type '"search" | "repeat" | "anchor" | "link" | "table" | "circle" | "filter" | "info" | "google" | "microsoft" | "github" | "gitlab" | "okta" | "angle-double-down" | "angle-double-right" | ... 172 more ... | undefined'.
     5 | export const plugin = new AppPlugin<{}>().setRootPage(App).addConfigPage({
     6 |   title: 'Configuration',
  >  7 |   icon: 'fa fa-cog',
       |   ^^^^
     8 |   // @ts-ignore - Would expect a Class component, however works absolutely fine with a functional one
     9 |   // Implementation: https://github.com/grafana/grafana/blob/fd44c01675e5497[33](https://github.com/grafana/grafana-plugin-examples/actions/runs/3298636396/jobs/5441011599#step:24:34)70969dfb9e78f173aff7910/public/app/features/plugins/PluginPage.tsx#L157
    10 |   body: AppConfig,

webpack 5.74.0 compiled with 1 error in 6000 ms
```