### PR TITLE
create-plugin: updates for ci workflow

### DIFF
--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -39,15 +39,6 @@ jobs:
       - name: Build frontend
         run: {{ packageManagerName }} run build
 
-      - name: Start grafana docker
-        run: docker-compose up -d
-
-      - name: Run e2e tests
-        run: {{ packageManagerName }} run e2e
-
-      - name: Stop grafana docker
-        run: docker-compose down
-
       - name: Check for backend
         id: check-for-backend
         run: |
@@ -60,7 +51,7 @@ jobs:
         if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
@@ -75,3 +66,31 @@ jobs:
         with:
           version: latest
           args: buildAll
+
+      - name: Check for E2E
+        id: check-for-e2e
+        run: |
+          if [ -d "cypress" ]
+          then
+            echo "has-e2e=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Start grafana docker
+        if: steps.check-for-e2e.outputs.has-e2e == 'true'
+        run: docker-compose up -d
+
+      - name: Run e2e tests
+        if: steps.check-for-e2e.outputs.has-e2e == 'true'
+        run: {{ packageManagerName }} run e2e
+
+      - name: Stop grafana docker
+        if: steps.check-for-e2e.outputs.has-e2e == 'true'
+        run: docker-compose down
+
+      - name: Archive E2E output
+        uses: actions/upload-artifact@v3
+        if: steps.check-for-e2e.outputs.has-e2e == 'true'
+        with:
+          name: cypress-videos
+          path: cypress/videos
+          retention-days: 5

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Archive E2E output
         uses: actions/upload-artifact@v3
-        if: steps.check-for-e2e.outputs.has-e2e == 'true'
+        if: steps.check-for-e2e.outputs.has-e2e == 'true' && steps.run-e2e-tests.outcome != 'success'
         with:
           name: cypress-videos
           path: cypress/videos


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the following adjustments:

1) Build the backend before running E2E tests (to be able to exercise a datasource)
2) Only run E2E tasks if the cypress directory exists
3) Uploads video output of E2E/cypress failures with 5 day retention
4) Bumps go to 1.20

These are just suggestions and how I've modified my plugins to operate (not all have E2E and build times are slower due to spinning up/down docker)

**Which issue(s) this PR fixes**:

No issue open currently.

**Special notes for your reviewer**:

I have these changes active in a panel plugin (an unpublished one)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.3.1-canary.242.272cf0e.0
  # or 
  yarn add @grafana/create-plugin@1.3.1-canary.242.272cf0e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
