### PR TITLE
Do not remove go_plugin_build_manifest on frontendbuild

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -127,7 +127,7 @@ const config = async (env): Promise<Configuration> => ({
 
   output: {
     clean: {
-      keep: new RegExp(`.*?_(amd64|arm(64)?)(.exe)?`),
+      keep: new RegExp(`(.*?_(amd64|arm(64)?)(.exe)?|go_plugin_build_manifest)`),
     },
     filename: '[name].js',
     library: {


### PR DESCRIPTION

**What this PR does / why we need it**:

If you build backend before frontend the go manifest file will be removed. This is problematic for certain CI pipelines that follow backend then frontend build steps.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/plugin-tools/issues/313

**Special notes for your reviewer**:
