### PR TITLE
Create Plugin: Fix lint:fix not passing args with NPM

### DIFF
--- a/packages/create-plugin/templates/common/package.json
+++ b/packages/create-plugin/templates/common/package.json
@@ -9,7 +9,7 @@
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
-    "lint:fix": "{{ packageManagerName }} run lint --fix",
+    "lint:fix": "{{ packageManagerName }} run lint{{#if_eq packageManagerName npm}} --{{/if_eq}} --fix",
     "e2e": "{{ packageManagerName }} exec cypress install && {{ packageManagerName }} exec grafana-e2e run",
     "e2e:update": "{{ packageManagerName }} exec cypress install && {{ packageManagerName }} exec grafana-e2e run --update-screenshots",
     "server": "docker-compose up --build",


### PR DESCRIPTION
**What this PR does / why we need it**:
When scaffolding a plugin using NPM the lint:fix command doesn't pass the `--fix` arg to eslint because the syntax requires a `--` for NPM to understand it should pass it down.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #264 

**Special notes for your reviewer**:
