### PR TITLE
Docs: fix typo on get-started.mdx

### DIFF
--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -78,7 +78,7 @@ You'll need to have the following tools set up:
 - [Mage](https://magefile.org/)
 - [Node.js](https://nodejs.org/en/download/) version 16 or above
 - Optionally [Yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or [PNPM](https://pnpm.io/installation)
-- [Docker](https://docs.docker.com/get-docker/).
+- [Docker](https://docs.docker.com/get-docker/)
 
 #### Choose a package manager
 


### PR DESCRIPTION
remove extra period