### PR TITLE
Use pluginId to generate the docker-compose.yml file

### DIFF
--- a/packages/create-plugin/src/commands/generate.plopfile.ts
+++ b/packages/create-plugin/src/commands/generate.plopfile.ts
@@ -93,8 +93,13 @@ export default function (plop: NodePlopAPI) {
       hasGithubLevitateWorkflow,
     }: CliArgs) {
       const exportPath = getExportPath(pluginName, orgName, pluginType);
+      const pluginId = normalizeId(pluginName, orgName, pluginType);
       // Copy over files that are shared between plugins types
-      const commonActions = getActionsForTemplateFolder({ folderPath: TEMPLATE_PATHS.common, exportPath });
+      const commonActions = getActionsForTemplateFolder({
+        folderPath: TEMPLATE_PATHS.common,
+        exportPath,
+        templateData: { pluginId },
+      });
 
       // Copy over files from the plugin type specific folder, e.g. "tempaltes/app" for "app" plugins ("app" | "panel" | "datasource").
       const pluginTypeSpecificActions = getActionsForTemplateFolder({
@@ -163,7 +168,15 @@ function replacePatternWithTemplateInReadme(
 }
 
 // TODO<use Plop action `addMany` instead>
-function getActionsForTemplateFolder({ folderPath, exportPath }: { folderPath: string; exportPath: string }) {
+function getActionsForTemplateFolder({
+  folderPath,
+  exportPath,
+  templateData = {},
+}: {
+  folderPath: string;
+  exportPath: string;
+  templateData?: Record<string, string>;
+}) {
   const files = glob.sync(`${folderPath}/**`, { dot: true });
   function getExportFileName(f: string) {
     // yarn and npm packing will not include `.gitignore` files
@@ -186,7 +199,10 @@ function getActionsForTemplateFolder({ folderPath, exportPath }: { folderPath: s
     force: IS_DEV,
     // We would still like to scaffold as many files as possible even if one fails
     abortOnFail: false,
-    data: EXTRA_TEMPLATE_VARIABLES,
+    data: {
+      ...EXTRA_TEMPLATE_VARIABLES,
+      ...templateData,
+    },
   }));
 }
 

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.0'
 
 services:
   grafana:
-    container_name: '{{ normalize_id pluginName orgName pluginType }}'
+    container_name: '{{ pluginId }}'
     build:
       context: ./.config
       args:
@@ -10,5 +10,5 @@ services:
     ports:
       - 3000:3000/tcp
     volumes:
-      - ./dist:/var/lib/grafana/plugins/{{ normalize_id pluginName orgName pluginType }}
+      - ./dist:/var/lib/grafana/plugins/{{ pluginId }}
       - ./provisioning:/etc/grafana/provisioning


### PR DESCRIPTION

**What this PR does / why we need it**:

Changes the docker-compose.yml template to use pluginID and adds the required logic for create-tool to generate the templates using said plugin id.

Migrate already passes pluginId to handlebars when rendering template.

**Which issue(s) this PR fixes**:

Fixes: https://github.com/grafana/plugin-tools/issues/125

**Special notes for your reviewer**:
