### PR TITLE
Create Plugin: Remove links pointing to deprecated starter templates

### DIFF
--- a/packages/create-plugin/src/commands/generate.plopfile.ts
+++ b/packages/create-plugin/src/commands/generate.plopfile.ts
@@ -257,7 +257,7 @@ function printSuccessMessage(answers: CliArgs) {
   ];
 
   return `
-  Congratulations on scaffolding a Grafana ${answers.pluginName} plugin! 🚀
+  Congratulations on scaffolding a Grafana ${answers.pluginType} plugin! 🚀
 
   ## What's next?
   Navigate into ./${directory} and run the following commands to get started:

--- a/packages/create-plugin/templates/datasource/src/plugin.json
+++ b/packages/create-plugin/templates/datasource/src/plugin.json
@@ -16,16 +16,7 @@
       "small": "img/logo.svg",
       "large": "img/logo.svg"
     },
-    "links": [
-      {
-        "name": "Website",
-        "url": "https://github.com/grafana/grafana-starter-datasource"
-      },
-      {
-        "name": "License",
-        "url": "https://github.com/grafana/grafana-starter-datasource/blob/master/LICENSE"
-      }
-    ],
+    "links": [],
     "screenshots": [],
     "version": "%VERSION%",
     "updated": "%TODAY%"

--- a/packages/create-plugin/templates/panel/src/plugin.json
+++ b/packages/create-plugin/templates/panel/src/plugin.json
@@ -13,16 +13,7 @@
       "small": "img/logo.svg",
       "large": "img/logo.svg"
     },
-    "links": [
-      {
-        "name": "Website",
-        "url": "https://github.com/grafana/grafana-starter-panel"
-      },
-      {
-        "name": "License",
-        "url": "https://github.com/grafana/grafana-starter-panel/blob/master/LICENSE"
-      }
-    ],
+    "links": [],
     "screenshots": [],
     "version": "%VERSION%",
     "updated": "%TODAY%"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Generated links in plugin.json incorrectly point to the deprecated starter templates. This PR removes them.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #129

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@0.7.1-canary.162.e431ddf.0
  # or 
  yarn add @grafana/create-plugin@0.7.1-canary.162.e431ddf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
