### PR TITLE
Add CSS to make links visible inside page content

### DIFF
--- a/docusaurus/website/src/css/custom.css
+++ b/docusaurus/website/src/css/custom.css
@@ -165,3 +165,7 @@ html[data-theme='dark'] {
   font-size: 0.9rem;
   margin-bottom: var(--ifm-global-spacing);
 }
+article a {
+  text-decoration: underline !important;
+  color: var(--text-link) !important;
+}

--- a/docusaurus/website/src/css/custom.css
+++ b/docusaurus/website/src/css/custom.css
@@ -165,7 +165,7 @@ html[data-theme='dark'] {
   font-size: 0.9rem;
   margin-bottom: var(--ifm-global-spacing);
 }
-article a {
+article .markdown a {
   text-decoration: underline !important;
   color: var(--text-link) !important;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds custom css to make links visible inside a doc's article

This is a temporal fix while saga provides the solution to the base css.

This is how they look with this css

![image](https://github.com/grafana/plugin-tools/assets/227916/b6702e11-f674-4025-96fd-4cd1336ed4e6)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
