### PR TITLE
Docs: Plugin-tools intro material - Doc review chunk 6

### DIFF
--- a/docusaurus/docs/creating-a-plugin.mdx
+++ b/docusaurus/docs/creating-a-plugin.mdx
@@ -55,7 +55,7 @@ To learn more about the types of plugins, refer to the [plugin management guidel
 
 ### Do you want a backend part of your plugin?
 
-App and datasource plugins can have a backend component written in Go. Backend plugins offer powerful features such as:
+App and data source plugins can have a backend component written in Go. Backend plugins offer powerful features such as:
 
 - Enable [Grafana Alerting](https://grafana.com/docs/grafana/latest/alerting/) for data sources.
 - Connect to non-HTTP services to which a browser normally can’t connect. For example, SQL database servers.

--- a/docusaurus/docs/creating-a-plugin.mdx
+++ b/docusaurus/docs/creating-a-plugin.mdx
@@ -16,7 +16,7 @@ To create a new Grafana plugin, run the following command in your shell:
 />
 
 :::info
-When promoted, enter answers to the given questions. For example: 
+When prompted, enter answers to the given questions. For example: 
 
 ```
 ? What is going to be the name of your plugin?: _mongodb_

--- a/docusaurus/docs/creating-a-plugin.mdx
+++ b/docusaurus/docs/creating-a-plugin.mdx
@@ -3,7 +3,7 @@ id: creating-a-plugin
 title: Creating a Plugin
 ---
 
-To create a new Grafana plugin run the following command in your shell:
+To create a new Grafana plugin, run the following command in your shell:
 
 <CodeSnippets
   paths={[
@@ -16,28 +16,28 @@ To create a new Grafana plugin run the following command in your shell:
 />
 
 :::info
-The answers to the name, organization and type of plugin prompts are combined to create the plugin directory name and the plugin id.
+When promoted, enter answers to the given questions. For example: 
 
 ```
-? What is going to be the name of your plugin? mongodb
-? What is the organization name of your plugin? grafana
-? What type of plugin would you like? datasource
+? What is going to be the name of your plugin?: _mongodb_
+? What is the organization name of your plugin?: _grafana_
+? What type of plugin would you like?: _datasource_
 ```
 
-In the above example, this will cause the directory and plugin ID to be named `grafana-mongodb-datasource`
+If you enter those values for name, organization, and plugin type, then the directory and plugin ID will be named `grafana-mongodb-datasource`.
 :::
 
-## Prompts
+## Prompts reference
 
-When running the create command, the following prompts appear asking for confirmation before making changes:
+When running the `create-plugin` command, the following prompts appear:
 
 ### What is the name of your plugin?
 
-The name of your plugin. This helps to identify its purpose.
+Enter the name of your plugin. This helps to identify its purpose.
 
 ### What is the organization name of your plugin?
 
-Grafana plugins require an organization name (normally your [Grafana account](https://grafana.com/signup/) username) to help uniquely identify your plugin.
+Enter the name of your organization. Grafana plugins require an organization name (normally your [Grafana account](https://grafana.com/signup/) username) to help uniquely identify your plugin.
 
 ### How would you describe your plugin?
 
@@ -47,26 +47,26 @@ Give your plugin a description. This will help users more easily understand what
 
 Select from the following choices:
 
-- **app** (Applications, or app plugins, create a custom out-of-the-box monitoring experience.)
-- **datasource** (Data source plugins add support for new databases or external APIs.)
-- **panel** (Add new visualizations to dashboards with panel plugins.)
+- **app**: Create a custom out-of-the-box monitoring experience.
+- **datasource**: Add support for new databases or external APIs.
+- **panel**: Add new visualizations to dashboards.
 
 To learn more about the types of plugins, refer to the [plugin management guidelines](https://grafana.com/docs/grafana/latest/administration/plugin-management/).
 
 ### Do you want a backend part of your plugin?
 
-App and Datasource plugins can have a backend component written in Go. Developing a backend to your plugin brings powerful features such as:
+App and datasource plugins can have a backend component written in Go. Backend plugins offer powerful features such as:
 
-- Enable Grafana Alerting for data sources.
-- Connect to non-HTTP services that normally can’t be connected to from a web browser, e.g. SQL database servers.
-- Keep state between users, e.g. query caching for data sources.
+- Enable [Grafana Alerting](https://grafana.com/docs/grafana/latest/alerting/) for data sources.
+- Connect to non-HTTP services to which a browser normally can’t connect. For example, SQL database servers.
+- Keep state between users. For example, query caching for data sources.
 - Use custom authentication methods and/or authorization checks that aren’t supported in Grafana.
-- Use a custom data source request proxy. To learn more see [Backend developer resources](https://grafana.com/docs/grafana/latest/developers/plugins/backend/#resources).
+- Use a custom data source request proxy. To learn more, refer to [Backend developer resources](https://grafana.com/docs/grafana/latest/developers/plugins/backend/#resources).
 
 ### Do you want to add Github CI and Release workflows?
 
 Add [github workflows](./ci.md) to your development cycle to help catch issues early or release your plugin to the community.
 
-### Do you want to add a Github workflow for automatically checking Grafana API compatibility on PRs?
+### Do you want to add a Github workflow to automatically check Grafana API compatibility on PRs?
 
-Add a [github workflow](./ci.md#compatibility-check-is-compatibleyml) to regularly check your plugin is compatibile with the latest version of Grafana.
+Add a [github workflow](./ci.md#compatibility-check-is-compatibleyml) to regularly check that your plugin is compatible with the latest version of Grafana.

--- a/docusaurus/docs/folder-structure.md
+++ b/docusaurus/docs/folder-structure.md
@@ -3,7 +3,7 @@ id: folder-structure
 title: Folder Structure
 ---
 
-After creation, your project should look similar to this:
+After you install the `create-plugin` tool and have answered the prompts, your project should look similar to this:
 
 ```
 myorg-myplugin-datasource/
@@ -43,17 +43,19 @@ myorg-myplugin-datasource/
 
 ## Required files
 
-For the plugin to function, **these files must exist with exact filenames**:
+You must have files with these exact filenames:
 
 | Filename            | Description                                                                          |
 | ------------------- | ------------------------------------------------------------------------------------ |
-| `./go.mod`          | Go modules dependencies, [reference](https://golang.org/cmd/go/#hdr-The_go_mod_file) |
-| `./src/plugin.json` | A JSON file describing the plugin                                                    |
-| `./src/module.ts`   | The entry point of the frontend plugin                                               |
-| `./pkg/main.go`     | The entry point of the backend plugin                                                |
+| `./go.mod`          | Go modules dependencies. Refer to [Golang documentation](https://golang.org/cmd/go/#hdr-The_go_mod_file) |
+| `./src/plugin.json` | A JSON file describing the plugin.                                                    |
+| `./src/module.ts`   | The entry point of the frontend plugin.                                             |
+| `./pkg/main.go`     | The entry point of the backend plugin.                                                |
 
-These files are optional:
+## Optional files
+
+These files in your project are optional:
 
 | Filename        | Description                                                                                                                                |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `./Magefile.go` | Whilst not required we strongly recommend using mage build files so that you can use the build targets provided by the backend plugin SDK. |
+| `./Magefile.go` | Optional: We strongly recommend using mage build files so that you can use the build targets provided by the backend plugin SDK. |

--- a/docusaurus/docs/folder-structure.md
+++ b/docusaurus/docs/folder-structure.md
@@ -58,4 +58,4 @@ These files in your project are optional:
 
 | Filename        | Description                                                                                                                                |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `./Magefile.go` | Optional: We strongly recommend using mage build files so that you can use the build targets provided by the backend plugin SDK. |
+| `./Magefile.go` | We strongly recommend using mage build files so that you can use the build targets provided by the backend plugin SDK. |

--- a/docusaurus/docs/getting-started.mdx
+++ b/docusaurus/docs/getting-started.mdx
@@ -59,7 +59,7 @@ You'll need to have the following tools set up:
 
 #### Choose a package manager
 
-When you first run `@grafana/create-plugin`, choose your package manager `npm`, `pnpm`, or `yarn`.
+When you first run `@grafana/create-plugin`, choose your package manager: `npm`, `pnpm`, or `yarn`.
 
 ## Output
 
@@ -123,7 +123,7 @@ When you've finished installing the tools, open the plugin folder:
 
 ## Key CLI commands
 
-After the `create-plugin` plugin tool is installed, you can run built-in commands in the shell:
+After `create-plugin` has finished, you can run built-in commands in the shell:
 
 ### <SyncCommand cmd="run dev" />
 

--- a/docusaurus/docs/getting-started.mdx
+++ b/docusaurus/docs/getting-started.mdx
@@ -44,7 +44,7 @@ Grafana plugin tools work with the following operating systems:
 
 #### Supported Grafana version
 
-We recommend that you build for a version of Grafana later than v9.0. The plugin tools may work with earlier versions, but Grafana Labs may not provide support for them.
+We generally recommend that you build for a version of Grafana later than v9.0. For more information about requirements and dependencies when developing with Grafana, see the [Grafana developer's guide](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md).
 
 #### Recommended tooling
 

--- a/docusaurus/docs/getting-started.mdx
+++ b/docusaurus/docs/getting-started.mdx
@@ -3,14 +3,16 @@ id: getting-started
 title: Getting Started
 ---
 
-Create Plugin is the officially supported way to develop plugins to extend Grafana in amazing ways! It offers a modern build setup with zero configuration.
+Grafana's plugin tools offer an officially supported way to extend Grafana's core functionality. We have designed these tools to help you to develop your plugins faster with a modern build setup and zero configuration. 
 
-Plugin tools consists of two packages:
+The plugin tools consist of two packages:
 
-- `create-plugin`: A command-line utility to scaffold new plugins or migrate plugins created with `@grafana/toolkit`.
-- `sign-plugin`: A command-line utility to sign plugins for distribution.
+- `create-plugin`: A CLI to scaffold new plugins or migrate plugins created with `@grafana/toolkit`.
+- `sign-plugin`: A CLI to sign plugins for distribution.
 
 ## Quick Start
+
+To scaffold your plugin, run the following command and follow the prompts: 
 
 <CodeSnippets
   paths={[
@@ -22,44 +24,54 @@ Plugin tools consists of two packages:
   queryString="current-package-manager"
 />
 
-Follow the prompts to scaffold a Grafana plugin. [See here](./creating-a-plugin.mdx) for detailed information about creating a plugin.
+For next steps, see [Creating a plugin](./creating-a-plugin.mdx) 
 
 :::note
 
-Plugins previously scaffolded with `@grafana/toolkit` can be migrated. Please see [this migration guide](./migrating-from-toolkit).
+If you have previously built a plugin with `@grafana/toolkit`, you can use our plugin tools to simplify migration. For more information, refer to the [Migration guide](./migrating-from-toolkit).
 
 :::
 
-### What you'll need
+### Before you begin 
 
-- [Go](https://go.dev/doc/install) version 1.18 or above
-- [Mage](https://magefile.org/)
-- [Node.js](https://nodejs.org/en/download/) version 16 or above:
-  - When installing Node.js, you are recommended to check all checkboxes related to dependencies.
-- Optionally [Yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or [PNPM](https://pnpm.io/installation)
-- [Docker](https://docs.docker.com/get-docker/)
+#### Supported operating systems
 
-### Supported Operating Systems
-Create Plugin currently supports the following operating systems:
+Grafana plugin tools work with the following operating systems:
 
 - Linux
 - macOS
 - Windows 10+ with WSL (Windows Subsystem for Linux)
 
-### Choosing a package manager
-Starting from v1.3 of Create Plugin when you create a new plugin, the CLI will use `npm`, `pnpm` or `yarn` depending on which tool you use to run `@grafana/create-plugin`.
+#### Supported Grafana version
+
+We recommend that you build for a version of Grafana later than v9.0. The plugin tools may work with earlier versions, but Grafana Labs may not provide support for them.
+
+#### Recommended tooling
+
+You'll need to have the following tools set up:
+
+- [Go](https://go.dev/doc/install) version 1.18 or later.
+- [Mage](https://magefile.org/).
+- [Node.js](https://nodejs.org/en/download/) version 16 or later.
+  - We recommend that you should install Node.js with all checkboxes related to dependencies checked.
+- [Docker](https://docs.docker.com/get-docker/).
+- Optional: [Yarn 1 (Classic)](https://classic.yarnpkg.com/lang/en/docs/install) or [pnpm](https://pnpm.io/installation).
+
+#### Choose a package manager
+
+When you first run `@grafana/create-plugin`, choose your package manager `npm`, `pnpm`, or `yarn`.
 
 ## Output
 
-Running the above command will create a directory called `<orgName>-<pluginName>-<pluginType>` inside the current directory. Within this new directory is the initial project structure to kickstart development.
+Run the above command to create a directory called `<orgName>-<pluginName>-<pluginType>` inside the current directory. This directory contains  the initial project structure to kickstart your plugin development.
 
 :::info
 
-The directory name `<orgName>-<pluginName>-<pluginType>` is based on the answers given by the prompts. Please replace any commands with the name of the generated folder.
+The directory name `<orgName>-<pluginName>-<pluginType>` is based on the answers you gave to the prompts. Use the name of the generated folder when prompted.
 
 :::
 
-Depending on the answers given to the prompts there should be a structure like:
+Depending on the answers you gave to the prompts, there should now be a structure like:
 
 ```
 <orgName>-<pluginName>-<pluginType>
@@ -97,7 +109,7 @@ Depending on the answers given to the prompts there should be a structure like:
 └── tsconfig.json
 ```
 
-Once the installation is done you can open the plugin folder:
+When you've finished installing the tools, open the plugin folder:
 
 <CodeSnippets
   paths={[
@@ -109,22 +121,22 @@ Once the installation is done you can open the plugin folder:
   queryString="current-package-manager"
 />
 
-## Scripts
+## Key CLI commands
 
-Inside the newly create plugin, you can run some built-in commands:
+After the `create-plugin` plugin tool is installed, you can run built-in commands in the shell:
 
 ### <SyncCommand cmd="run dev" />
 
-Builds plugin in development mode and runs in watch mode. The plugin will be rebuilt whenever you make changes to the code. You will see build errors and lint warnings in the console.
+Builds the plugin in _development mode_ and runs in _watch mode_. Rebuilds the plugin whenever you make changes to the code. You'll see build errors and lint warnings in the console.
 
 ### <SyncCommand cmd="run test" />
 
-Runs the tests and watches for changes
+Runs the tests and watches for changes.
 
 ### <SyncCommand cmd="run build" />
 
-Creates a production build of the plugin optimizing for the best performance. The build is minified and the filenames include hashes.
+Creates a production build of the plugin that optimizes for the best performance. Minifies the build and includes hashes in the filenames.
 
 <h3><code>mage -v</code></h3>
 
-Build backend plugin binaries for Linux, Windows and Darwin.
+Builds backend plugin binaries for Linux, Windows and Darwin.

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/create-plugin",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "main": "index.js",
   "repository": {
     "directory": "packages/create-plugin",


### PR DESCRIPTION
### What is this feature?
This is a PR holding a review of 3 plugins docs, focusing on structure, editorial soundness, and conformity to doc team style guidelines.

Note 1: The label type/docs is not available for this repo, but this issue should be tracked in Docs projects.

Note 2: The contents of this repo will be moved as part of doc plan phase 2. However, the editing will take place in the Docusaurus repo where the files now live. 

### Why do we need this feature?
This fulfills the doc improvement initiative described in the plugins doc plan.

### Who is this feature for?
Plugin developers