### PR TITLE
Instruct jest to transform all packages (including all inside node_modules)

### DIFF
--- a/packages/create-plugin/templates/common/.config/jest.config.js
+++ b/packages/create-plugin/templates/common/.config/jest.config.js
@@ -32,7 +32,5 @@ module.exports = {
       },
     ],
   },
-  transformIgnorePatterns: [
-    'node_modules/(?!(ol)/)', // <- exclude the open layers library
-  ],
+  transformIgnorePatterns: [],
 };


### PR DESCRIPTION
Closes https://github.com/grafana/plugin-tools/issues/111

This is an initial solution to the problem described in https://github.com/grafana/plugin-tools/issues/111

It is not feaseable for now to create an maintain a list of packages that need transformation and we'll investigate later in the future a better performant solution.

For now, even though slower, this guarantees tests to run inside jest with ESM and commonjs code.
