### PR TITLE
Fix 'Install dependencies' command in generated frontend README

### DIFF
--- a/packages/create-plugin/templates/_partials/frontend-getting-started.md
+++ b/packages/create-plugin/templates/_partials/frontend-getting-started.md
@@ -3,7 +3,7 @@
 1. Install dependencies
 
    ```bash
-   {{ packageManagerName }} run install
+   {{ packageManagerName }} install
    ```
 
 2. Build plugin in development mode and run in watch mode


### PR DESCRIPTION
It should be yarn/npm install, without the 'run' in between.
