### PR TITLE
Add a manual mock for react-inlinesvg to prevent errors when running test with grafana-ui and icons

### DIFF
--- a/packages/create-plugin/templates/common/.config/jest.config.js
+++ b/packages/create-plugin/templates/common/.config/jest.config.js
@@ -4,9 +4,12 @@
  * In order to extend the configuration follow the steps in .config/README.md
  */
 
+const path = require('path');
+
 module.exports = {
   moduleNameMapper: {
     "\\.(css|scss|sass)$": "identity-obj-proxy",
+    "react-inlinesvg": path.resolve(__dirname, "mocks", "react-inlinesvg.tsx"),
   },
   modulePaths: ['<rootDir>/src'],
   setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],

--- a/packages/create-plugin/templates/common/.config/mocks/react-inlinesvg.tsx
+++ b/packages/create-plugin/templates/common/.config/mocks/react-inlinesvg.tsx
@@ -1,0 +1,25 @@
+// Due to the grafana/ui Icon component making fetch requests to
+// `/public/img/icon/<icon_name>.svg` we need to mock react-inlinesvg to prevent
+// the failed fetch requests from displaying errors in console.
+
+import React from 'react';
+
+type Callback = (...args: any[]) => void;
+
+export interface StorageItem {
+  content: string;
+  queue: Callback[];
+  status: string;
+}
+
+export const cacheStore: { [key: string]: StorageItem } = Object.create(null);
+
+const SVG_FILE_NAME_REGEX = /(.+)\/(.+)\.svg$/;
+
+const InlineSVG = ({ src }: { src: string }) => {
+  // testId will be the file name without extension (e.g. `public/img/icons/angle-double-down.svg` -> `angle-double-down`)
+  const testId = src.replace(SVG_FILE_NAME_REGEX, '$2');
+  return <svg xmlns="http://www.w3.org/2000/svg" data-testid={testId} viewBox="0 0 24 24" />;
+};
+
+export default InlineSVG;


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes a recurrent jest react error when testing components using grafana/ui components that display icons.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/plugin-tools/issues/120

**Special notes for your reviewer**:
