### PR TITLE
Docs: Remove duplicate OS section of getting started page

### DIFF
--- a/docusaurus/docs/getting-started.mdx
+++ b/docusaurus/docs/getting-started.mdx
@@ -42,12 +42,6 @@ Make sure you are using supported a supported OS, Grafana version, and tooling.
 
 #### Supported operating systems
 
-- [Go](https://go.dev/doc/install) version 1.18 or above
-- [Mage](https://magefile.org/)
-- [Node.js](https://nodejs.org/en/download/) version 16 or above:
-- Optionally [Yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or [PNPM](https://pnpm.io/installation)
-- [Docker](https://docs.docker.com/get-docker/)
-
 Grafana plugin tools work with the following operating systems:
 
 - Linux

--- a/docusaurus/docs/getting-started.mdx
+++ b/docusaurus/docs/getting-started.mdx
@@ -56,12 +56,11 @@ We generally recommend that you build for a version of Grafana later than v9.0. 
 
 You'll need to have the following tools set up:
 
-- [Go](https://go.dev/doc/install) version 1.18 or later.
-- [Mage](https://magefile.org/).
-- [Node.js](https://nodejs.org/en/download/) version 16 or later.
-  - We recommend that you should install Node.js with all checkboxes related to dependencies checked.
+- [Go](https://go.dev/doc/install) version 1.18 or above
+- [Mage](https://magefile.org/)
+- [Node.js](https://nodejs.org/en/download/) version 16 or above
+- Optionally [Yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or [PNPM](https://pnpm.io/installation)
 - [Docker](https://docs.docker.com/get-docker/).
-- Optional: [Yarn 1 (Classic)](https://classic.yarnpkg.com/lang/en/docs/install) or [pnpm](https://pnpm.io/installation).
 
 #### Choose a package manager
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
[Getting Started](https://grafana.github.io/plugin-tools/docs/getting-started) page lists build tools twice, once under the supported OS section - assuming that was an accident (probably an artifact of a merge). 

![image](https://github.com/grafana/plugin-tools/assets/42971704/2f054c95-2234-4b21-8489-a4f30de426b1)


**Which issue(s) this PR fixes**:
None as far as I'm aware.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

->

