### PR TITLE
Create Plugin: Fix react types errors

### DIFF
--- a/packages/create-plugin/templates/common/package.json
+++ b/packages/create-plugin/templates/common/package.json
@@ -30,9 +30,7 @@
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^29.2.2",
     "@types/lodash": "^4.14.188",
-    "@types/node": "^18.11.9",
-    "@types/react": "17.0.42",
-    "@types/react-dom": "17.0.14",{{#if_eq pluginType "app"}}
+    "@types/node": "^18.11.9",{{#if_eq pluginType "app"}}
     "@types/react-router-dom": "^5.3.3",{{/if_eq}}
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.1",


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Yarn 1's hoisting appears to cause `@types/react` version collisions resulting in failed app builds post scaffold due to react-router-dom bringing a different version with it. Removing them from the package.json seems to fix things.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.3.1-canary.238.2a7fa4d.0
  # or 
  yarn add @grafana/create-plugin@1.3.1-canary.238.2a7fa4d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
