### PR TITLE
Fix: Prevent error if rootUrls arg is not passed

### DIFF
--- a/packages/sign-plugin/src/commands/sign.command.ts
+++ b/packages/sign-plugin/src/commands/sign.command.ts
@@ -8,7 +8,7 @@ import { getVersion } from '../utils/getVersion';
 export const sign = async (argv: minimist.ParsedArgs) => {
   const pluginDistDir = path.resolve('dist');
   const signatureType: string = argv.signatureType;
-  const rootUrls: string[] = argv.rootUrls.split(',') ?? [];
+  const rootUrls: string[] = argv.rootUrls?.split(',') ?? [];
 
   if (!existsSync(pluginDistDir)) {
     throw new Error('Plugin `dist` directory is missing. Did you build the plugin before attempting to sign?');

--- a/packages/sign-plugin/src/commands/sign.command.ts
+++ b/packages/sign-plugin/src/commands/sign.command.ts
@@ -8,7 +8,7 @@ import { getVersion } from '../utils/getVersion';
 export const sign = async (argv: minimist.ParsedArgs) => {
   const pluginDistDir = path.resolve('dist');
   const signatureType: string = argv.signatureType;
-  const rootUrls: string[] = argv.rootUrls.split(',');
+  const rootUrls: string[] = argv.rootUrls.split(',') ?? [];
 
   if (!existsSync(pluginDistDir)) {
     throw new Error('Plugin `dist` directory is missing. Did you build the plugin before attempting to sign?');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The sign command code expects rootUrl to always be an array regardless of what is passed.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #130 

**Special notes for your reviewer**:
I'm gonna open a separate issue for writing some tests for sign-plugin package.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/sign-plugin@0.0.2-canary.136.8403097.0
  # or 
  yarn add @grafana/sign-plugin@0.0.2-canary.136.8403097.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
