### PR TITLE
Adding tracking and consent banner to docusaurus website

### DIFF
--- a/docusaurus/website/docusaurus.config.dev.js
+++ b/docusaurus/website/docusaurus.config.dev.js
@@ -41,6 +41,16 @@ const config = {
       prism: themeConfigPrism,
       colorMode: themeConfigColorMode,
     }),
+  
+  customFields: {
+    rudderStackTracking: {
+      url: "https://rs.grafana-dev.com",
+      writeKey: "1w02fcWseyqcwsJA9CSKRkfEOfU",
+      configUrl: "https://rsc.grafana.com",
+      sdkUrl: "https://rsdk.grafana.com",
+    },
+    canSpamUrl: "https://grafana-dev.com/canspam",
+  },
 };
 
 module.exports = config;

--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -41,7 +41,16 @@ const config = {
       prism: themeConfigPrism,
       colorMode: themeConfigColorMode,
     }),
-
+  
+  customFields: {
+    rudderStackTracking: {
+      url: "https://rs.grafana.com",
+      writeKey: "1sBAgwTlZ2K0zTzkM8YTWorZI00",
+      configUrl: "https://rsc.grafana.com",
+      sdkUrl: "https://rsdk.grafana.com",
+    },
+    canSpamUrl: "https://grafana.com/canspam",
+  },
 };
 
 module.exports = config;

--- a/docusaurus/website/package.json
+++ b/docusaurus/website/package.json
@@ -20,6 +20,7 @@
     "@iconscout/unicons": "^4.0.8",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "cookiejs": "^2.1.2",
     "gridsome-remark-figure-caption": "1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/docusaurus/website/src/components/CookieConsent/CookieConsent.tsx
+++ b/docusaurus/website/src/components/CookieConsent/CookieConsent.tsx
@@ -1,0 +1,26 @@
+import React, { MouseEventHandler } from "react";
+import styles from "./styles.module.css";
+
+type Props = {
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+};
+
+export function CookieConsent({ onClick }: Props) {
+  return (
+    <div className={styles.cookieConsent}>
+      <div className={styles.cookieConsentContainer}>
+        <div>
+          Grafana Labs uses cookies for the normal operation of this website.{" "}
+          <a href="https://grafana.com/terms#cookie-policy">
+            <strong>Learn more.</strong>
+          </a>
+        </div>
+        <div>
+          <button className={styles.cookieConsentCta} onClick={onClick}>
+            Got it!
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docusaurus/website/src/components/CookieConsent/styles.module.css
+++ b/docusaurus/website/src/components/CookieConsent/styles.module.css
@@ -1,0 +1,39 @@
+.cookieConsent {
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  z-index: 1;  
+  border-top: 1px solid color-mix(in srgb, var(--ifm-color-warning) 20%, transparent);
+
+}
+
+.cookieConsentContainer {
+  align-items: center;
+  background-color: var(--ifm-color-black);
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding: 10px;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .cookieConsentContainer {
+    flex-direction: row;
+    padding-left: 40px;
+    padding-right: 40px;
+  }
+}
+
+.cookieConsentCta {
+  background-color: var(--ifm-color-info);
+  border: 1px solid var(--ifm-color-info);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: bold;
+  min-height: 2.5rem;
+  padding: 0 1.5rem;
+}

--- a/docusaurus/website/src/theme/Root.tsx
+++ b/docusaurus/website/src/theme/Root.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import { useLocation } from "@docusaurus/router";
+
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { CookieConsent } from "../components/CookieConsent/CookieConsent";
+import {
+  RudderStackTrackingConfig,
+  startTracking,
+  trackPage,
+} from "./tracking";
+import {
+  analyticsVersion,
+  cookieName,
+  getCookie,
+  setCookie,
+} from "./tracking/cookie";
+
+export default function Root({ children }) {
+  const location = useLocation();
+  const {
+    siteConfig: { customFields },
+  } = useDocusaurusContext();
+
+  const rudderStackConfig =
+    customFields.rudderStackTracking as RudderStackTrackingConfig;
+
+  const setCookieAndStartTracking = () => {
+    setCookie(cookieName, {
+      analytics: analyticsVersion,
+    });
+
+    setShouldShow(false);
+    startTracking(rudderStackConfig);
+  }
+
+  const [shouldShow, setShouldShow] = useState(false);
+
+  const canSpam = async () => {
+    try {
+      const response = await fetch(customFields.canSpamUrl as string, { mode: "no-cors" });
+      if (response.status === 204) {
+        return true;
+      }
+    } catch (e) {
+      // do nothing
+    }
+    return false;
+  }
+
+  const onClick = () => {
+    return setCookieAndStartTracking();
+  };
+
+  useEffect(() => {
+    // If the user has already given consent, start tracking.
+    if (getCookie(cookieName, "analytics") === analyticsVersion) {
+      return setCookieAndStartTracking();
+    }
+
+    // If the user is from an IP address that does not require consent, start tracking.
+    canSpam().then((result) => {
+      if (result) {
+        return setCookieAndStartTracking();
+      }
+    }).catch(console.error);
+
+    // If the user has not given consent and is from IP address that requires consent, show the consent banner.
+    setShouldShow(true);
+  }, []);
+
+  useEffect(() => {
+    trackPage();
+  }, [location]);
+
+  return (
+    <>
+      {children}
+      {shouldShow && <CookieConsent onClick={onClick} />}
+    </>
+  );
+}

--- a/docusaurus/website/src/theme/tracking/cookie.ts
+++ b/docusaurus/website/src/theme/tracking/cookie.ts
@@ -1,0 +1,34 @@
+import cookie from "cookiejs";
+
+export const cookieName = "consent";
+export const analyticsVersion = "2";
+
+export function getCookie(name: string, key: string) {
+  let res = cookie.get(name);
+
+  try {    
+    if (res && typeof res === "string") {
+      
+      const parsed = JSON.parse(decodeURIComponent(res));
+      
+      if (parsed[key] !== undefined) {
+        return parsed[key];
+      }
+    }
+  } catch (e) {    
+    // do nothing
+  }
+  if (key === undefined) {
+    return res;
+  }  
+}
+
+export function setCookie(name: string, value: any) {
+  let val = value;
+
+  if (typeof value === "object") {
+    val = JSON.stringify(value);
+  }  
+
+  return cookie.set(name, val, { expires: 365, domain: `.${window.location.hostname}` });
+}

--- a/docusaurus/website/src/theme/tracking/index.ts
+++ b/docusaurus/website/src/theme/tracking/index.ts
@@ -1,0 +1,79 @@
+declare global {
+  interface Window {
+    rudderanalytics: any;
+  }
+}
+
+let rudderId;
+
+export function getRudderId() {
+  return rudderId;
+}
+
+const isRudderstackSetup = (config: RudderStackTrackingConfig) =>
+  config && config.writeKey && config.url && config.sdkUrl;
+
+// Enqueue all rudderstack requests until it is loaded and consent is granted
+let rudderstack = {};
+let rudderQueue = [];
+const rudderMethods = ["page", "track", "identify", "reset"];
+for (const method of rudderMethods) {
+  rudderstack[method] = (...args) => {
+    rudderQueue.push([method].concat(args));
+  };
+}
+
+export type RudderStackTrackingConfig = {
+  url: string;
+  writeKey: string;
+  configUrl: string;
+  sdkUrl: string;
+};
+
+export function startTracking(config: RudderStackTrackingConfig) {
+  if (isRudderstackSetup(config)) {
+    const { writeKey, url, configUrl } = config;
+
+    const initRudderstack = async () => {
+      rudderId = await window.rudderanalytics.getAnonymousId();
+
+      window.rudderanalytics.load(writeKey, url, { configUrl });
+      rudderstack = window.rudderanalytics;
+
+      // send any queued requests
+      for (const [method, ...args] of rudderQueue) {
+        rudderstack[method](...args);
+      }
+      // clean up afterwards so trackPage
+      rudderQueue = undefined;
+    };
+
+    const el = document.createElement("script");
+    el.async = true;
+    el.src = config.sdkUrl;
+    el.onload = initRudderstack;
+    document.getElementsByTagName("head")[0].appendChild(el);
+  }
+}
+
+export function trackPage() {
+  // rudderstack automagically accesses all this but if it isn't loaded we need to
+  // define it manually.
+  if (rudderQueue) {
+    const { href, pathname } = location;
+    const properties = {
+      url:
+        document.querySelector("link[rel='canonical']").getAttribute("href") ||
+        href,
+      path: pathname,
+      referrer: document.referrer || "$direct",
+      title: document.title,
+      tab_url: href,
+    };
+    // @ts-ignore we don't have the types.
+    rudderstack.page(properties);
+  } else {
+    // @ts-ignore we don't have the types.
+    rudderstack.page();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@iconscout/unicons": "^4.0.8",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
+        "cookiejs": "^2.1.2",
         "gridsome-remark-figure-caption": "1.2.1",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
@@ -10954,6 +10955,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cookiejs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejs/-/cookiejs-2.1.2.tgz",
+      "integrity": "sha512-FXsQ2Ub/bTjlt2aXiJsiT33g6iEXdYTIKabJa9Jn5CZjOyzszJjOGKWyqs+silY+xYmA9eiif2vGAxv2pJndcg=="
     },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",


### PR DESCRIPTION
Related to https://github.com/grafana/grafana-developer-portal/issues/7

This PR adds a consent banner and rudderstack code for tracking into our docs website. 