### PR TITLE
Templates: Use getDefaultQuery method to set query default values

### DIFF
--- a/packages/create-plugin/templates/backend/src/datasource.ts
+++ b/packages/create-plugin/templates/backend/src/datasource.ts
@@ -1,10 +1,14 @@
-import { DataSourceInstanceSettings } from '@grafana/data';
-
-import { MyQuery, MyDataSourceOptions } from './types';
+import { DataSourceInstanceSettings, CoreApp } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
+
+import { MyQuery, MyDataSourceOptions, DEFAULT_QUERY } from './types';
 
 export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>) {
     super(instanceSettings);
+  }
+
+  getDefaultQuery(_: CoreApp): Partial<MyQuery> {
+    return DEFAULT_QUERY
   }
 }

--- a/packages/create-plugin/templates/datasource/src/components/QueryEditor.tsx
+++ b/packages/create-plugin/templates/datasource/src/components/QueryEditor.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent, PureComponent } from 'react';
 import { LegacyForms } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
-import { DEFAULT_QUERY, MyDataSourceOptions, MyQuery } from '../types';
+import { MyDataSourceOptions, MyQuery } from '../types';
 
 const { FormField } = LegacyForms;
 

--- a/packages/create-plugin/templates/datasource/src/components/QueryEditor.tsx
+++ b/packages/create-plugin/templates/datasource/src/components/QueryEditor.tsx
@@ -1,10 +1,8 @@
-import defaults from 'lodash/defaults';
-
 import React, { ChangeEvent, PureComponent } from 'react';
 import { LegacyForms } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';
-import { defaultQuery, MyDataSourceOptions, MyQuery } from '../types';
+import { DEFAULT_QUERY, MyDataSourceOptions, MyQuery } from '../types';
 
 const { FormField } = LegacyForms;
 
@@ -24,8 +22,7 @@ export class QueryEditor extends PureComponent<Props> {
   };
 
   render() {
-    const query = defaults(this.props.query, defaultQuery);
-    const { queryText, constant } = query;
+    const { queryText, constant } = this.props.query;
 
     return (
       <div className="gf-form">

--- a/packages/create-plugin/templates/datasource/src/datasource.ts
+++ b/packages/create-plugin/templates/datasource/src/datasource.ts
@@ -1,5 +1,3 @@
-import defaults from 'lodash/defaults';
-
 import {
   DataQueryRequest,
   DataQueryResponse,
@@ -9,7 +7,7 @@ import {
   FieldType,
 } from '@grafana/data';
 
-import { MyQuery, MyDataSourceOptions, defaultQuery } from './types';
+import { MyQuery, MyDataSourceOptions, DEFAULT_QUERY } from './types';
 
 export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>) {
@@ -23,12 +21,11 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
 
     // Return a constant for each query.
     const data = options.targets.map((target) => {
-      const query = defaults(target, defaultQuery);
       return new MutableDataFrame({
-        refId: query.refId,
+        refId: target.refId,
         fields: [
           { name: 'Time', values: [from, to], type: FieldType.time },
-          { name: 'Value', values: [query.constant, query.constant], type: FieldType.number },
+          { name: 'Value', values: [target.constant, target.constant], type: FieldType.number },
         ],
       });
     });

--- a/packages/create-plugin/templates/datasource/src/types.ts
+++ b/packages/create-plugin/templates/datasource/src/types.ts
@@ -5,7 +5,7 @@ export interface MyQuery extends DataQuery {
   constant: number;
 }
 
-export const defaultQuery: Partial<MyQuery> = {
+export const DEFAULT_QUERY: Partial<MyQuery> = {
   constant: 6.5,
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Rather than merging props.query with defaults in the editor and merging target with defaults in the datasource.query method, we should suggest that developers use the [`getDefaultQuery`](https://github.com/grafana/grafana/blob/75cceec62c3e99ba15b0da4958c28e97eea31ea1/packages/grafana-data/src/types/datasource.ts#L360) method. Using this method, defaults will be applied before the query editor is rendered the first time and before the query runner executes the query the first time. 


