### PR TITLE
Docs: move error handling topic

### DIFF
--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/error-handling.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/error-handling.md
@@ -1,7 +1,7 @@
 ---
 id: error-handling
 title: Error handling
-sidebar_position: 5
+sidebar_position: 4
 description: How to handle errors in plugins.
 keywords:
   - grafana

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/error-handling.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/error-handling.md
@@ -1,7 +1,6 @@
 ---
 id: error-handling
 title: Error handling
-sidebar_position: 4
 description: How to handle errors in plugins.
 keywords:
   - grafana


### PR DESCRIPTION
I propose to move the error handling topic out of Introduction into Create a plugin/Develop a plugin. As it contains a mix of conceptual and how-to information, the latter seems more appropriate.