### PR TITLE
Remove default logging examples as their usage is prone to user error

### DIFF
--- a/packages/create-plugin/templates/backend/pkg/plugin/datasource.go
+++ b/packages/create-plugin/templates/backend/pkg/plugin/datasource.go
@@ -1,15 +1,15 @@
 package plugin
 
 import (
-		"context"
-		"encoding/json"
-		"fmt"
-		"math/rand"
-		"time"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
 
-		"github.com/grafana/grafana-plugin-sdk-go/backend"
-		"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-		"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 // Make sure Datasource implements required interfaces. This is important to do
@@ -18,14 +18,14 @@ import (
 // backend.CheckHealthHandler interfaces. Plugin should not implement all these
 // interfaces- only those which are required for a particular task.
 var (
-		_ backend.QueryDataHandler      = (*Datasource)(nil)
-		_ backend.CheckHealthHandler    = (*Datasource)(nil)
-		_ instancemgmt.InstanceDisposer = (*Datasource)(nil)
+	_ backend.QueryDataHandler      = (*Datasource)(nil)
+	_ backend.CheckHealthHandler    = (*Datasource)(nil)
+	_ instancemgmt.InstanceDisposer = (*Datasource)(nil)
 )
 
 // NewDatasource creates a new datasource instance.
 func NewDatasource(_ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-		return &Datasource{}, nil
+	return &Datasource{}, nil
 }
 
 // Datasource is an example datasource which can respond to data queries, reports
@@ -36,7 +36,7 @@ type Datasource struct{}
 // created. As soon as datasource settings change detected by SDK old datasource instance will
 // be disposed and a new one will be created using NewSampleDatasource factory function.
 func (d *Datasource) Dispose() {
-		// Clean up datasource instance resources.
+	// Clean up datasource instance resources.
 }
 
 // QueryData handles multiple queries and returns multiple responses.
@@ -44,49 +44,49 @@ func (d *Datasource) Dispose() {
 // The QueryDataResponse contains a map of RefID to the response for each query, and each response
 // contains Frames ([]*Frame).
 func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-		// create response struct
-		response := backend.NewQueryDataResponse()
+	// create response struct
+	response := backend.NewQueryDataResponse()
 
-		// loop over queries and execute them individually.
-		for _, q := range req.Queries {
-				res := d.query(ctx, req.PluginContext, q)
+	// loop over queries and execute them individually.
+	for _, q := range req.Queries {
+		res := d.query(ctx, req.PluginContext, q)
 
-				// save the response in a hashmap
-				// based on with RefID as identifier
-				response.Responses[q.RefID] = res
-		}
+		// save the response in a hashmap
+		// based on with RefID as identifier
+		response.Responses[q.RefID] = res
+	}
 
-		return response, nil
+	return response, nil
 }
 
 type queryModel struct{}
 
 func (d *Datasource) query(_ context.Context, pCtx backend.PluginContext, query backend.DataQuery) backend.DataResponse {
-		var response backend.DataResponse
+	var response backend.DataResponse
 
-		// Unmarshal the JSON into our queryModel.
-		var qm queryModel
+	// Unmarshal the JSON into our queryModel.
+	var qm queryModel
 
-		err := json.Unmarshal(query.JSON, &qm)
-		if err != nil {
-				return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("json unmarshal: %v", err.Error()))
-		}
+	err := json.Unmarshal(query.JSON, &qm)
+	if err != nil {
+		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("json unmarshal: %v", err.Error()))
+	}
 
-		// create data frame response.
-		// For an overview on data frames and how grafana handles them:
-		// https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/
-		frame := data.NewFrame("response")
+	// create data frame response.
+	// For an overview on data frames and how grafana handles them:
+	// https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/
+	frame := data.NewFrame("response")
 
-		// add fields.
-		frame.Fields = append(frame.Fields,
-				data.NewField("time", nil, []time.Time{query.TimeRange.From, query.TimeRange.To}),
-				data.NewField("values", nil, []int64{10, 20}),
-		)
+	// add fields.
+	frame.Fields = append(frame.Fields,
+		data.NewField("time", nil, []time.Time{query.TimeRange.From, query.TimeRange.To}),
+		data.NewField("values", nil, []int64{10, 20}),
+	)
 
-		// add the frames to the response.
-		response.Frames = append(response.Frames, frame)
+	// add the frames to the response.
+	response.Frames = append(response.Frames, frame)
 
-		return response
+	return response
 }
 
 // CheckHealth handles health checks sent from Grafana to the plugin.
@@ -94,16 +94,16 @@ func (d *Datasource) query(_ context.Context, pCtx backend.PluginContext, query 
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (d *Datasource) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-		var status = backend.HealthStatusOk
-		var message = "Data source is working"
+	var status = backend.HealthStatusOk
+	var message = "Data source is working"
 
-		if rand.Int()%2 == 0 {
-				status = backend.HealthStatusError
-				message = "randomized error"
-		}
+	if rand.Int()%2 == 0 {
+		status = backend.HealthStatusError
+		message = "randomized error"
+	}
 
-		return &backend.CheckHealthResult{
-				Status:  status,
-				Message: message,
-		}, nil
+	return &backend.CheckHealthResult{
+		Status:  status,
+		Message: message,
+	}, nil
 }

--- a/packages/create-plugin/templates/backend/pkg/plugin/datasource.go
+++ b/packages/create-plugin/templates/backend/pkg/plugin/datasource.go
@@ -1,16 +1,15 @@
 package plugin
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"math/rand"
-	"time"
+		"context"
+		"encoding/json"
+		"fmt"
+		"math/rand"
+		"time"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
+		"github.com/grafana/grafana-plugin-sdk-go/backend"
+		"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+		"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 // Make sure Datasource implements required interfaces. This is important to do
@@ -19,14 +18,14 @@ import (
 // backend.CheckHealthHandler interfaces. Plugin should not implement all these
 // interfaces- only those which are required for a particular task.
 var (
-	_ backend.QueryDataHandler      = (*Datasource)(nil)
-	_ backend.CheckHealthHandler    = (*Datasource)(nil)
-	_ instancemgmt.InstanceDisposer = (*Datasource)(nil)
+		_ backend.QueryDataHandler      = (*Datasource)(nil)
+		_ backend.CheckHealthHandler    = (*Datasource)(nil)
+		_ instancemgmt.InstanceDisposer = (*Datasource)(nil)
 )
 
 // NewDatasource creates a new datasource instance.
 func NewDatasource(_ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-	return &Datasource{}, nil
+		return &Datasource{}, nil
 }
 
 // Datasource is an example datasource which can respond to data queries, reports
@@ -37,7 +36,7 @@ type Datasource struct{}
 // created. As soon as datasource settings change detected by SDK old datasource instance will
 // be disposed and a new one will be created using NewSampleDatasource factory function.
 func (d *Datasource) Dispose() {
-	// Clean up datasource instance resources.
+		// Clean up datasource instance resources.
 }
 
 // QueryData handles multiple queries and returns multiple responses.
@@ -45,53 +44,49 @@ func (d *Datasource) Dispose() {
 // The QueryDataResponse contains a map of RefID to the response for each query, and each response
 // contains Frames ([]*Frame).
 func (d *Datasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-	// when logging at a non-Debug level, make sure you don't include sensitive information in the message
-	// (like the *backend.QueryDataRequest)
-	log.DefaultLogger.Debug("QueryData called", "numQueries", len(req.Queries))
+		// create response struct
+		response := backend.NewQueryDataResponse()
 
-	// create response struct
-	response := backend.NewQueryDataResponse()
+		// loop over queries and execute them individually.
+		for _, q := range req.Queries {
+				res := d.query(ctx, req.PluginContext, q)
 
-	// loop over queries and execute them individually.
-	for _, q := range req.Queries {
-		res := d.query(ctx, req.PluginContext, q)
+				// save the response in a hashmap
+				// based on with RefID as identifier
+				response.Responses[q.RefID] = res
+		}
 
-		// save the response in a hashmap
-		// based on with RefID as identifier
-		response.Responses[q.RefID] = res
-	}
-
-	return response, nil
+		return response, nil
 }
 
 type queryModel struct{}
 
 func (d *Datasource) query(_ context.Context, pCtx backend.PluginContext, query backend.DataQuery) backend.DataResponse {
-	var response backend.DataResponse
+		var response backend.DataResponse
 
-	// Unmarshal the JSON into our queryModel.
-	var qm queryModel
+		// Unmarshal the JSON into our queryModel.
+		var qm queryModel
 
-	err := json.Unmarshal(query.JSON, &qm)
-	if err != nil {
-		return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("json unmarshal: %v", err.Error()))
-	}
+		err := json.Unmarshal(query.JSON, &qm)
+		if err != nil {
+				return backend.ErrDataResponse(backend.StatusBadRequest, fmt.Sprintf("json unmarshal: %v", err.Error()))
+		}
 
-	// create data frame response.
-	// For an overview on data frames and how grafana handles them:
-	// https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/
-	frame := data.NewFrame("response")
+		// create data frame response.
+		// For an overview on data frames and how grafana handles them:
+		// https://grafana.com/docs/grafana/latest/developers/plugins/data-frames/
+		frame := data.NewFrame("response")
 
-	// add fields.
-	frame.Fields = append(frame.Fields,
-		data.NewField("time", nil, []time.Time{query.TimeRange.From, query.TimeRange.To}),
-		data.NewField("values", nil, []int64{10, 20}),
-	)
+		// add fields.
+		frame.Fields = append(frame.Fields,
+				data.NewField("time", nil, []time.Time{query.TimeRange.From, query.TimeRange.To}),
+				data.NewField("values", nil, []int64{10, 20}),
+		)
 
-	// add the frames to the response.
-	response.Frames = append(response.Frames, frame)
+		// add the frames to the response.
+		response.Frames = append(response.Frames, frame)
 
-	return response
+		return response
 }
 
 // CheckHealth handles health checks sent from Grafana to the plugin.
@@ -99,20 +94,16 @@ func (d *Datasource) query(_ context.Context, pCtx backend.PluginContext, query 
 // datasource configuration page which allows users to verify that
 // a datasource is working as expected.
 func (d *Datasource) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	// when logging at a non-Debug level, make sure you don't include sensitive information in the message
-	// (like the *backend.QueryDataRequest)
-	log.DefaultLogger.Debug("CheckHealth called")
+		var status = backend.HealthStatusOk
+		var message = "Data source is working"
 
-	var status = backend.HealthStatusOk
-	var message = "Data source is working"
+		if rand.Int()%2 == 0 {
+				status = backend.HealthStatusError
+				message = "randomized error"
+		}
 
-	if rand.Int()%2 == 0 {
-		status = backend.HealthStatusError
-		message = "randomized error"
-	}
-
-	return &backend.CheckHealthResult{
-		Status:  status,
-		Message: message,
-	}, nil
+		return &backend.CheckHealthResult{
+				Status:  status,
+				Message: message,
+		}, nil
 }


### PR DESCRIPTION
Following some recent plugin reviews, it appears that we have some work to do to encourage best practices for logging

## TL;DR
### When logging, make sure you don't include any sensitive information in the message