### PR TITLE
Chore: Remove unused deps from scaffolded plugins

### DIFF
--- a/packages/create-plugin/templates/common/package.json
+++ b/packages/create-plugin/templates/common/package.json
@@ -33,16 +33,8 @@
     "@types/lodash": "^4.14.188",{{#if_eq pluginType "app"}}
     "@types/react-router-dom": "^5.3.3",{{/if_eq}}
     "@types/node": "^18.11.9",
-    "@typescript-eslint/eslint-plugin": "^5.42.1",
-    "@typescript-eslint/parser": "^5.42.1",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.1",
-    "eslint": "8.26.0",
-    "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-jsdoc": "^39.6.2",
-    "eslint-plugin-prettier": "^4.0.0",
-    "eslint-plugin-react": "^7.26.1",
-    "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-webpack-plugin": "^3.1.1",
     "fork-ts-checker-webpack-plugin": "^7.2.0",
     "glob": "^8.0.3",


### PR DESCRIPTION
### What changed?

Similar to the changes in https://github.com/grafana/plugin-tools/pull/215, this PR removes the unnecessary dependencies in the generated plugins (dependencies which are either unused or [are defined as dependencies of the @grafana/eslint-config package](https://github.com/grafana/eslint-config-grafana/blob/master/package.json#L23)).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.1.2-canary.221.156b869.0
  # or 
  yarn add @grafana/create-plugin@1.1.2-canary.221.156b869.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
