### PR TITLE
Templates/Webpack: Include full path in dev mode image output filename

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -110,7 +110,7 @@ const config = async (env): Promise<Configuration> => {
             // Keep publicPath relative for host.com/grafana/ deployments
             publicPath: `public/plugins/${pluginJson.id}/img/`,
             outputPath: 'img/',
-            filename: Boolean(env.production) ? '[hash][ext]' : '[name][ext]',
+            filename: Boolean(env.production) ? '[hash][ext]' : '[file]',
           },
         },
         {


### PR DESCRIPTION
**What this PR does / why we need it**:

:wave:  Having multiple images with same filename but under different folders in `img/` causes webpack to error in dev mode because output path only includes the filename. For example we have `img/technology/generic.svg` and `/img/cloud/generic.svg' and it tries to ouput both into `img/generic.svg`, causing a conflict.

This PR makes dev output filename use the full img path, fixing this issue
