### PR TITLE
Fix: include uppercase characters when normalising plugin id

### DIFF
--- a/packages/create-plugin/src/utils/tests/utils.handlebars.test.ts
+++ b/packages/create-plugin/src/utils/tests/utils.handlebars.test.ts
@@ -31,5 +31,15 @@ describe('Handlebars helpers', () => {
         expect(actual).toEqual(`myorg-myplugin-${type}`);
       }
     );
+
+    test.each([PLUGIN_TYPES.app, PLUGIN_TYPES.datasource, PLUGIN_TYPES.panel])(
+      'should handle uppercase characters',
+      (type: PLUGIN_TYPES) => {
+        const pluginName = `MyPlugin`;
+        const orgName = 'MyOrg';
+        const actual = normalizeId(pluginName, orgName, type);
+        expect(actual).toEqual(`myorg-myplugin-${type}`);
+      }
+    );
   });
 });

--- a/packages/create-plugin/src/utils/utils.handlebars.ts
+++ b/packages/create-plugin/src/utils/utils.handlebars.ts
@@ -12,7 +12,7 @@ export const ifEq = (a: any, b: any, options: HelperOptions) => {
 
 export const normalizeId = (pluginName: string, orgName: string, type: PLUGIN_TYPES) => {
   const re = new RegExp(`-?${type}$`, 'i');
-  const nameRegex = new RegExp('[^0-9a-z]', 'g');
+  const nameRegex = new RegExp('[^0-9a-zA-Z]', 'g');
 
   const newPluginName = pluginName.replace(re, '').replace(nameRegex, '');
   const newOrgName = orgName.replace(nameRegex, '');


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Users can type all sorts into the prompts when scaffolding a new plugin. Right now the `normalizeId` function strips uppercase characters which creates incorrect IDs (see path of directory created below):

```
success Installed "@grafana/create-plugin@0.5.0" with binaries:
      - create-plugin
? What is going to be the name of your plugin? My Plugin
? What is the organization name of your plugin? HeyWesty
? How would you describe your plugin?
? What kind of plugin would you like?  panel
? Do you want to add Github CI and Release workflows? Yes
? Do you want to add a Github workflow for automatically checking "Grafana API compatibility" on PRs? Yes
✔  ++ /Users/jackwestbrook/Sandbox/plugin-tools-tests/eyesty-ylugin-panel/.config/.eslintrc
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@0.5.1-canary.142.d32fe7f.0
  # or 
  yarn add @grafana/create-plugin@0.5.1-canary.142.d32fe7f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
