### PR TITLE
Making grafana-image parameter flexible

### DIFF
--- a/docusaurus/docs/docker.mdx
+++ b/docusaurus/docs/docker.mdx
@@ -42,7 +42,7 @@ To test a plugin across different versions of Grafana, set an environment variab
 
 ### Configure the Grafana image
 
-The default Docker image in the plugin tool is `grafana-enterprise`. If you want to override this image, alter the `docker-compose.yaml` by adding the `grafana_image` build argument like so:
+The default Docker image in the plugin tool is `grafana-enterprise`. If you want to override this image, alter the `docker-compose.yaml` by changing the `grafana_image` build argument like so:
 
 ```yaml
 version: '3.7'

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -41,6 +41,7 @@ export enum PLUGIN_TYPES {
 // Example: "@grafana/ui": "{{ grafanaVersion }}"
 export const EXTRA_TEMPLATE_VARIABLES = {
   grafanaVersion: '9.5.3',
+  grafanaImage: 'grafana-enterprise',
 };
 
 export const GRAFANA_FE_PACKAGES = [

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     build:
       context: ./.config
       args:
-        grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}}
+        grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}} }
         grafana_version: ${GRAFANA_VERSION:-{{~grafanaVersion~}} }
     ports:
       - 3000:3000/tcp

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./.config
       args:
+        grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}}
         grafana_version: ${GRAFANA_VERSION:-{{~grafanaVersion~}} }
     ports:
       - 3000:3000/tcp


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Making `grafana-image` flexible in the same way we already do for `grafana-version`


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.7.0-canary.286.6a4650a.0
  # or 
  yarn add @grafana/create-plugin@1.7.0-canary.286.6a4650a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
