### PR TITLE
Docs: Fix mismatches between doc titles and H1s

### DIFF
--- a/docusaurus/docs/introduction/error-handling.md
+++ b/docusaurus/docs/introduction/error-handling.md
@@ -11,7 +11,7 @@ keywords:
   - error handling
 ---
 
-# Work with error handling
+# Error handling
 
 This guide explains how to handle errors in plugins and provides suggestions for common scenarios.
 

--- a/docusaurus/docs/metadata.md
+++ b/docusaurus/docs/metadata.md
@@ -8,7 +8,7 @@ keywords:
   - documentation
 ---
 
-# plugin.json
+# Reference (plugin.json)
 
 The `plugin.json` file is required for all plugins. When Grafana starts, it scans the plugin folders and mounts every folder that contains a plugin.json file unless the folder contains a subfolder named dist. In that case, Grafana mounts the dist folder instead.
 

--- a/docusaurus/docs/migration-guides/angular-react.md
+++ b/docusaurus/docs/migration-guides/angular-react.md
@@ -6,7 +6,7 @@ keywords: [grafana, plugins, angular, react, migration, migrate]
 description: "How to migrate a Grafana plugin from AngularJS to React."
 ---
 
-# Migrate a plugin from AngularJS to React
+# Migrate from AngularJS to React
 
 If you want to migrate a plugin to Grafana's React-based plugin platform, then we recommend that you release it under a new major version. Consider keeping a release branch for the previous version to be able to roll out patch releases for versions prior to Grafana 7.
 

--- a/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
+++ b/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
@@ -1,6 +1,6 @@
 ---
 id: publish-a-plugin
-title: Publish a plugin
+title: Publish or update a plugin
 sidebar_position: 4
 description: "Learn how to package and share your plugin."
 keywords:

--- a/docusaurus/docs/publish-a-plugin/publishing-and-signing-criteria.md
+++ b/docusaurus/docs/publish-a-plugin/publishing-and-signing-criteria.md
@@ -12,7 +12,7 @@ keywords:
   - signing
 ---
 
-# Plugin publishing and signing criteria
+# Publishing and signing criteria
 
 Grafana plugins must adhere to the Grafana Labs [Plugin Policy](https://grafana.com/legal/plugins/). Our review process for publishing and signing will examine your compliance with this policy.
 


### PR DESCRIPTION
A few topics don't have the same verbage for the doc title (appearing on TOC) and the H1 at the top. This PR fixes mismatches between doc titles and H1s.