### PR TITLE
create-plugin: Add link to documentation about troubleshooting create-plugin on windows 

### DIFF
--- a/packages/create-plugin/src/bin/run.ts
+++ b/packages/create-plugin/src/bin/run.ts
@@ -6,7 +6,9 @@ import { isUnsupportedPlatform } from '../utils/utils.os';
 
 // Exit early if operating system isn't supported.
 if (isUnsupportedPlatform()) {
-  console.error("Unsupported operating system 'Windows' detected. Please use WSL with create-plugin.");
+  console.error(
+    "Unsupported operating system 'Windows' detected. Please use WSL with create-plugin. For more info visit: https://grafana.com/developers/plugin-tools/troubleshooting#i-am-getting-unsupported-operating-system-windows-detected-please-use-wsl-with-create-plugin"
+  );
   process.exit(1);
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When create-plugin detects Windows OS we shoe the error, that this OS is not supported. We need to add access to documentation with details

**Which issue(s) this PR fixes**:

Fixes #347

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.11.0-canary.365.32f6dfa.0
  # or 
  yarn add @grafana/create-plugin@1.11.0-canary.365.32f6dfa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
