### PR TITLE
Docs: change link target for plugin.json

### DIFF
--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/build-a-data-source-backend-plugin.md
@@ -125,12 +125,12 @@ The folders and files used to build the backend for the data source are:
 
 #### plugin.json
 
-The [plugin.json](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/) file is required for all plugins. When building a backend plugin these properties are important:
+The [plugin.json](../../metadata.md) file is required for all plugins. When building a backend plugin these properties are important:
 
 | property   | description                                                                                                                                                   |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | backend    | Should be set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin.                                        |
-| executable | This is the name of the executable that Grafana expects to start, see [plugin.json reference](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/) for details. |
+| executable | This is the name of the executable that Grafana expects to start, see [plugin.json reference](h../../metadata.md) for details. |
 | alerting   | Should be set to `true` if your backend datasource supports alerting.                                                                                         |
 
 In the next step we will look at the query endpoint!

--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/build-a-logs-data-source-plugin.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/build-a-logs-data-source-plugin.md
@@ -32,7 +32,7 @@ When these steps are done, then you can improve the user experience with one or 
 
 ### Step 1: Enable logs support
 
-Tell Grafana that your data source plugin can return log data, by adding `"logs": true` to the [plugin.json](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/) file.
+Tell Grafana that your data source plugin can return log data, by adding `"logs": true` to the [plugin.json](../../metadata.md) file.
 
 ```json
 {

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/add-authentication-for-data-source-plugins.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/add-authentication-for-data-source-plugins.md
@@ -135,7 +135,7 @@ Be sure not to confuse the data source proxy with the [auth proxy](https://grafa
 
 ### Add a proxy route to your plugin
 
-To forward requests through the Grafana proxy, you need to configure one or more _proxy routes_. A proxy route is a template for any outgoing request that is handled by the proxy. You can configure proxy routes in the [plugin.json](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/) file.
+To forward requests through the Grafana proxy, you need to configure one or more _proxy routes_. A proxy route is a template for any outgoing request that is handled by the proxy. You can configure proxy routes in the [plugin.json](../../metadata.md) file.
 
 1. Add the route to `plugin.json`:
 

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/enable-annotations.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/enable-annotations.md
@@ -17,7 +17,7 @@ You can add support to your plugin for annotations that will insert information 
 
 To enable annotations, simply add two lines of code to your plugin. Grafana uses your default query editor for editing annotation queries.
 
-1. Add `"annotations": true` to the [plugin.json](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/) file to let Grafana know that your plugin supports annotations.
+1. Add `"annotations": true` to the [plugin.json](../../metadata.md) file to let Grafana know that your plugin supports annotations.
 
    **In `plugin.json`:**
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v7.x-v8.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v7.x-v8.x.md
@@ -156,7 +156,7 @@ You can still run and develop an unsigned plugin by running your Grafana instanc
 
 We have upgraded react-hook-form from version 6 to version 7. To make your forms compatible with version 7, refer to the [react-hook-form-migration-guide](https://react-hook-form.com/migrate-v6-to-v7/).
 
-## Update the plugin.json
+## Update the `plugin.json`
 
 The property that defines which Grafana version your plugin supports has been renamed and now it is a range instead of a specific version.
 

--- a/docusaurus/docs/shared/plugin-anatomy.md
+++ b/docusaurus/docs/shared/plugin-anatomy.md
@@ -12,7 +12,7 @@ While certain plugin types can have specific configuration options, let's look a
 - `name` is what users will see in the list of plugins. If you're creating a data source, this is typically the name of the database it connects to, such as Prometheus, PostgreSQL, or Stackdriver.
 - `id` uniquely identifies your plugin, and should start with your Grafana username, to avoid clashing with other plugins. [Sign up for a Grafana account](https://grafana.com/signup/) to claim your username.
 
-To see all the available configuration settings for the `plugin.json`, refer to the [plugin.json Schema](https://grafana.com/docs/grafana/latest/plugins/developing/plugin.json/).
+To see all the available configuration settings for the `plugin.json`, refer to the [plugin.json Schema](../metadata.md).
 
 ### module.ts
 

--- a/packages/create-plugin/templates/_partials/distributing-your-plugin.md
+++ b/packages/create-plugin/templates/_partials/distributing-your-plugin.md
@@ -14,7 +14,7 @@ Before signing a plugin for the first time please consult the Grafana [plugin si
 
 1. Create a [Grafana Cloud account](https://grafana.com/signup).
 2. Make sure that the first part of the plugin ID matches the slug of your Grafana Cloud account.
-   - _You can find the plugin ID in the plugin.json file inside your plugin directory. For example, if your account slug is `acmecorp`, you need to prefix the plugin ID with `acmecorp-`._
+   - _You can find the plugin ID in the `plugin.json` file inside your plugin directory. For example, if your account slug is `acmecorp`, you need to prefix the plugin ID with `acmecorp-`._
 3. Create a Grafana Cloud API key with the `PluginPublisher` role.
 4. Keep a record of this API key as it will be required for signing a plugin
 

--- a/packages/create-plugin/templates/app/README.md
+++ b/packages/create-plugin/templates/app/README.md
@@ -18,5 +18,5 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
 Below you can find source code for existing app plugins and other related documentation.
 
 - [Basic app plugin example](https://github.com/grafana/grafana-plugin-examples/tree/master/examples/app-basic#readme)
-- [Plugin.json documentation](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/)
+- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json)
 - [How to sign a plugin?](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/)

--- a/packages/create-plugin/templates/datasource/README.md
+++ b/packages/create-plugin/templates/datasource/README.md
@@ -18,5 +18,5 @@ Grafana supports a wide range of data sources, including Prometheus, MySQL, and 
 Below you can find source code for existing app plugins and other related documentation.
 
 - [Basic data source plugin example](https://github.com/grafana/grafana-plugin-examples/tree/master/examples/datasource-basic#readme)
-- [Plugin.json documentation](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/)
+- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json)
 - [How to sign a plugin?](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/)

--- a/packages/create-plugin/templates/panel/README.md
+++ b/packages/create-plugin/templates/panel/README.md
@@ -19,5 +19,5 @@ Use panel plugins when you want to do things like visualize data returned by dat
 Below you can find source code for existing app plugins and other related documentation.
 
 - [Basic panel plugin example](https://github.com/grafana/grafana-plugin-examples/tree/master/examples/panel-basic#readme)
-- [Plugin.json documentation](https://grafana.com/docs/grafana/latest/developers/plugins/metadata/)
+- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json)
 - [How to sign a plugin?](https://grafana.com/docs/grafana/latest/developers/plugins/sign-a-plugin/)


### PR DESCRIPTION
- Update link target for plugin.json from Hugo to Docusaurus site in docs.
- Update link target to https://grafana.comdevelopers/plugin-tools/reference-plugin-json for READMEs