### PR TITLE
<FeatureArea>: Add new flag "bundle" to sign command

### DIFF
--- a/packages/sign-plugin/src/commands/bundle.command.ts
+++ b/packages/sign-plugin/src/commands/bundle.command.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, readdirSync, copyFileSync, rmSync, readFileSync } from "fs";
+import { mkdirSync, readdirSync, copyFileSync, rmSync, readFileSync } from "fs";
 import { platform } from 'os';
 import { getPluginJson } from "../utils/pluginValidation";
 import { resolve, join } from 'path';
@@ -42,14 +42,10 @@ export const bundle = (pluginDistDir: string) => {
 
         console.log('verifying file permissions...')
         if (platform() === 'win32') { 
-            console.warn("Warning: Windows-based systems cannot update unix permissions. Please use WSL or a Unix based system to automatically handle permissions.");
+          console.warn("Warning: Windows-based systems cannot update unix permissions. You will need to manually update these in a unix environment.");
+        } else {
+          execSync(`find ${pluginId} -name '${pluginJson.executable}*' -exec chmod 0755 {} \\;`)
         }
-        const newFiles = readdirSync(pluginId);
-        newFiles.forEach(fileName => {
-            if (fileName.startsWith(pluginJson.executable)) {
-                chmodSync(`${pluginId}/${fileName}`, '0755')
-            }
-        })
 
         console.log('Zipping Bundle...')
         // plugin must be zipped inside folder named after pluginId + version

--- a/packages/sign-plugin/src/commands/bundle.command.ts
+++ b/packages/sign-plugin/src/commands/bundle.command.ts
@@ -1,0 +1,75 @@
+import { chmodSync, mkdirSync, readdirSync, copyFileSync, rmSync, readFileSync } from "fs";
+import { platform } from 'os';
+import { getPluginJson } from "../utils/pluginValidation";
+import { resolve, join } from 'path';
+import { createHash } from "crypto";
+import { execSync } from "child_process";
+
+export const zipFolder = (zipName: string, folderPath: string): void => {
+    if(!zipName.endsWith('.zip')) { zipName = `${zipName}.zip`}
+    if(platform() === 'win32') {
+        // we call powershell in case of system default being cmd
+        execSync(`powershell Compress-Archive -Path ${folderPath} -Destination ${zipName}`)
+        return;
+    }
+    execSync(`zip -r ${zipName} ${folderPath}`);
+}
+
+function copyDirectory(source: string, destination: string) {
+    mkdirSync(destination, { recursive: true });
+
+    readdirSync(source, { withFileTypes: true }).forEach((entry) => {
+        let sourcePath = join(source, entry.name);
+        let destinationPath = join(destination, entry.name);
+
+        entry.isDirectory()
+        ? copyDirectory(sourcePath, destinationPath)
+        : copyFileSync(sourcePath, destinationPath);
+    });
+}
+
+export const bundle = (pluginDistDir: string) => {
+    const pluginJson = getPluginJson(resolve(pluginDistDir, 'plugin.json'));
+    const pluginId = pluginJson.id;
+
+    try {
+        console.log('Creating Bundle Directory...')
+        // plugin files must be contained inside a dir with same name as the plugin id
+        mkdirSync(pluginId)
+
+        console.log('Copying Files to Bundle...')
+        copyDirectory(pluginDistDir, pluginId)
+
+        console.log('verifying file permissions...')
+        if (platform() === 'win32') { 
+            console.warn("Warning: Windows-based systems cannot update unix permissions. Please use WSL or a Unix based system to automatically handle permissions.");
+        }
+        const newFiles = readdirSync(pluginId);
+        newFiles.forEach(fileName => {
+            if (fileName.startsWith(pluginJson.executable)) {
+                chmodSync(`${pluginId}/${fileName}`, '0755')
+            }
+        })
+
+        console.log('Zipping Bundle...')
+        // plugin must be zipped inside folder named after pluginId + version
+        const outputFilename = `${pluginId}-${pluginJson.info.version}.zip`;
+
+        zipFolder(outputFilename, pluginId)
+
+        console.log('Cleaning Up...')
+        rmSync(pluginId, {recursive: true, force: true});
+
+        // md5 or sha1 is required for submission, log for convinience
+        const buff = readFileSync(outputFilename);
+        const md5Hash = createHash("md5").update(buff).digest("hex");
+        const sha1Hash = createHash("sha1").update(buff).digest("hex");
+
+        console.log(`Bundled Successfully - ${outputFilename}`)
+        console.log(`md5: ${md5Hash}`)
+        console.log(`sha1: ${sha1Hash}`)
+    } catch (err) {
+        console.warn('Error bundling plugin: ', err);
+        process.exitCode = 1;
+    }
+}

--- a/packages/sign-plugin/src/commands/sign.command.ts
+++ b/packages/sign-plugin/src/commands/sign.command.ts
@@ -4,13 +4,15 @@ import { existsSync } from 'fs';
 import { assertRootUrlIsValid } from '../utils/pluginValidation';
 import { buildManifest, signManifest, saveManifest } from '../utils/manifest';
 import { getVersion } from '../utils/getVersion';
+import { bundle } from './bundle.command';
 
 export const sign = async (argv: minimist.ParsedArgs) => {
   const distDir = argv.distDir ?? 'dist';
   const pluginDistDir = path.resolve(distDir);
   const signatureType: string = argv.signatureType;
   const rootUrls: string[] = argv.rootUrls?.split(',') ?? [];
-
+  const bundleDist: boolean = argv.bundle ?? false;
+  
   if (!existsSync(pluginDistDir)) {
     throw new Error(`Plugin \`${distDir}\` directory is missing. Did you build the plugin before attempting to sign?`);
   }
@@ -35,6 +37,10 @@ export const sign = async (argv: minimist.ParsedArgs) => {
     saveManifest(pluginDistDir, signedManifest);
 
     console.log('Signed successfully');
+
+    if (bundleDist) {
+      bundle(pluginDistDir);
+    }
   } catch (err) {
     console.warn(err);
     process.exitCode = 1;


### PR DESCRIPTION
**What this PR does / why we need it**:

When trying to bundle a plugin for submission, the process is manual and can be tedious; especially when making typos or forgetting a step.

This adds a new flag `--bundle` to the sign command. When running the sign command with the bundle flag, this will:

1. Copy the dist folder contents into a folder matching the plugin id (lifted from dist/plugin.json)
2. Updates the permissions of the executable files to 0755 (*nix systems only)
3. Zip that folder matching the syntax {pluginId}-{version}.zip, satisfying the submission requirements 
4. Delete the folder created in step 1
5. Calculates and logs the md5 and sha1 of the zipped folder, to make submission simple

**Special notes for your reviewer**:

Some notes:
+ This doesn't fix #411, but would be a great first-step if accepted; the next step would be to allow a flag value, e.g. `--bundle="multiple"` and then handle that case. If this approach is acceptable, then I will add that functionality as well.

+ scaffolding and zipping works on *nix and windows systems.   

+ Setting permissions works on *nix systems only. Setting permissions on windows *won't* work, even using WSL, due to how windows manages permissions.

Extra feedback request:

+ Since *nix permissions don't work on Windows and can't persist to a unix environment, should we instead throw an error and instruct the user to run the command on a unix machine instead or that the flag only works on unix machines? The only benefit to a windows user really is that the folder name/structure would be present to imitate. If so, I'll also strip out the windows-specific portions.

+ I placed this as a flag for the sign command, since the workflow is going to be sign -> bundle for the vast majority of the user workflows and the sign command already has the dist dir set. I can break this out into a fully new command though if that would be preferred.  