### PR TITLE
Chore: Update `glob` to v10

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/utils.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/utils.ts
@@ -1,10 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import util from 'util';
-import glob from 'glob';
+import { glob } from 'glob';
 import { SOURCE_DIR } from './constants';
-
-const globAsync = util.promisify(glob);
 
 export function getPackageJson() {
   return require(path.resolve(process.cwd(), 'package.json'));
@@ -21,11 +19,11 @@ export function hasReadme() {
 // Support bundling nested plugins by finding all plugin.json files in src directory
 // then checking for a sibling module.[jt]sx? file.
 export async function getEntries(): Promise<Record<string, string>> {
-  const pluginsJson = await globAsync('**/src/**/plugin.json', { absolute: true });
+  const pluginsJson = await glob('**/src/**/plugin.json', { absolute: true });
 
   const plugins = await Promise.all(pluginsJson.map((pluginJson) => {
       const folder = path.dirname(pluginJson);
-      return globAsync(`${folder}/module.{ts,tsx,js,jsx}`, { absolute: true });
+      return glob(`${folder}/module.{ts,tsx,js,jsx}`, { absolute: true });
     })
   );
 

--- a/packages/create-plugin/templates/common/package.json
+++ b/packages/create-plugin/templates/common/package.json
@@ -28,7 +28,6 @@
     "@swc/jest": "^0.2.23",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
-    "@types/glob": "^8.0.0",
     "@types/jest": "^29.2.2",
     "@types/lodash": "^4.14.188",{{#if_eq pluginType "app"}}
     "@types/react-router-dom": "^5.3.3",{{/if_eq}}
@@ -37,7 +36,7 @@
     "css-loader": "^6.7.1",
     "eslint-webpack-plugin": "^3.1.1",
     "fork-ts-checker-webpack-plugin": "^7.2.0",
-    "glob": "^8.0.3",
+    "glob": "^10.0.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",


### PR DESCRIPTION
### What changed?

Updated the `glob` dependency in the generated plugins from `v8` to `v10`.