### PR TITLE
Fix fonts not loaded correctly on generated bundles

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -117,7 +117,7 @@ const config = async (env): Promise<Configuration> => ({
         type: 'asset/resource',
         generator: {
           // Keep publicPath relative for host.com/grafana/ deployments
-          publicPath: `public/plugins/${pluginJson.id}/fonts`,
+          publicPath: `public/plugins/${pluginJson.id}/fonts/`,
           outputPath: 'fonts/',
           filename: Boolean(env.production) ? '[hash][ext]' : '[name][ext]',
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a missing forwardslash to the webpack font loader

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/plugin-tools/issues/249

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
