### PR TITLE
Adding noindex for now until we reshuffle the content

### DIFF
--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -16,7 +16,7 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',
-
+  noIndex: true,
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'grafana', // Usually your GitHub org/user name.


### PR DESCRIPTION
Adding 

`<meta name="robots" content="noindex, nofollow">`

globally to the github.io/plugin-tools website to prevent indexing until we reshuffle the content and at some point migrate towards the dev portal.

fyi @josmperez 
