### PR TITLE
Update transform regex to detect nested modules

### DIFF
--- a/packages/create-plugin/templates/common/.config/jest/utils.js
+++ b/packages/create-plugin/templates/common/.config/jest/utils.js
@@ -8,7 +8,7 @@
  * This utility function is useful in combination with jest `transformIgnorePatterns` config
  * to transform specific packages (e.g.ES modules) in a projects node_modules folder.
  */
-const nodeModulesToTransform = (moduleNames) => `node_modules\/(?!(${moduleNames.join('|')})\/)`;
+const nodeModulesToTransform = (moduleNames) => `node_modules\/(?!.*(${moduleNames.join('|')})\/.*)`;
 
 // Array of known nested grafana package dependencies that only bundle an ESM version
 const grafanaESModules = [


### PR DESCRIPTION
This PR updates the jest `transformIgnorePatterns` regex to ensure nested modules are supported.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.12.1-canary.375.26435ce.0
  # or 
  yarn add @grafana/create-plugin@1.12.1-canary.375.26435ce.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
