### PR TITLE
Docs: Refactor 'Get started' section

### DIFF
--- a/docusaurus/docs/get-started/cli-commands.md
+++ b/docusaurus/docs/get-started/cli-commands.md
@@ -1,0 +1,36 @@
+---
+id: cli-commands
+title: Key CLI commands
+description: The CLI commands you need to know for plugin development.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - create-plugin
+  - CLI
+  - command line
+  - commands
+sidebar_position: 3
+---
+
+# Key CLI commands
+
+After `create-plugin` has finished, you can run the following built-in commands in the shell:
+
+## <SyncCommand cmd="run dev" />
+
+Builds the plugin in _development mode_ and runs in _watch mode_. Rebuilds the plugin whenever you make changes to the code. You'll see build errors and lint warnings in the console.
+
+## <SyncCommand cmd="run test" />
+
+Runs the tests and watches for changes.
+
+## <SyncCommand cmd="run build" />
+
+Creates a production build of the plugin that optimizes for the best performance. Minifies the build and includes hashes in the filenames.
+
+<h2>
+  <code>mage -v</code>
+</h2>
+
+Builds backend plugin binaries for Linux, Windows and Darwin.

--- a/docusaurus/docs/get-started/folder-structure.md
+++ b/docusaurus/docs/get-started/folder-structure.md
@@ -10,8 +10,9 @@ keywords:
   - folders
 sidebar_position: 2
 ---
+# Folder structure
 
-After you install the `create-plugin` tool and have answered the prompts, your project should look similar to this:
+After you install the [`create-plugin` tool](../get-started/get-started.mdx) and have answered the prompts, there should now be a folder structure like so:
 
 ```
 myorg-myplugin-datasource/

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -22,6 +22,10 @@ The plugin tools consist of two packages:
 - `create-plugin`: A CLI to scaffold new plugins or migrate plugins created with `@grafana/toolkit`.
 - `sign-plugin`: A CLI to sign plugins for distribution.
 
+## Before you begin
+
+Ensure that your system, tools, and development environment are adequate for plugin development. For our recommendations, refer to [Set up development environment](./set-up-development-environment.mdx).
+
 ## Quick Start
 
 To scaffold your plugin, follow these steps:
@@ -54,36 +58,6 @@ To scaffold your plugin, follow these steps:
 
   :::
 
-### Before you begin
-
-Make sure you are using supported a supported OS, Grafana version, and tooling.
-
-#### Supported operating systems
-
-Grafana plugin tools work with the following operating systems:
-
-- Linux
-- macOS
-- Windows 10+ with WSL (Windows Subsystem for Linux)
-
-#### Supported Grafana version
-
-We generally recommend that you build for a version of Grafana later than v9.0. For more information about requirements and dependencies when developing with Grafana, see the [Grafana developer's guide](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md).
-
-#### Recommended tooling
-
-You'll need to have the following tools set up:
-
-- Go ([Version](https://github.com/grafana/plugin-tools/blob/main/packages/create-plugin/templates/backend/go.mod#L3))
-- [Mage](https://magefile.org/)
-- [LTS](https://nodejs.dev/en/about/releases/) version of Node.js
-- Optionally [Yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or [PNPM](https://pnpm.io/installation)
-- [Docker](https://docs.docker.com/get-docker/)
-
-#### Choose a package manager
-
-When you first run `@grafana/create-plugin`, choose your package manager: `npm`, `pnpm`, or `yarn`.
-
 ## Output
 
 Run the above command to create a directory called `<orgName>-<pluginName>-<pluginType>` inside the current directory. This directory contains the initial project structure to kickstart your plugin development.
@@ -94,57 +68,9 @@ The directory name `<orgName>-<pluginName>-<pluginType>` is based on the answers
 
 :::
 
-Depending on the answers you gave to the prompts, there should now be a structure like:
+Refer to [Folder structure](./folder-structure.md) for a description of what you should expect to see.
 
-```
-<orgName>-<pluginName>-<pluginType>
-├── .config/
-├── .eslintrc
-├── .github
-│   └── workflows
-├── .gitignore
-├── .nvmrc
-├── .prettierrc.js
-├── CHANGELOG.md
-├── LICENSE
-├── Magefile.go
-├── README.md
-├── cypress
-│   └── integration
-├── docker-compose.yaml
-├── go.mod
-├── go.sum
-├── jest-setup.js
-├── jest.config.js
-├── node_modules
-├── package.json
-├── pkg
-│   ├── main.go
-│   └── plugin
-├── src
-│   ├── README.md
-│   ├── components
-│   ├── datasource.ts
-│   ├── img
-│   ├── module.ts
-│   ├── plugin.json
-│   └── types.ts
-└── tsconfig.json
-```
-
-When you've finished installing the tools, open the plugin folder:
-
-<CodeSnippets
-  paths={[
-    'createplugin-install.npm.shell.md',
-    'createplugin-install.pnpm.shell.md',
-    'createplugin-install.yarn.shell.md',
-  ]}
-  groupId="package-manager"
-  queryString="current-package-manager"
-/>
-
-## Create-plugin prompts reference
+## Prompts
 
 When running the `create-plugin` command, the following prompts appear:
 
@@ -189,25 +115,3 @@ Add [Github workflows](/create-a-plugin/develop-a-plugin/set-up-github-workflows
 ### Do you want to add a Github workflow to automatically check Grafana API compatibility on PRs?
 
 Add a [Github workflow](/create-a-plugin/develop-a-plugin/set-up-github-workflows#the-compatibility-check-is-compatibleyml) to regularly check that your plugin is compatible with the latest version of Grafana.
-
-## Key CLI commands
-
-After `create-plugin` has finished, you can run built-in commands in the shell:
-
-### <SyncCommand cmd="run dev" />
-
-Builds the plugin in _development mode_ and runs in _watch mode_. Rebuilds the plugin whenever you make changes to the code. You'll see build errors and lint warnings in the console.
-
-### <SyncCommand cmd="run test" />
-
-Runs the tests and watches for changes.
-
-### <SyncCommand cmd="run build" />
-
-Creates a production build of the plugin that optimizes for the best performance. Minifies the build and includes hashes in the filenames.
-
-<h3>
-  <code>mage -v</code>
-</h3>
-
-Builds backend plugin binaries for Linux, Windows and Darwin.

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -8,26 +8,58 @@ description: Set up your development environment with Docker for Grafana plugin 
   - create-plugin
   - Docker
   - setup 
-sidebar_position: 3
+sidebar_position: 1
 ---
+
+# Set up development environment
+
+We have chosen to use Docker for plugin development because it simplifies the process of creating, deploying, and running applications. It allows you to create consistent and isolated environments for your plugin. This makes it easy to manage dependencies and ensure that the plugin runs the same way across different machines.
+
+With the `create-plugin` tool, the Docker container is configured with the necessary variables to allow easy access to Grafana and to load plugins without the need for them to be signed. The plugin tool also adds a live reload feature that allows you to make your frontend code changes to trigger refreshes in the browser.
 
 import DockerNPM from '@snippets/docker-grafana-version.npm.md';
 import DockerPNPM from '@snippets/docker-grafana-version.pnpm.md';
 import DockerYarn from '@snippets/docker-grafana-version.yarn.md';
 
-The `create-plugin` tool includes a development environment featuring [Docker](https://docs.docker.com/get-docker/). It allows you to start an instance of the Grafana application for plugin developers against which you can code.
+## Before you begin
+
+Make sure you are using supported a supported OS, Grafana version, and tooling.
+
+### Supported operating systems
+
+Grafana plugin tools work with the following operating systems:
+
+- Linux
+- macOS
+- Windows 10+ with WSL (Windows Subsystem for Linux)
+
+### Supported Grafana version
+
+We generally recommend that you build for a version of Grafana later than v9.0. For more information about requirements and dependencies when developing with Grafana, see the [Grafana developer's guide](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md).
+
+### Recommended tooling
+
+You'll need to have the following tools set up:
+
+- Go ([Version](https://github.com/grafana/plugin-tools/blob/main/packages/create-plugin/templates/backend/go.mod#L3))
+- [Mage](https://magefile.org/)
+- [LTS](https://nodejs.dev/en/about/releases/) version of Node.js
+- Optionally [Yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or [PNPM](https://pnpm.io/installation)
+- [Docker](https://docs.docker.com/get-docker/)
+
+### Choose a package manager
+
+When you first run `@grafana/create-plugin`, choose your package manager: `npm`, `pnpm`, or `yarn`.
+
+## Set up Docker environment
+
+The [`create-plugin` tool](../get-started/get-started.mdx) includes a development environment featuring [Docker](https://docs.docker.com/get-docker/). It allows you to start an instance of the Grafana application for plugin developers against which you can code.
 
 :::info
 
-It's not necessary to [sign a plugin](../publish-a-plugin/sign-a-plugin.md) during development. The that is scaffolded with `@grafana/create-plugin` will load the plugin without a signature.
+It's not necessary to [sign a plugin](../publish-a-plugin/sign-a-plugin.md) during development. The development environment that is scaffolded with `@grafana/create-plugin` will load the plugin without a signature.
 
 :::
-
-## Why use the Docker environment
-
-We have chosen to use Docker because it simplifies the process of creating, deploying, and running applications. It allows you to create consistent and isolated environments for your plugin. This makes it easy to manage dependencies and ensure that the plugin runs the same way across different machines.
-
-With the `create-plugin` tool, the Docker container is configured with the necessary variables to allow easy access to Grafana and to load plugins without the need for them to be signed. The plugin tool also adds a live reload feature that allows you to make your frontend code changes to trigger refreshes in the browser.
 
 ## Get started with Docker
 


### PR DESCRIPTION
Refactor 'Get started' section for usability, reducing redundancy. Highlights:
- Tighten up 'Get started' main page to make it more breezy
- Move CLI reference to its own page
- Remove duplication of Folder Structure
- Move prerequisites to Development Environment topic

Fixes https://github.com/grafana/plugin-tools/issues/468