### PR TITLE
Create Plugin: Enable apps by default

### DIFF
--- a/packages/create-plugin/templates/app/provisioning/plugins/apps.yaml
+++ b/packages/create-plugin/templates/app/provisioning/plugins/apps.yaml
@@ -1,0 +1,5 @@
+apiVersion: 1
+
+apps:
+  - type: '{{ normalize_id pluginName orgName 'app' }}'
+    disabled: false

--- a/packages/create-plugin/templates/scenes-app/provisioning/plugins/apps.yaml
+++ b/packages/create-plugin/templates/scenes-app/provisioning/plugins/apps.yaml
@@ -1,0 +1,5 @@
+apiVersion: 1
+
+apps:
+  - type: '{{ normalize_id pluginName orgName 'app' }}'
+    disabled: false


### PR DESCRIPTION
Fixes https://github.com/grafana/plugin-tools/issues/234.

### What changed?
Added Grafana provisioning to enable the scaffolded `app` and `scenes-app` plugins by default when they are run with the generated docker-compose file (`npm run server`).  
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.6.0-canary.274.89a40e3.0
  # or 
  yarn add @grafana/create-plugin@1.6.0-canary.274.89a40e3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
