### PR TITLE
Add `@latest` to docs and scripts using npx commands 

### DIFF
--- a/docusaurus/docs/creating-a-plugin.md
+++ b/docusaurus/docs/creating-a-plugin.md
@@ -6,7 +6,7 @@ title: Creating a Plugin
 To create a new Grafana plugin run the following command in your shell:
 
 ```shell
-npx @grafana/create-plugin
+npx @grafana/create-plugin@latest
 ```
 
 :::info

--- a/docusaurus/docs/getting-started.md
+++ b/docusaurus/docs/getting-started.md
@@ -13,7 +13,7 @@ Plugin tools consists of two packages:
 ## Quick Start
 
 ```shell
-npx @grafana/create-plugin
+npx @grafana/create-plugin@latest
 ```
 
 Follow the prompts to scaffold a Grafana plugin. [See here](./creating-a-plugin.md) for detailed information about creating a plugin.

--- a/docusaurus/docs/migrating-from-toolkit.md
+++ b/docusaurus/docs/migrating-from-toolkit.md
@@ -25,7 +25,7 @@ Before running the following command we strongly suggest backing up the code. Id
 To get started, in the root directory of the existing plugin (where the `package.json` file is) run the following command and answer the prompts.
 
 ```
-npx @grafana/create-plugin migrate
+npx @grafana/create-plugin@latest migrate
 ```
 
 ## Prompts

--- a/docusaurus/docs/nested-plugins.md
+++ b/docusaurus/docs/nested-plugins.md
@@ -6,7 +6,7 @@ title: Nested Plugins
 Grafana app plugins can nest frontend datasource and panel plugins making it easy to ship a complete user experience. To take advantage of this feature first scaffold an app plugin using `@grafana/create-plugin`:
 
 ```bash
-npx @grafana/create-plugin
+npx @grafana/create-plugin@latest
 ```
 
 When prompted `What type of plugin would you like?` select `app`.

--- a/docusaurus/docs/updating-to-new-releases.md
+++ b/docusaurus/docs/updating-to-new-releases.md
@@ -6,7 +6,7 @@ title: Updating to New Releases
 To update an existing plugin to use a newer version of `create-plugin` run the following update command:
 
 ```shell
-npx @grafana/create-plugin update
+npx @grafana/create-plugin@latest update
 ```
 
 This command will rerun the original scaffolding commands against the configuration files, dependencies, and scripts, using the latest version of `create-plugin`. It will prompt to confirm any destructive operations are agreed to prior to being run.

--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -49,7 +49,7 @@ yarn dlx @grafana/create-plugin
 #### [`npx`](https://github.com/npm/npx)
 
 ```bash
-npx @grafana/create-plugin
+npx @grafana/create-plugin@latest
 ```
 
 #### [`npm`](https://docs.npmjs.com/cli/v7/commands/npm-init)
@@ -71,7 +71,7 @@ following command to migrate it to the new build tooling:
 # Run this command from the root of your plugin
 cd ./my-plugin
 
-npx @grafana/create-plugin migrate
+npx @grafana/create-plugin@latest migrate
 ```
 
 For more information see [here](https://grafana.github.io/plugin-tools/docs/migrating-from-toolkit)
@@ -90,7 +90,7 @@ that automatically updates the build configuration for you:
 # Run this command from the root of your plugin
 cd ./my-plugin
 
-npx @grafana/create-plugin update
+npx @grafana/create-plugin@latest update
 ```
 
 For more information see [here](https://grafana.github.io/plugin-tools/docs/updating-to-new-releases)

--- a/packages/create-plugin/templates/common/package.json
+++ b/packages/create-plugin/templates/common/package.json
@@ -13,7 +13,7 @@
     "e2e": "yarn cypress install && yarn grafana-e2e run",
     "e2e:update": "yarn cypress install && yarn grafana-e2e run --update-screenshots",
     "server": "docker-compose up --build",
-    "sign": "npx --yes @grafana/sign-plugin"
+    "sign": "npx --yes @grafana/sign-plugin@latest"
   },
   "author": "{{ sentenceCase orgName }}",
   "license": "Apache-2.0",

--- a/packages/sign-plugin/README.md
+++ b/packages/sign-plugin/README.md
@@ -9,7 +9,7 @@ Sign Grafana plugins with ease.
     - [Sign a public plugin](#sign-a-public-plugin)
     - [Sign a private plugin](#sign-a-private-plugin)
       - [`npx`](#npx)
-      - [`yarn` (> 2.x)](#yarn--2x)
+      - [`yarn` (\> 2.x)](#yarn--2x)
   - [Contributing](#contributing)
 
 **`@grafana/sign-plugin`** works on macOS, Windows and Linux.<br />
@@ -30,14 +30,14 @@ In your plugin directory, sign the plugin with your Grafana API key. Grafana sig
 
 ```bash
 export GRAFANA_API_KEY=<YOUR_API_KEY>
-npx @grafana/sign-plugin
+npx @grafana/sign-plugin@latest
 ```
 
 If the plugin distribution directory differs from the default `dist`, specify the path to use with the `--distDir` flag.
 
 ```bash
 export GRAFANA_API_KEY=<YOUR_API_KEY>
-npx @grafana/sign-plugin --distDir path/to/directory
+npx @grafana/sign-plugin@latest --distDir path/to/directory
 ```
 
 ### Sign a private plugin
@@ -45,7 +45,7 @@ npx @grafana/sign-plugin --distDir path/to/directory
 In your plugin directory, run the following to create a MANIFEST.txt file in the dist directory of your plugin.
 
 ```bash
-npx @grafana/sign-plugin --rootUrls https://example.com/grafana
+npx @grafana/sign-plugin@latest --rootUrls https://example.com/grafana
 ```
 
 Alterntives:
@@ -53,13 +53,13 @@ Alterntives:
 #### [`npx`](https://github.com/npm/npx)
 
 ```bash
-npx @grafana/sign-plugin
+npx @grafana/sign-plugin@latest
 ```
 
 #### [`yarn`](https://yarnpkg.com/cli/dlx) (> 2.x)
 
 ```bash
-yarn dlx @grafana/sign-plugin
+yarn dlx @grafana/sign-plugin@latest
 ```
 
 ## Contributing


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
adding `@latest` to `npx` commands to avoid issues with local caching. Ref: https://github.com/npm/cli/issues/2329


grafana/grafana docs PR: https://github.com/grafana/grafana/pull/64140

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.0.1-canary.208.ba32fb6.0
  npm install @grafana/sign-plugin@1.0.1-canary.208.ba32fb6.0
  # or 
  yarn add @grafana/create-plugin@1.0.1-canary.208.ba32fb6.0
  yarn add @grafana/sign-plugin@1.0.1-canary.208.ba32fb6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
