### PR TITLE
Adding dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"


### PR DESCRIPTION
Adding dependabot for github actions to keep github workflows up to date.

Related but NOT fixing https://github.com/grafana/plugin-tools/issues/393 completely