### PR TITLE
Move to underscore from dots in urls

### DIFF
--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v10.0.x-v10.1.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v10.0.x-v10.1.x.md
@@ -1,5 +1,5 @@
 ---
-id: migrate-10.0.x-to-10.1.x
+id: migrate-10_0_x-to-10_1_x
 title: 10.0.x to 10.1.x
 sidebar_position: 1
 description: How to migrate plugins from Grafana version 10.0.x to 10.1.x.

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v6.x-v7.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v6.x-v7.x.md
@@ -1,5 +1,5 @@
 ---
-id: migrate-6.x-to-7.0
+id: migrate-6_x-to-7_0
 title: 6.x to 7.0
 sidebar_position: 8
 description: How to upgrade plugins from Grafana version 6.x to 7.0.

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v7.x-v8.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v7.x-v8.x.md
@@ -1,5 +1,5 @@
 ---
-id: migrate-7.x-to-8.x
+id: migrate-7_x-to-8_x
 title: 7.x to 8.x
 sidebar_position: 7
 description: How to migrate Grafana v7.x plugins to the updated plugin system available in Grafana v8.x.

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v8.3.x-8.4.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v8.3.x-8.4.x.md
@@ -1,5 +1,5 @@
 ---
-id: migrate-8.3.x-to-8.4.x
+id: migrate-8_3_x-to-8_4_x
 title: 8.3.x to 8.4.x
 sidebar_position: 6
 description: How to migrate Grafana v8.3.x plugins to Grafana v8.4.x.

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v8.x-v9.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v8.x-v9.x.md
@@ -1,5 +1,5 @@
 ---
-id: migrate-8.x-to-9.x
+id: migrate-8_x-to-9_x
 title: 8.x to 9.x
 sidebar_position: 5
 description: How to migrate plugins from version 8.x to 9.x.

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.1.x-v9.2.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.1.x-v9.2.x.md
@@ -1,5 +1,5 @@
 ---
-id: migrate-9.1.x-to-9.2.x
+id: migrate-9_1_x-to-9_2_x
 title: 9.1.x to 9.2.x
 sidebar_position: 4
 description: How to migrate plugins from Grafana version 9.1.x to 9.2.x.

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.3.x-9.4.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.3.x-9.4.x.md
@@ -1,5 +1,5 @@
 ---
-id: migrate-9.3.x-to-9.4.x
+id: migrate-9_3_x-to-9_4_x
 title: 9.3.x to 9.4.x
 sidebar_position: 3
 description: How to migrate from Grafana 9.3.x to 9.4.x.

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -1,5 +1,5 @@
 ---
-id: migrate-9.x-to-10.x
+id: migrate-9_x-to-10_x
 title: 9.x to 10.x
 sidebar_position: 2
 description: How to migrate plugins from Grafana version 9.x to 10.x.


### PR DESCRIPTION
Since we are running behind a reverse proxy in nginx and are actively hiding `index.html` fetches from urls to keep them pretty -> there is no way for nginx to know when to fetch a static asset and when to fetch a `${page}/index.html`

This leads to pages that have dots in url being broken if they have no trailing `/index.html` set. 

To make our lives easier - we should just avoid dots in the url while we are running in reverse proxy mode.