### PR TITLE
Fix swc-core version to 1.3.75 to prevent existing bug with baseUrls

### DIFF
--- a/packages/create-plugin/templates/common/package.json
+++ b/packages/create-plugin/templates/common/package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e-selectors": "{{ grafanaVersion }}",
     "@grafana/eslint-config": "^6.0.0",
     "@grafana/tsconfig": "^1.2.0-rc1",
-    "@swc/core": "^1.3.62",
+    "@swc/core": "1.3.75",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Fixes a reported issue where running build after running `npm install` or `yarn install` fails o build with error

`panicked at 'base_dir(./src) must be absolute. Please ensure that `jsc.baseUrl` is specified correctly.'`

The error is fixed by pinning the version of @swc/core to a known working version 1.3.75.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.10.1-canary.346.8316a63.0
  # or 
  yarn add @grafana/create-plugin@1.10.1-canary.346.8316a63.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
