### PR TITLE
Bumped mage action to v2 to avoid the warning "Node.js 12 actions are…

### DIFF
--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -59,14 +59,14 @@ jobs:
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v1
+        uses: magefile/mage-action@v2
         with:
           version: latest
           args: coverage
 
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v1
+        uses: magefile/mage-action@v2
         with:
           version: latest
           args: buildAll

--- a/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
@@ -41,14 +41,14 @@ jobs:
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v1
+        uses: magefile/mage-action@v2
         with:
           version: latest
           args: coverage
 
       - name: Build backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: magefile/mage-action@v1
+        uses: magefile/mage-action@v2
         with:
           version: latest
           args: buildAll


### PR DESCRIPTION
… deprecated"

The ci.yml and release.yml workflow files use an outdated version of the mage action. This outdated version uses Node 12 as a runtime, which leads to a warning when the workflows are used. This commit bumps the mage action version to 2, which uses to Node 16 as a runtime.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:  We need it to get rid of the warning shown by GitHub:
"Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: magefile/mage-action@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/."

**Which issue(s) this PR fixes**: None

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**: Tested successfully.
