### PR TITLE
Docs: fix backend developer resources link

### DIFF
--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -183,7 +183,7 @@ App and data source plugins can have a backend component written in Go. Backend 
 - Connect to non-HTTP services to which a browser normally can’t connect. For example, SQL database servers.
 - Keep state between users. For example, query caching for data sources.
 - Use custom authentication methods and/or authorization checks that aren’t supported in Grafana.
-- Use a custom data source request proxy. To learn more, refer to [Backend developer resources](./introduction/backend-plugins#resources).
+- Use a custom data source request proxy. To learn more, refer to [Backend developer resources](/introduction/backend-plugins#resources).
 
 ### Do you want to add Github CI and Release workflows?
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
       "eslint --ext .js,.tsx,.ts --cache --fix",
       "prettier --write"
     ],
-    "*.{css,md,mdx,json}": "prettier --write"
+    "*.{css,md,json}": "prettier --write"
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The link from get-started to backend developer resources appears to randomly break. I believe it's caused by the period at the start of the link.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
