### PR TITLE
sign-plugin: GRAFANA_ACESS_POLICY_TOKEN has been added instaed of GRAFANA_API_KEY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: '@grafana/sign-plugin - sign generated plugin'
         env:
-          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
+          GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
         run: node ../../sign-plugin/dist/bin/run.js --rootUrls http://www.example.com --signatureType private
         working-directory: ./packages/create-plugin/generated
 

--- a/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GRAFANA_API_KEY: $\{{ secrets.GRAFANA_API_KEY }} # Requires a Grafana API key from Grafana.com.
+      GRAFANA_ACCESS_POLICY_TOKEN: $\{{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 {{#if_eq packageManagerName "pnpm"}}
@@ -65,7 +66,7 @@ jobs:
 
       - name: Sign plugin
         run: {{ packageManagerName }} run sign
-        if: $\{{ env.GRAFANA_API_KEY != '' }}
+        if: $\{{ env.GRAFANA_ACCESS_POLICY_TOKEN != '' }}
 
       - name: Get plugin metadata
         id: metadata

--- a/packages/sign-plugin/src/utils/manifest.ts
+++ b/packages/sign-plugin/src/utils/manifest.ts
@@ -76,18 +76,26 @@ export async function buildManifest(dir: string): Promise<ManifestInfo> {
 
 export async function signManifest(manifest: ManifestInfo): Promise<string> {
   const GRAFANA_API_KEY = process.env.GRAFANA_API_KEY;
-  if (!GRAFANA_API_KEY) {
-    throw new Error(
-      'You must create a GRAFANA_API_KEY env variable to sign plugins. Please see: https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/#generate-an-api-key for instructions.'
-    );
+  const GRAFANA_ACCESS_POLICY_TOKEN = process.env.GRAFANA_ACCESS_POLICY_TOKEN;
+
+  if(!GRAFANA_ACCESS_POLICY_TOKEN) {
+    if (!GRAFANA_API_KEY) {
+      throw new Error(
+        'You must create a GRAFANA_ACCESS_POLICY_TOKEN env variable to sign plugins. Please see: https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/#generate-an-api-key for instructions.'
+      );
+    }
+    else {
+      console.warn(`\x1b[33m%s\x1b[0m`,'The usage of GRAFANA_API_KEY is deprecated, please consider using GRAFANA_ACCESS_POLICY_TOKEN instead. For more info visit https://grafana.com/docs/grafana/latest/developers/plugins/publish-a-plugin/sign-a-plugin')
+    }
   }
 
   const GRAFANA_COM_URL = process.env.GRAFANA_COM_URL || 'https://grafana.com/api';
   const url = GRAFANA_COM_URL + '/plugins/ci/sign';
 
+  const token = GRAFANA_ACCESS_POLICY_TOKEN ? GRAFANA_ACCESS_POLICY_TOKEN : GRAFANA_API_KEY;
   try {
     const info = await postData(url, manifest, {
-      Authorization: 'Bearer ' + GRAFANA_API_KEY,
+      Authorization: 'Bearer ' + token,
     });
     if (info.status !== 200) {
       console.error('Error: ', info);


### PR DESCRIPTION
**What this PR does / why we need it**:

- The signing package should first try to read a new env variable called GRAFANA_ACCESS_POLICY_TOKEN and use it for signing purposes
- If this env variable is not set, fallback to GRAFANA_API_KEY and use it instead and show warning message, that usage of GRAFANA_API_KEY here is deprecated
- Provided GitHub actions for sign/releasing of plugins are updated
- Our integration test for sign plugin is updated

Fixes #323 

