### PR TITLE
Scaffolding: Display the "What's next?" message as a markdown

### DIFF
--- a/packages/create-plugin/src/commands/generate.plopfile.ts
+++ b/packages/create-plugin/src/commands/generate.plopfile.ts
@@ -3,6 +3,7 @@ import glob from 'glob';
 import path from 'path';
 import fs from 'fs';
 import { ifEq, normalizeId } from '../utils/utils.handlebars';
+import { displayAsMarkdown } from '../utils/utils.console';
 import {
   IS_DEV,
   TEMPLATE_PATHS,
@@ -256,7 +257,7 @@ function printSuccessMessage(answers: CliArgs) {
     '  * Open http://localhost:3000 in your browser to create a dashboard to begin developing your plugin.',
   ];
 
-  return `
+  return displayAsMarkdown(`
   Congratulations on scaffolding a Grafana ${answers.pluginType} plugin! 🚀
 
   ## What's next?
@@ -266,5 +267,5 @@ ${commands.map((command) => command).join('\n')}
   View the README.md for futher information.
   Learn more about Grafana Plugins at https://grafana.com/docs/grafana/latest/plugins/developing/development/
 
-`;
+`);
 }


### PR DESCRIPTION
### What changed?
Although we have a pretty cool "What's next?" section displayed after scaffolding a plugin, we accidentally rendered it as plain text in the CLI. This PR changes that by rendering the message as markdown.

|  **Before**  |    **After**    |
|--------------|-----------------|
| ![Screenshot 2022-11-30 at 10 24 13](https://user-images.githubusercontent.com/9974811/204763223-11b29cf1-f7f4-4718-bdeb-60be6af7f15d.png) | ![Screenshot 2022-11-30 at 10 45 09](https://user-images.githubusercontent.com/9974811/204763312-705c065f-4fba-44e3-b1f3-e9f83fbbb253.png) |