### PR TITLE
Adjusting dependabot dependency labels

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -12,7 +12,7 @@
     [
       "omit-commits",
       {
-        "labels": "no-changelog"
+        "labels": ["no-changelog", "github_actions"]
       }
     ],
     [

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,16 @@
 
 version: 2
 updates:
-
+  # Check for updates to GitHub Actions every month
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every month
+    schedule:      
       interval: "monthly"
     labels:
         - "github_actions"
         - "dependencies"
         - "no stalebot"
+  # Check for updates to npm dependencies every month
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,11 @@ updates:
         - "dependencies"
         - "no stalebot"
   - package-ecosystem: "npm"
-      directory: "/"
-      schedule:
-        interval: "monthly"
-      # Specify labels for npm pull requests
-      labels:
-        - "javascript"
-        - "dependencies"
-        - "no stalebot"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Specify labels for npm pull requests
+    labels:
+      - "javascript"
+      - "dependencies"
+      - "no stalebot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       # Check for updates to GitHub Actions every month
       interval: "monthly"
     labels:
-        - "github-actions"
+        - "github_actions"
         - "dependencies"
         - "no stalebot"
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,16 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"
+    labels:
+        - "github-actions"
+        - "dependencies"
+        - "no stalebot"
+  - package-ecosystem: "npm"
+      directory: "/"
+      schedule:
+        interval: "monthly"
+      # Specify labels for npm pull requests
+      labels:
+        - "javascript"
+        - "dependencies"
+        - "no stalebot"


### PR DESCRIPTION
Should theoretically control what labels are set, not sure it practically works but let's see.