### PR TITLE
CreatePlugin: Change default docker image to grafana-enterprise

### DIFF
--- a/docusaurus/docs/advanced-configuration.md
+++ b/docusaurus/docs/advanced-configuration.md
@@ -146,3 +146,26 @@ We need to update the `scripts` in the `package.json` to use the extended Webpac
 -"dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
 +"dev": "webpack -w -c ./webpack.config.ts --env development",
 ```
+
+### Configure grafana image to use when running docker
+
+By default `grafana-enterprise` will be used as the docker image for all docker related commands. If you want to override this behaviour simply alter the `docker-compose.yaml` by adding the following build arg `grafana_image`. 
+
+**Example:**
+
+```yaml
+version: '3.7'
+
+services:
+  grafana:
+    container_name: 'myorg-basic-app'
+    build:
+      context: ./.config
+      args:
+        grafana_version: ${GRAFANA_VERSION:-9.1.2}
+        grafana_image: ${GRAFANA_IMAGE:-grafana}
+```
+
+In this example we are assigning the environment variable `GRAFANA_IMAGE` to the build arg `grafana_image` with a default value of `grafana`. This will give you the possibility to set the value while running the docker-compose commands which might be convinent in some scenarios.
+
+---

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -1,6 +1,7 @@
 ARG grafana_version=latest
+ARG grafana_image=grafana-enterprise
 
-FROM grafana/grafana:${grafana_version}
+FROM grafana/${grafana_image}:${grafana_version}
 
 # Make it as simple as possible to access the grafana instance for development purposes
 # Do NOT enable these settings in a public facing / production grafana instance

--- a/packages/create-plugin/templates/common/.config/README.md
+++ b/packages/create-plugin/templates/common/.config/README.md
@@ -139,3 +139,26 @@ We need to update the `scripts` in the `package.json` to use the extended Webpac
 -"dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
 +"dev": "webpack -w -c ./webpack.config.ts --env development",
 ```
+
+### Configure grafana image to use when running docker
+
+By default `grafana-enterprise` will be used as the docker image for all docker related commands. If you want to override this behaviour simply alter the `docker-compose.yaml` by adding the following build arg `grafana_image`. 
+
+**Example:**
+
+```yaml
+version: '3.7'
+
+services:
+  grafana:
+    container_name: 'myorg-basic-app'
+    build:
+      context: ./.config
+      args:
+        grafana_version: ${GRAFANA_VERSION:-9.1.2}
+        grafana_image: ${GRAFANA_IMAGE:-grafana}
+```
+
+In this example we are assigning the environment variable `GRAFANA_IMAGE` to the build arg `grafana_image` with a default value of `grafana`. This will give you the possibility to set the value while running the docker-compose commands which might be convinent in some scenarios.
+
+---


### PR DESCRIPTION
**What this PR does / why we need it**:
We got a question about why the `GF_ENTERPRISE_*` environment variables wasn't picked up properly after migrating to the `create-plugin` configuration files. The reason for this is that we are using the `grafana/grafana` docker image which doesn't contain the enerprise version of Grafana.

This PR will change so that all the docker related configuration that is scaffolded by `create-plugin` will use `grafana/grafana-enterprise` as the default docker image. It also adds a way to configure this without adding any changes to the `./config` folder which might cause issues while updating.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@0.10.0-canary.197.f95c2c8.0
  # or 
  yarn add @grafana/create-plugin@0.10.0-canary.197.f95c2c8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
