### PR TITLE
Adding the noindex back until we start redirecting

### DIFF
--- a/docusaurus/website/docusaurus.config.base.js
+++ b/docusaurus/website/docusaurus.config.base.js
@@ -22,6 +22,7 @@ const generalConfig = {
     defaultLocale: 'en',
     locales: ['en'],
   },
+  noIndex: true,
 };
 
 const plugins = [


### PR DESCRIPTION
Adding the noIndex by default back until we start redirecting pages from grafana.com/docs