### PR TITLE
Bugfix: Enable plugins to lazy load modules

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -135,7 +135,7 @@ const config = async (env): Promise<Configuration> => {
         type: 'amd',
       },
       path: path.resolve(process.cwd(), DIST_DIR),
-      publicPath: '/',
+      publicPath: `public/plugins/${pluginJson.id}/`,
     },
 
     plugins: [


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It should solve the following issue: https://github.com/grafana/plugin-tools/issues/229

Tested for the following plugins:

- [x] OnCall
- [x] K6
- [x] ML

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@1.12.3-canary.427.81fafa5.0
  npm install @grafana/sign-plugin@1.1.1-canary.427.81fafa5.0
  # or 
  yarn add @grafana/create-plugin@1.12.3-canary.427.81fafa5.0
  yarn add @grafana/sign-plugin@1.1.1-canary.427.81fafa5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
