### PR TITLE
Docs: add new section to get-started

### DIFF
--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -15,31 +15,20 @@ import ScaffoldNPM from '@snippets/createplugin-scaffold.npm.md';
 import ScaffoldPNPM from '@snippets/createplugin-scaffold.pnpm.md';
 import ScaffoldYarn from '@snippets/createplugin-scaffold.yarn.md';
 
-# Grafana plugin developer's guide
+# Get started with plugins
 
-Extend Grafana's built-in capabilities with plugins. Plugins enable Grafana 
-to accomplish specialized tasks, custom-tailored to your requirements. 
-By making a plugin for your organization, you can connect Grafana to other 
-data sources, ticketing tools, and CI/CD tooling.
+Extend Grafana's built-in capabilities with plugins custom-tailored 
+to your requirements. This guide is designed to help you quickly get up 
+and running with a working plugin.  
 
-You can create plugins for private use or contribute them to the open 
-source community by publishing to the Grafana 
-[plugin catalog](https://grafana.com/plugins). 
-This catalog has hundreds of other community and commercial plugins.
+From here, you can explore the rest of our documentation,
+[SDK for Go](../introduction/grafana-plugin-sdk-for-go), and 
+[plugin examples](https://github.com/grafana/grafana-plugin-examples/) to build 
+your knowledge and add more advanced capabilities. And when you're ready, you can
+publish your plugin in the Grafana [plugin catalog](https://grafana.com/plugins). 
 
-## Types of plugins
-
-You can create several types of plugins, including:
-
-* **Panel plugins** - Visualize data and navigate between dashboards.
-* **Data source plugins** - Link to new databases or other sources of data.
-* **App plugins** - Create rich applications for custom out-of-the-box experiences.
-
-## Plugin tools
-
-Grafana's plugin tools offer an officially supported way to extend Grafana's core functionality. We have designed these tools to help you to develop your plugins faster with a modern build setup and zero configuration.
-
-The plugin tools consist of two packages:
+Grafana offers two CLI plugin tools to help you to develop your plugins faster 
+with a modern build setup and zero configuration.
 
 - `create-plugin`: A CLI to scaffold new plugins or migrate plugins created with `@grafana/toolkit`.
 - `sign-plugin`: A CLI to sign plugins for distribution.

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -22,7 +22,7 @@ to your requirements. This guide is designed to help you quickly get up
 and running with a working plugin.  
 
 From here, you can explore the rest of our documentation,
-[SDK for Go](../introduction/grafana-plugin-sdk-for-go), and 
+[SDK for Go](/developers/plugin-tools/introduction/grafana-plugin-sdk-for-go), and 
 [plugin examples](https://github.com/grafana/grafana-plugin-examples/) to build 
 your knowledge and add more advanced capabilities. And when you're ready, you can
 publish your plugin in the Grafana [plugin catalog](https://grafana.com/plugins). 

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -15,6 +15,28 @@ import ScaffoldNPM from '@snippets/createplugin-scaffold.npm.md';
 import ScaffoldPNPM from '@snippets/createplugin-scaffold.pnpm.md';
 import ScaffoldYarn from '@snippets/createplugin-scaffold.yarn.md';
 
+# Grafana plugin developer's guide
+
+Extend Grafana's built-in capabilities with plugins. Plugins enable Grafana 
+to accomplish specialized tasks, custom-tailored to your requirements. 
+By making a plugin for your organization, you can connect Grafana to other 
+data sources, ticketing tools, and CI/CD tooling.
+
+You can create plugins for private use or contribute them to the open 
+source community by publishing to the Grafana 
+[plugin catalog](https://grafana.com/plugins). 
+This catalog has hundreds of other community and commercial plugins.
+
+## Types of plugins
+
+You can create several types of plugins, including:
+
+* **Panel plugins** - Visualize data and navigate between dashboards.
+* **Data source plugins** - Link to new databases or other sources of data.
+* **App plugins** - Create rich applications for custom out-of-the-box experiences.
+
+## Plugin tools
+
 Grafana's plugin tools offer an officially supported way to extend Grafana's core functionality. We have designed these tools to help you to develop your plugins faster with a modern build setup and zero configuration.
 
 The plugin tools consist of two packages:


### PR DESCRIPTION
Add a new section to the top of "Get started" to introduce the documentation and describe the types of plugins available. New H1 says "Grafana plugin developer's guide" instead of "Get started".