### PR TITLE
Create Plugin: Fix incorrect templates being used for scaffolding

### DIFF
--- a/packages/create-plugin/src/commands/generate.plopfile.ts
+++ b/packages/create-plugin/src/commands/generate.plopfile.ts
@@ -127,8 +127,6 @@ export default function (plop: NodePlopAPI) {
         return acc;
       }, []);
 
-      console.log([...backendActions, ...pluginTypeSpecificActions, ...commonActions].length, pluginActions.length);
-
       // Copy over Github workflow files (if selected)
       const ciWorkflowActions = hasGithubWorkflows
         ? getActionsForTemplateFolder({ folderPath: TEMPLATE_PATHS.ciWorkflows, exportPath })

--- a/packages/create-plugin/src/commands/generate.plopfile.ts
+++ b/packages/create-plugin/src/commands/generate.plopfile.ts
@@ -114,7 +114,8 @@ export default function (plop: NodePlopAPI) {
         : [];
 
       // Common, pluginType and backend actions can contain the same destination filenames.
-      // This filtering allows overriding templates by removing the duplication destinations
+      // This filtering removes the duplicates to prevent plop erroring and makes sure the correct
+      // template is scaffolded.
       const pluginActions = [...commonActions, ...pluginTypeSpecificActions, ...backendActions]
         .reduceRight((acc, file) => {
           const exists = acc.some((f) => f.path === file.path);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Right now when we scaffold the different types of plugins in DEV we use the `force` property on plop actions so we can regenerate the plugin without needing to delete the plugin directory first. However for production cases we don't want to trash a developers plugin if they accidentally run the command.

This behaviour difference has a bug in production which prevents a pluginType or backend template (that should be used as an override) from being written to the same location. E.g If a user scaffolds a backend datasource there is `templates/datasource/src/datasource.ts` and `templates/backend/src/datasource.ts` and they should both be scaffolded to `src/datasource.ts`. Currently the first template found will be written and the second will fail causing the scaffolded plugin to have incorrect source code.

This PR attempts to address this by filtering through the destination paths of the combined "common", "pluginType" and "backend" templates to only keep the last entry for a given destination path.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #157

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@0.6.3-canary.158.10dc5db.0
  # or 
  yarn add @grafana/create-plugin@0.6.3-canary.158.10dc5db.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
