### PR TITLE
Do not generate videos for cypress e2e tests

### DIFF
--- a/packages/create-plugin/templates/common/cypress.json
+++ b/packages/create-plugin/templates/common/cypress.json
@@ -1,0 +1,3 @@
+{
+  "video": false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a cypress.json  file to the common template to not generate videos when running.

The current (older) version of Cypress is slow in specific scenarios in CI when generating videos.

A effort is in place to [migrate to cypress 12](https://github.com/grafana/plugin-tools/issues/299) which should bring a solution to the video generation problem
