### PR TITLE
Create Plugin: Update docs to build backend before running docker

### DIFF
--- a/packages/create-plugin/src/commands/generate.plopfile.ts
+++ b/packages/create-plugin/src/commands/generate.plopfile.ts
@@ -253,7 +253,11 @@ function printSuccessMessage(answers: CliArgs) {
     `- \`cd ./${directory}\``,
     '- `yarn install` to install frontend dependencies.',
     '- `yarn dev` to build (and watch) the plugin frontend code.',
-    ...(answers.hasBackend ? ['- `mage -v build:linux` to build the plugin backend code. Rerun this command every time you edit your backend files.'] : []),
+    ...(answers.hasBackend
+      ? [
+          '- `mage -v build:linux` to build the plugin backend code. Rerun this command every time you edit your backend files.',
+        ]
+      : []),
     '- `docker-compose up` to start a grafana development server. Restart this command after each time you run mage to run your new backend code.',
     '- Open http://localhost:3000 in your browser to create a dashboard to begin developing your plugin.',
   ];

--- a/packages/create-plugin/src/commands/generate.plopfile.ts
+++ b/packages/create-plugin/src/commands/generate.plopfile.ts
@@ -252,9 +252,9 @@ function printSuccessMessage(answers: CliArgs) {
   const commands = [
     `- \`cd ./${directory}\``,
     '- `yarn install` to install frontend dependencies.',
-    '- `docker-compose up` to start a grafana development server.',
     '- `yarn dev` to build (and watch) the plugin frontend code.',
-    ...(answers.hasBackend ? ['- `mage -v build:linux` to build the plugin backend code.'] : []),
+    ...(answers.hasBackend ? ['- `mage -v build:linux` to build the plugin backend code. Rerun this command every time you edit your backend files.'] : []),
+    '- `docker-compose up` to start a grafana development server. Restart this command after each time you run mage to run your new backend code.',
     '- Open http://localhost:3000 in your browser to create a dashboard to begin developing your plugin.',
   ];
 

--- a/packages/create-plugin/templates/app/README.md
+++ b/packages/create-plugin/templates/app/README.md
@@ -8,8 +8,8 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
 
 ## Getting started
 
--- INSERT FRONTEND GETTING STARTED --
 {{#if hasBackend}}-- INSERT BACKEND GETTING STARTED --{{/if}}
+-- INSERT FRONTEND GETTING STARTED --
 
 -- INSERT DISTRIBUTING YOUR PLUGIN --
 

--- a/packages/create-plugin/templates/datasource/README.md
+++ b/packages/create-plugin/templates/datasource/README.md
@@ -8,8 +8,8 @@ Grafana supports a wide range of data sources, including Prometheus, MySQL, and 
 
 ## Getting started
 
--- INSERT FRONTEND GETTING STARTED --
 {{#if hasBackend}}-- INSERT BACKEND GETTING STARTED --{{/if}}
+-- INSERT FRONTEND GETTING STARTED --
 
 -- INSERT DISTRIBUTING YOUR PLUGIN --
 

--- a/packages/create-plugin/templates/panel/README.md
+++ b/packages/create-plugin/templates/panel/README.md
@@ -10,7 +10,6 @@ Use panel plugins when you want to do things like visualize data returned by dat
 
 ## Getting started
 
-{{#if hasBackend}}-- INSERT BACKEND GETTING STARTED --{{/if}}
 -- INSERT FRONTEND GETTING STARTED --
 
 -- INSERT DISTRIBUTING YOUR PLUGIN --

--- a/packages/create-plugin/templates/panel/README.md
+++ b/packages/create-plugin/templates/panel/README.md
@@ -10,8 +10,8 @@ Use panel plugins when you want to do things like visualize data returned by dat
 
 ## Getting started
 
--- INSERT FRONTEND GETTING STARTED --
 {{#if hasBackend}}-- INSERT BACKEND GETTING STARTED --{{/if}}
+-- INSERT FRONTEND GETTING STARTED --
 
 -- INSERT DISTRIBUTING YOUR PLUGIN --
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures instructions guide users towards building their plugin's backend before running docker.

Right now if you build a plugin with a backend with the create-plugin tool and follow the instructions as written you'll get a 503 error message with the message "plugin unavailable". This is because if you follow the instructions as currently written you are building the backend of your plugin (`mage -v`) _after_ you've run `yarn server` or `docker-compose up -build` which kicks of a dockerized version of grafana but which does not restart if the new files in your plugin are built. It may not be clear to the user that they need to restart yarn server/docker and/or run these commands in a different order.

I think in the future it would be awesome to add some tooling to rebuild/restart the server on backend changes as well, but this feels like a nice small incremental improvement in helping people get started faster.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@0.8.2-canary.167.f98dad9.0
  # or 
  yarn add @grafana/create-plugin@0.8.2-canary.167.f98dad9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
