### PR TITLE
Documentation: Fix path in for template README.md for jest customizations

### DIFF
--- a/packages/create-plugin/templates/common/.config/README.md
+++ b/packages/create-plugin/templates/common/.config/README.md
@@ -60,7 +60,7 @@ A common issue found with the current jest config involves importing an npm pack
 
 ```javascript
 process.env.TZ = 'UTC';
-const { grafanaESModules, nodeModulesToTransform } = require('./jest/utils');
+const { grafanaESModules, nodeModulesToTransform } = require('./config/jest/utils');
 
 module.exports = {
   // Jest configuration provided by Grafana


### PR DESCRIPTION

**What this PR does / why we need it**:

The README.md copied to a plugin .config directory contains an incorrect path for extending jest configurations.

**Which issue(s) this PR fixes**:

No issue opened

**Special notes for your reviewer**:

Minor doc update noticed while update plugins and needing to customize jest.  The docs on the main site are correct, this just syncs them up.
