### PR TITLE
Chore: Remove axios as a dependency for sign-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8453,6 +8453,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -8578,6 +8579,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
       "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -10046,6 +10048,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -11723,6 +11726,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -14216,6 +14220,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -24513,6 +24518,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ps-tree": {
@@ -30523,7 +30529,6 @@
       "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.1.3",
         "minimist": "^1.2.2"
       },
       "bin": {

--- a/packages/sign-plugin/package.json
+++ b/packages/sign-plugin/package.json
@@ -23,7 +23,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "axios": "^1.1.3",
     "minimist": "^1.2.2"
   },
   "devDependencies": {

--- a/packages/sign-plugin/src/utils/manifest.ts
+++ b/packages/sign-plugin/src/utils/manifest.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import fs from 'fs/promises';
 import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
-import axios from 'axios';
+import { postData } from './request';
 
 const MANIFEST_FILE = 'MANIFEST.txt';
 
@@ -86,8 +86,8 @@ export async function signManifest(manifest: ManifestInfo): Promise<string> {
   const url = GRAFANA_COM_URL + '/plugins/ci/sign';
 
   try {
-    const info = await axios.post(url, manifest, {
-      headers: { Authorization: 'Bearer ' + GRAFANA_API_KEY },
+    const info = await postData(url, manifest, {
+      Authorization: 'Bearer ' + GRAFANA_API_KEY,
     });
     if (info.status !== 200) {
       console.error('Error: ', info);

--- a/packages/sign-plugin/src/utils/request.ts
+++ b/packages/sign-plugin/src/utils/request.ts
@@ -1,0 +1,51 @@
+import https, { RequestOptions } from 'https';
+import { URL } from 'url';
+
+interface Headers {
+  Authorization: string;
+  [header: string]: string;
+}
+
+interface Response<R> {
+  data: R;
+  status: number;
+}
+
+export async function postData(urlString: string, data: unknown, headers: Headers): Promise<Response<string>> {
+  return new Promise<Response<string>>((resolve, reject) => {
+    const url = new URL(urlString);
+    const postData = JSON.stringify(data);
+
+    const options: RequestOptions = {
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: url.pathname,
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      const chunks: Buffer[] = [];
+
+      res.on('data', (chunk: Buffer) => chunks.push(chunk));
+
+      res.on('end', () => {
+        const results = Buffer.concat(chunks);
+        resolve({
+          data: results.toString(),
+          status: res.statusCode ?? 200,
+        });
+      });
+
+      res.on('error', reject);
+    });
+
+    req.on('error', reject);
+
+    req.write(postData);
+    req.end();
+  });
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes axios as a dependency for sign-plugin. Axios is only used to make a single post request and it adds a layer of "black box" that can make situations like https://github.com/grafana/plugin-tools/issues/290 harder to diagnostic.

### Test run with a success case

![image](https://github.com/grafana/plugin-tools/assets/227916/813b4e40-47a3-41fc-8279-89d845e2c584)


### Test run with an error case 

![image](https://github.com/grafana/plugin-tools/assets/227916/e8ae1b95-7b3e-489b-b5dc-e881a527b77d)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/sign-plugin@1.0.3-canary.292.c5013c7.0
  # or 
  yarn add @grafana/sign-plugin@1.0.3-canary.292.c5013c7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
