### PR TITLE
Revert "CI: Update workflows to use permissions rather than PAT"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,15 +47,12 @@ jobs:
     needs: test
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     name: Release packages
-    permissions:
-      contents: write
-      pull-requests: write
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
 
       - name: Prepare repository
         run: git fetch --unshallow --tags
@@ -75,7 +72,7 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: yarn release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,6 @@ jobs:
   deploy:
     name: Deploy docs to GitHub Pages
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -34,7 +32,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
           # Build output to publish to the `gh-pages` branch:
           publish_dir: ./docusaurus/website/build
           # The following lines assign commit authorship to the official

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - '.github/workflows/deploy.yml'
-      - '.github/workflows/test-build.yml'
+      - '.github/workflows/test-deploy.yml'
       - 'docusaurus/**'
 
 jobs:


### PR DESCRIPTION
Our release process needs to be able to push commits to main which is a protected branch. The automated GITHUB_TOKEN in workflows doesn't allow for this so going back to using a PAT. 😞 