### PR TITLE
Create-Plugin: Ignore grafana dependencies when migrating

### DIFF
--- a/packages/create-plugin/src/commands/migrate.command.ts
+++ b/packages/create-plugin/src/commands/migrate.command.ts
@@ -58,8 +58,12 @@ export const migrate = async () => {
     // (skipped automatically if there is nothing to update)
     // ------------------------------------------------
     if (hasNpmDependenciesToUpdate()) {
-      if (await confirmPrompt(TEXT.updateNpmDependenciesPrompt + getPackageJsonUpdatesAsText())) {
-        updatePackageJson();
+      if (
+        await confirmPrompt(
+          TEXT.updateNpmDependenciesPrompt + getPackageJsonUpdatesAsText({ ignoreGrafanaDependencies: true })
+        )
+      ) {
+        updatePackageJson({ ignoreGrafanaDependencies: true });
         printSuccessMessage(TEXT.updateNpmDependenciesSuccess);
       } else {
         printMessage(TEXT.updateNpmDependenciesAborted);

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -40,6 +40,15 @@ export const EXTRA_TEMPLATE_VARIABLES = {
   grafanaVersion: '9.1.2',
 };
 
+export const GRAFANA_FE_PACKAGES = [
+  '@grafana/data',
+  '@grafana/e2e-selectors',
+  '@grafana/e2e',
+  '@grafana/runtime',
+  '@grafana/schema',
+  '@grafana/ui',
+];
+
 export const MIGRATION_CONFIG = {
   // Files that should be overriden during a migration.
   // (paths are relative to the scaffolded projects root)


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR prevents create-plugin from updating any `@grafana/` dependencies that are already listed in a plugins `package.json` when running `npx @create-plugin migrate`. Doing so should ease the pain for a plugin developer migrating without needing to edit source code to deal with typescript errors in build or test.

This feels a little tricky to implement as we rely heavily on the templates for location of dependencies and delete `@grafana/**` dependencies that are listed as `devDependencies` when they should be `dependencies` etc. This led me to opt for to storing references to the "original" package versions then, when calculating the NPM updates, use these references instead to keep the moving / deleting logic without changing the package versions.


| Before | After |
| --- | --- |
| <img width="1679" alt="Screenshot 2022-10-26 at 16 15 07" src="https://user-images.githubusercontent.com/73201/198050489-64a6914a-569f-42c5-b6e1-5eb7653929b6.png"> | <img width="1677" alt="Screenshot 2022-10-26 at 16 15 20" src="https://user-images.githubusercontent.com/73201/198050478-468ac28e-ad24-4705-8ea4-53e25b2f3062.png"> |


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49

**Special notes for your reviewer**:
Bear in mind create-plugin will _still_ introduce `@grafana` dependencies with the "latest" version if they are not present in the plugins `package.json`. An example of this is clock-panel that has no e2e setup however during migration `e2e` and `e2e-selectors` are added along with a docker compose that reference 9.1.2. I don't really think we should get too smart with this and I'm leaning towards us adding a "next steps" document for post migration that covers these sorts of things to aid developers to make the most out of the setup create-plugin migration will provide.