### PR TITLE
create-plugin: eslint configuration: add ignore for directory src/libs

### DIFF
--- a/packages/create-plugin/templates/common/.config/.eslintrc
+++ b/packages/create-plugin/templates/common/.config/.eslintrc
@@ -4,10 +4,11 @@
  * In order to extend the configuration follow the steps in
  * https://grafana.github.io/plugin-tools/docs/advanced-configuration#extending-the-eslint-config
  */
- {
+{
   "extends": ["@grafana/eslint-config"],
   "root": true,
   "rules": {
     "react/prop-types": "off"
-  }
+  },
+  "ignorePatterns": ["src/libs/*"]
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

When a plugin includes minified external libraries in src/libs/*, eslint will try lint these files and often fails with thousands of errors.

I converted a plugin (not yet published) and encountered this problem, there were roughly 22,000 lint errors and the plugin would not compile.

This adds an ignore so the libraries can be used (maybe this should go into @grafana/eslint-config ?)

**Which issue(s) this PR fixes**:

No issue open right now.

**Special notes for your reviewer**:
