### PR TITLE
Docs: Refactor 'get started' guide, refactor 'references', add several index pages

### DIFF
--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/index.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/index.md
@@ -1,0 +1,15 @@
+---
+id: develop-plugin
+title: How to develop a Grafana plugin
+description: How-to guides for Grafana plugin development.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - develop
+  - development
+---
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/add-authentication-for-data-source-plugins.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/add-authentication-for-data-source-plugins.md
@@ -32,11 +32,11 @@ Configure your data source plugin to authenticate against a third-party API in o
 
 ## Encrypt data source configuration
 
-Data source plugins have two ways of storing custom configuration: `jsonData` and `secureJsonData`. 
+Data source plugins have two ways of storing custom configuration: `jsonData` and `secureJsonData`.
 
 Users with the Viewer role can access data source configuration such as the contents of `jsonData` in cleartext. If you've enabled anonymous access, anyone who can access Grafana in their browser can see the contents of `jsonData`.
 
-Users of [Grafana Enterprise](https://grafana.com/products/enterprise/grafana/) can restrict access to data sources to specific users and teams. For more information, refer to [Data source permissions](https://grafana.com/docs/grafana/latest/enterprise/datasource_permissions). You can see the settings that the current user has access to by entering `window.grafanaBootData` in the developer console of your browser. 
+Users of [Grafana Enterprise](https://grafana.com/products/enterprise/grafana/) can restrict access to data sources to specific users and teams. For more information, refer to [Data source permissions](https://grafana.com/docs/grafana/latest/enterprise/datasource_permissions). You can see the settings that the current user has access to by entering `window.grafanaBootData` in the developer console of your browser.
 
 :::caution
 
@@ -135,7 +135,7 @@ Be sure not to confuse the data source proxy with the [auth proxy](https://grafa
 
 ### Add a proxy route to your plugin
 
-To forward requests through the Grafana proxy, you need to configure one or more _proxy routes_. A proxy route is a template for any outgoing request that is handled by the proxy. You can configure proxy routes in the [plugin.json](../../metadata.md) file.
+To forward requests through the Grafana proxy, you need to configure one or more _proxy routes_. A proxy route is a template for any outgoing request that is handled by the proxy. You can configure proxy routes in the [plugin.json](../../reference/metadata.md) file.
 
 1. Add the route to `plugin.json`:
 
@@ -148,11 +148,11 @@ To forward requests through the Grafana proxy, you need to configure one or more
    ]
    ```
 
-  :::note
+:::note
 
-  You need to restart the Grafana server every time you make a change to your `plugin.json` file.
+You need to restart the Grafana server every time you make a change to your `plugin.json` file.
 
-  :::
+:::
 
 1. In the `DataSource`, extract the proxy URL from `instanceSettings` to a class property called `url`:
 

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/enable-annotations.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/enable-annotations.md
@@ -17,7 +17,7 @@ You can add support to your plugin for annotations that will insert information 
 
 To enable annotations, simply add two lines of code to your plugin. Grafana uses your default query editor for editing annotation queries.
 
-1. Add `"annotations": true` to the [plugin.json](../../metadata.md) file to let Grafana know that your plugin supports annotations.
+1. Add `"annotations": true` to the [plugin.json](../../reference/metadata.md) file to let Grafana know that your plugin supports annotations.
 
    **In `plugin.json`:**
 

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/index.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/index.md
@@ -1,0 +1,16 @@
+---
+id: extend-plugin
+title: How to extend a Grafana plugin
+description: How-to guides for enhancing Grafana plugin development.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - develop
+  - development
+  - extension
+---
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docusaurus/docs/create-a-plugin/index.md
+++ b/docusaurus/docs/create-a-plugin/index.md
@@ -1,0 +1,15 @@
+---
+id: create-plugin
+title: Develop and extend a Grafana plugin
+description: How-to guides for Grafana plugin development.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - develop
+  - development
+---
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docusaurus/docs/get-started/folder-structure.md
+++ b/docusaurus/docs/get-started/folder-structure.md
@@ -11,7 +11,7 @@ keywords:
 sidebar_position: 2
 ---
 
-After you install the `create-plugin` tool and have answered the prompts, your project should look similar to this:
+After you [install the `create-plugin` tool](./get-started.mdx#step-1-scaffold-a-new-plugin) and have answered the prompts, your project should look similar to this:
 
 ```
 myorg-myplugin-datasource/
@@ -53,17 +53,17 @@ myorg-myplugin-datasource/
 
 You must have files with these exact filenames:
 
-| Filename            | Description                                                                          |
-| ------------------- | ------------------------------------------------------------------------------------ |
+| Filename            | Description                                                                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
 | `./go.mod`          | Go modules dependencies. Refer to [Golang documentation](https://golang.org/cmd/go/#hdr-The_go_mod_file) |
-| `./src/plugin.json` | A JSON file describing the plugin.                                                    |
-| `./src/module.ts`   | The entry point of the frontend plugin.                                             |
-| `./pkg/main.go`     | The entry point of the backend plugin.                                                |
+| `./src/plugin.json` | A JSON file describing the plugin.                                                                       |
+| `./src/module.ts`   | The entry point of the frontend plugin.                                                                  |
+| `./pkg/main.go`     | The entry point of the backend plugin.                                                                   |
 
 ## Optional files
 
 These files in your project are optional:
 
-| Filename        | Description                                                                                                                                |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Filename        | Description                                                                                                            |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `./Magefile.go` | We strongly recommend using mage build files so that you can use the build targets provided by the backend plugin SDK. |

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -18,6 +18,26 @@ import InstallNPM from '@snippets/createplugin-install.npm.md';
 import InstallPNPM from '@snippets/createplugin-install.pnpm.md';
 import InstallYarn from '@snippets/createplugin-install.yarn.md';
 
+# Get started
+
+Welcome to the world of Grafana plugin creation, where you can enhance Grafana's foundational features. In this guide, you'll learn how to get started by scaffolding a plugin, running it in an efficient development environment, and using its basic features.
+
+## Why create a Grafana plugin?
+
+Grafana plugin development allows you to create many different types of user experiences using [SDK-supported](/introduction/grafana-plugin-sdk-for-go) features. For example, you can make:
+
+- **Data-source plugins** - connections to a new database or other source of data
+- **App plugins** - integrated out-of-the-box experiences
+- **Panel plugins** - new ways of visualizing data
+
+:::tip
+
+If this is your first time creating a plugin, we recommand that you familiarize yourself with the fundamentals of plugin types, backend plugins, data frames, and other key concepts. For more, refer to [Introduction to Grafana plugin development](/introduction/).
+
+:::
+
+## Use plugin tools to develop your plugins faster
+
 Grafana's plugin tools offer an officially supported way to extend Grafana's core functionality. We have designed these tools to help you to develop your plugins faster with a modern build setup and zero configuration.
 
 The plugin tools consist of two packages:
@@ -25,43 +45,17 @@ The plugin tools consist of two packages:
 - `create-plugin`: A CLI to scaffold new plugins or migrate plugins created with `@grafana/toolkit`.
 - `sign-plugin`: A CLI to sign plugins for distribution.
 
-## Quick Start
+  :::info
 
-To scaffold your plugin, follow these steps:
-
-1. Run the following command:
-
-  <CodeSnippets
-    snippets={[
-      { component: ScaffoldNPM, label: 'npm' },
-      { component: ScaffoldPNPM, label: 'pnpm' },
-      { component: ScaffoldYarn, label: 'yarn' },
-    ]}
-    groupId="package-manager"
-    queryString="current-package-manager"
-  />
-
-1. When prompted, enter answers to the given questions. For example:
-
-  ```
-  ? What is going to be the name of your plugin?: mongodb
-  ? What is the organization name of your plugin?: grafana
-  ? What type of plugin would you like?: datasource
-  ```
-
-  If you enter those values for name, organization, and plugin type, then the directory and plugin ID will be named `grafana-mongodb-datasource`.
-
-  :::note
-
-  If you have previously built a plugin with `@grafana/toolkit`, you can use our plugin tools to simplify migration. For more information, refer to [Migrate from toolkit](/migration-guides/migrate-from-toolkit.mdx).
+  If you have previously built a plugin with `@grafana/toolkit`, you can use our plugin tools to make the jump to our newest tools. For more information, refer to [Migrate from toolkit](/migration-guides/migrate-from-toolkit.mdx).
 
   :::
 
-### Before you begin
+## Before you begin
 
 Make sure you are using supported a supported OS, Grafana version, and tooling.
 
-#### Supported operating systems
+### Supported operating systems
 
 Grafana plugin tools work with the following operating systems:
 
@@ -69,35 +63,59 @@ Grafana plugin tools work with the following operating systems:
 - macOS
 - Windows 10+ with WSL (Windows Subsystem for Linux)
 
-#### Supported Grafana version
+### Supported Grafana version
 
 We generally recommend that you build for a version of Grafana later than v9.0. For more information about requirements and dependencies when developing with Grafana, see the [Grafana developer's guide](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md).
 
-#### Recommended tooling
+### Recommended tooling
 
 You'll need to have the following tools set up:
 
 - Go ([Version](https://github.com/grafana/plugin-tools/blob/main/packages/create-plugin/templates/backend/go.mod#L3))
 - [Mage](https://magefile.org/)
 - [LTS](https://nodejs.dev/en/about/releases/) version of Node.js
-- Optionally [Yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or [PNPM](https://pnpm.io/installation)
 - [Docker](https://docs.docker.com/get-docker/)
+- Optionally, [Yarn 1](https://classic.yarnpkg.com/lang/en/docs/install) or [PNPM](https://pnpm.io/installation)
 
-#### Choose a package manager
+#### Supported package managers
 
 When you first run `@grafana/create-plugin`, choose your package manager: `npm`, `pnpm`, or `yarn`.
 
-## Output
+## Step 1: Scaffold a new plugin
 
-Run the above command to create a directory called `<orgName>-<pluginName>-<pluginType>` inside the current directory. This directory contains the initial project structure to kickstart your plugin development.
+Scaffold your plugin with a single command! Run the following command and answer the prompts:
 
-:::info
+{' '}
+<CodeSnippets
+  snippets={[
+    { component: ScaffoldNPM, label: 'npm' },
+    { component: ScaffoldPNPM, label: 'pnpm' },
+    { component: ScaffoldYarn, label: 'yarn' },
+  ]}
+  groupId="package-manager"
+  queryString="current-package-manager"
+/>
 
-The directory name `<orgName>-<pluginName>-<pluginType>` is based on the answers you gave to the prompts. Use the name of the generated folder when prompted.
+For help with the prompts, refer to the [Prompts reference](/reference/prompt-cli-reference#prompts).
 
-:::
+## Step 2: Open the generated folder structure
 
-Depending on the answers you gave to the prompts, there should now be a structure like:
+When you've finished installing the tools, open the plugin folder:
+
+{' '}
+<CodeSnippets
+  snippets={[
+    { component: InstallNPM, label: 'npm' },
+    { component: InstallPNPM, label: 'pnpm' },
+    { component: InstallYarn, label: 'yarn' },
+  ]}
+  groupId="package-manager"
+  queryString="current-package-manager"
+/>
+
+The directory name `<orgName>-<pluginName>-<pluginType>` is based on the answers you gave to the prompts. Use the name of the generated folder when prompted. This directory contains the initial project structure to kickstart your plugin development.
+
+The file structure should look like this:
 
 ```
 <orgName>-<pluginName>-<pluginType>
@@ -135,67 +153,15 @@ Depending on the answers you gave to the prompts, there should now be a structur
 └── tsconfig.json
 ```
 
-When you've finished installing the tools, open the plugin folder:
+For more information about these files, refer to [Folder structure](get-started/folder-structure/).
 
-<CodeSnippets
-  snippets={[
-    { component: InstallNPM, label: 'npm' },
-    { component: InstallPNPM, label: 'pnpm' },
-    { component: InstallYarn, label: 'yarn' },
-  ]}
-  groupId="package-manager"
-  queryString="current-package-manager"
-/>
+## Step 3: Run your plugin in Docker
 
-## Create-plugin prompts reference
+With the `create-plugin` tool, you can use a Docker container to simplify the configuration, loading, and development processes. For more information, refer to [Set up development environment](get-started/set-up-development-environment/).
 
-When running the `create-plugin` command, the following prompts appear:
+## Step 4: Use CLI commands
 
-### What is the name of your plugin?
-
-Enter the name of your plugin. This helps to identify its purpose.
-
-### What is the organization name of your plugin?
-
-Enter the name of your organization. Grafana plugins require an organization name (normally your [Grafana account](https://grafana.com/signup/) username) to help uniquely identify your plugin.
-
-### How would you describe your plugin?
-
-Give your plugin a description. This will help users more easily understand what it does when the plugin is distributed.
-
-### What type of plugin would you like?
-
-Select from the following choices:
-
-- **app**: Create a custom out-of-the-box monitoring experience.
-- **datasource**: Add support for new databases or external APIs.
-- **panel**: Add new visualizations to dashboards.
-- **scenesapp**: Create scenes applications or scenes plugins (that is, dashboard-like experiences in app plugins).
-
-To learn more about the types of plugins, refer to the [plugin management guidelines](https://grafana.com/docs/grafana/latest/administration/plugin-management/).
-To learn more about scenes, refer to the [Scenes documentation](https://grafana.com/developers/scenes).
-
-### Do you want a backend part of your plugin?
-
-App and data source plugins can have a backend component written in Go. Backend plugins offer powerful features such as:
-
-- Enable [Grafana Alerting](https://grafana.com/docs/grafana/latest/alerting/) for data sources.
-- Connect to non-HTTP services to which a browser normally can’t connect. For example, SQL database servers.
-- Keep state between users. For example, query caching for data sources.
-- Use custom authentication methods and/or authorization checks that aren’t supported in Grafana.
-- Use a custom data source request proxy. To learn more, refer to [Backend developer resources](./introduction/backend-plugins#resources).
-
-### Do you want to add Github CI and Release workflows?
-
-Add [Github workflows](/create-a-plugin/develop-a-plugin/set-up-github-workflows) to your development cycle to help catch issues early or release your plugin to the community.
-
-### Do you want to add a Github workflow to automatically check Grafana API compatibility on PRs?
-
-Add a [Github workflow](/create-a-plugin/develop-a-plugin/set-up-github-workflows#the-compatibility-check-is-compatibleyml) to regularly check that your plugin is compatible with the latest version of Grafana.
-
-## Key CLI commands
-
-After `create-plugin` has finished, you can run built-in commands in the shell:
+After you have installed `create-plugin`, you can run built-in commands in the shell. For example:
 
 ### <SyncCommand cmd="run dev" />
 
@@ -214,3 +180,15 @@ Creates a production build of the plugin that optimizes for the best performance
 </h3>
 
 Builds backend plugin binaries for Linux, Windows and Darwin.
+
+:::info
+
+For a complete list of available CLI commands, refer to [CLI commands](/reference/prompt-cli-reference#cli-commands).
+
+:::
+
+## Next steps
+
+- Start your plugin journey with one of our [plugin development tutorials](/tutorials/).
+- Learn how to [develop](/create-a-plugin/develop-a-plugin/) a plugin and [extend](/create-a-plugin/extend-a-plugin/) its functionality.
+- [Package](/publish-a-plugin/package-a-plugin), [sign](/publish-a-plugin/sign-a-plugin), and [publish](/publish-a-plugin/publish-a-plugin) your new plugin.

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -115,8 +115,6 @@ For help with the prompts, refer to the [Prompts reference](/reference/prompt-cl
 
 When you've finished installing the tools, open the plugin folder:
 
-{' '}
-
 <CodeSnippets
   snippets={[
     { component: InstallNPM, label: 'npm' },

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -22,6 +22,20 @@ import InstallYarn from '@snippets/createplugin-install.yarn.md';
 
 Welcome to the world of Grafana plugin creation, where you can enhance Grafana's foundational features. In this guide, you'll learn how to get started by scaffolding a plugin, running it in an efficient development environment, and using its basic features.
 
+## Quick Start
+
+Scaffold a new plugin with a single command! Run the following and answer the prompts:
+
+<CodeSnippets
+  snippets={[
+    { component: ScaffoldNPM, label: 'npm' },
+    { component: ScaffoldPNPM, label: 'pnpm' },
+    { component: ScaffoldYarn, label: 'yarn' },
+  ]}
+  groupId="package-manager"
+  queryString="current-package-manager"
+/>
+
 ## Why create a Grafana plugin?
 
 Grafana plugin development allows you to create many different types of user experiences using [SDK-supported](/introduction/grafana-plugin-sdk-for-go) features. For example, you can make:
@@ -81,11 +95,10 @@ You'll need to have the following tools set up:
 
 When you first run `@grafana/create-plugin`, choose your package manager: `npm`, `pnpm`, or `yarn`.
 
-## Step 1: Scaffold a new plugin
+## Step 1: Install the `create-plugin` tool
 
-Scaffold your plugin with a single command! Run the following command and answer the prompts:
+Run the following command and answer the prompts:
 
-{' '}
 <CodeSnippets
   snippets={[
     { component: ScaffoldNPM, label: 'npm' },
@@ -103,6 +116,7 @@ For help with the prompts, refer to the [Prompts reference](/reference/prompt-cl
 When you've finished installing the tools, open the plugin folder:
 
 {' '}
+
 <CodeSnippets
   snippets={[
     { component: InstallNPM, label: 'npm' },

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -7,7 +7,7 @@ description: Set up your development environment with Docker for Grafana plugin 
   - plugin
   - create-plugin
   - Docker
-  - setup 
+  - setup
 sidebar_position: 3
 ---
 
@@ -15,11 +15,11 @@ import DockerNPM from '@snippets/docker-grafana-version.npm.md';
 import DockerPNPM from '@snippets/docker-grafana-version.pnpm.md';
 import DockerYarn from '@snippets/docker-grafana-version.yarn.md';
 
-The `create-plugin` tool includes a development environment featuring [Docker](https://docs.docker.com/get-docker/). It allows you to start an instance of the Grafana application for plugin developers against which you can code.
+The `create-plugin` tool](./get-started.mdx#use-plugin-tools-to-develop-your-plugins-faster) includes a development environment featuring [Docker](https://docs.docker.com/get-docker/). It allows you to start an instance of the Grafana application for plugin developers against which you can code.
 
 :::info
 
-It's not necessary to [sign a plugin](../publish-a-plugin/sign-a-plugin.md) during development. The that is scaffolded with `@grafana/create-plugin` will load the plugin without a signature.
+It's not necessary to [sign a plugin](../publish-a-plugin/sign-a-plugin.md) during development. Grafana will load the plugin that is scaffolded with `@grafana/create-plugin` without a signature.
 
 :::
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v7.x-v8.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v7.x-v8.x.md
@@ -199,7 +199,7 @@ import { cx, css } from '@emotion/css';
 
 ## Update needed for app plugins using dashboards
 
-To make side navigation work properly - app plugins targeting Grafana `8.+` and integrating into the side menu via [addToNav](../../metadata.md#properties-4) property need to adjust their `plugin.json` and all dashboard json files to have a matching `uid`.
+To make side navigation work properly - app plugins targeting Grafana `8.+` and integrating into the side menu via [addToNav](../../reference/metadata.md#properties-4) property need to adjust their `plugin.json` and all dashboard json files to have a matching `uid`.
 
 **`plugin.json`**
 

--- a/docusaurus/docs/reference/_category_.json
+++ b/docusaurus/docs/reference/_category_.json
@@ -1,6 +1,6 @@
 {
   "position": 100,
-  "label": "Reference",
+  "label": "References",
   "collapsible": true,
   "collapsed": true
 }

--- a/docusaurus/docs/reference/_category_.json
+++ b/docusaurus/docs/reference/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 100,
+  "label": "Reference",
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docusaurus/docs/reference/index.md
+++ b/docusaurus/docs/reference/index.md
@@ -1,0 +1,20 @@
+---
+id: references
+title: References
+description: References for Grafana plugin development.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - develop
+  - development
+  - reference
+  - references
+  - metadata
+  - CLI
+  - prompts
+---
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docusaurus/docs/reference/metadata.md
+++ b/docusaurus/docs/reference/metadata.md
@@ -1,6 +1,6 @@
 ---
 id: reference-plugin-json
-title: Reference (plugin.json)
+title: Plugin.json
 description: Reference for the Grafana plugin.json metadata file.
 keywords:
   - grafana
@@ -9,10 +9,10 @@ keywords:
   - plugin.json
   - API reference
   - API
-sidebar_position: 70
+sidebar_position: 10
 ---
 
-# Reference (plugin.json)
+# Plugin.json metadata reference
 
 The `plugin.json` file is required for all plugins. When Grafana starts, it scans the plugin folders and mounts every folder that contains a plugin.json file unless the folder contains a subfolder named dist. In that case, Grafana mounts the dist folder instead.
 
@@ -38,7 +38,7 @@ The `plugin.json` file is required for all plugins. When Grafana starts, it scan
 | `metrics`            | boolean                       | No       | For data source plugins, if the plugin supports metric queries. Used to enable the plugin in the panel editor.                                                                                                                                                                                                                                                                                          |
 | `preload`            | boolean                       | No       | Initialize plugin on startup. By default, the plugin initializes on first use. Useful for app plugins that should load without user interaction.                                                                                                                                                                                                                                                        |
 | `queryOptions`       | [object](#queryoptions)       | No       | For data source plugins. There is a query options section in the plugin's query editor and these options can be turned on if needed.                                                                                                                                                                                                                                                                    |
-| `routes`             | [object](#routes)[]           | No       | For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](../docs/create-a-plugin/extend-a-plugin/add-authentication-for-data-source-plugins.md).                                                   |
+| `routes`             | [object](#routes)[]           | No       | For data source plugins. Proxy routes used for plugin authentication and adding headers to HTTP requests made by the plugin. For more information, refer to [Authentication for data source plugins](../docs/create-a-plugin/extend-a-plugin/add-authentication-for-data-source-plugins.md).                                                                                                            |
 | `skipDataQuery`      | boolean                       | No       | For panel plugins. Hides the query editor.                                                                                                                                                                                                                                                                                                                                                              |
 | `state`              | string                        | No       | Marks a plugin as a pre-release. Possible values are: `alpha`, `beta`.                                                                                                                                                                                                                                                                                                                                  |
 | `streaming`          | boolean                       | No       | For data source plugins, if the plugin supports streaming. Used in Explore to start live streaming.                                                                                                                                                                                                                                                                                                     |

--- a/docusaurus/docs/reference/prompts-cli.md
+++ b/docusaurus/docs/reference/prompts-cli.md
@@ -1,8 +1,7 @@
 ---
 id: prompt-cli-reference
 title: Prompts and CLI
-sidebar_position: 2
-description: Reference for plugin tools' prompts and CLI commands.
+description: Reference for prompts and CLI commands.
 keywords:
   - grafana
   - plugins
@@ -10,11 +9,12 @@ keywords:
   - create-plugin
   - prompts
   - CLI
+sidebar_position: 20
 ---
 
-# Plugin tools' prompts and CLI commands
+# Plugin tools' prompts and CLI commands reference
 
-Refer to this document for a list of prompts and CLI commands available through the [create-plugin](../get-started/get-started.mdx) tool.
+Refer to this document for a list of prompts and CLI commands available through the [create-plugin](../get-started/get-started.mdx#quick-start) tool.
 
 ## Prompts
 
@@ -52,7 +52,7 @@ App and data source plugins can have a backend component written in Go. Backend 
 - Connect to non-HTTP services to which a browser normally can’t connect. For example, SQL database servers.
 - Keep state between users. For example, query caching for data sources.
 - Use custom authentication methods and/or authorization checks that aren’t supported in Grafana.
-- Use a custom data source request proxy. To learn more, refer to [Backend developer resources](./introduction/backend-plugins#resources).
+- Use a custom data source request proxy. To learn more, refer to [Backend developer resources](../introduction/backend.md#resources).
 
 ### Do you want to add Github CI and Release workflows?
 
@@ -64,46 +64,46 @@ Add a [Github workflow](/create-a-plugin/develop-a-plugin/set-up-github-workflow
 
 ## CLI commands
 
-### <SyncCommand cmd="run build" />
+### `run build`
 
 Compiles and bundles the project using Webpack in production mode.
 
-### <SyncCommand cmd="run dev" />
+### `run dev`
 
 Runs Webpack in watch mode for development, continually monitoring for changes.
 
-### <SyncCommand cmd="run e2e" />
+### `run e2e`
 
 Runs Grafana end-to-end tests using Cypress.
 
-### <SyncCommand cmd="run e2e:update" />
+### `run e2e:update`
 
 Runs Grafana end-to-end tests and tests any test screenshots, using Cypress.
 
-### <SyncCommand cmd="run lint" />
+### `run lint`
 
 Lints the frontend codebase using ESLint with the `.gitignore` file to ignore certain files. Results are cached locally to speed up future linting tasks.
 
-### <SyncCommand cmd="run lint:fix" />
+### `run lint:fix`
 
 Lints the frontend codebase using ESLint and automatically fixes detected issues.
 
-### <SyncCommand cmd="run typecheck" />
+### `run typecheck`
 
 Performs a type-checking process on the frontend code using TypeScript.
 
-## <SyncCommand cmd="run server" />
+### `run server`
 
 Launches the https://grafana.com/developers/plugin-tools/get-started/set-up-development-environment using Docker.
 
-## <SyncCommand cmd="run sign" />
+### `run sign`
 
 Signs the Grafana plugin using the latest version of `@grafana/sign-plugin`.
 
-### <SyncCommand cmd="run test" />
+### `run test`
 
 Executes frontend tests, running only the tests that have changed, and enables a watch mode for ongoing testing.
 
-### <SyncCommand cmd="run test:ci" />
+### `run test:ci`
 
 Runs frontend tests for CI, ensuring it passes even with no tests, and utilizes a maximum of four workers for parallel execution.

--- a/docusaurus/docs/reference/prompts-cli.md
+++ b/docusaurus/docs/reference/prompts-cli.md
@@ -1,0 +1,109 @@
+---
+id: prompt-cli-reference
+title: Prompts and CLI
+sidebar_position: 2
+description: Reference for plugin tools' prompts and CLI commands.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - create-plugin
+  - prompts
+  - CLI
+---
+
+# Plugin tools' prompts and CLI commands
+
+Refer to this document for a list of prompts and CLI commands available through the [create-plugin](../get-started/get-started.mdx) tool.
+
+## Prompts
+
+When running the `create-plugin` command, the following prompts appear:
+
+### What is the name of your plugin?
+
+Enter the name of your plugin. This helps to identify its purpose.
+
+### What is the organization name of your plugin?
+
+Enter the name of your organization. Grafana plugins require an organization name (normally your [Grafana account](https://grafana.com/signup/) username) to help uniquely identify your plugin.
+
+### How would you describe your plugin?
+
+Give your plugin a description. This will help users more easily understand what it does when the plugin is distributed.
+
+### What type of plugin would you like?
+
+Select from the following choices:
+
+- **app**: Create a custom out-of-the-box monitoring experience.
+- **datasource**: Add support for new databases or external APIs.
+- **panel**: Add new visualizations to dashboards.
+- **scenesapp**: Create scenes applications or scenes plugins (that is, dashboard-like experiences in app plugins).
+
+To learn more about the types of plugins, refer to the [plugin management guidelines](https://grafana.com/docs/grafana/latest/administration/plugin-management/).
+To learn more about scenes, refer to the [Scenes documentation](https://grafana.com/developers/scenes).
+
+### Do you want a backend part of your plugin?
+
+App and data source plugins can have a backend component written in Go. Backend plugins offer powerful features such as:
+
+- Enable [Grafana Alerting](https://grafana.com/docs/grafana/latest/alerting/) for data sources.
+- Connect to non-HTTP services to which a browser normally can’t connect. For example, SQL database servers.
+- Keep state between users. For example, query caching for data sources.
+- Use custom authentication methods and/or authorization checks that aren’t supported in Grafana.
+- Use a custom data source request proxy. To learn more, refer to [Backend developer resources](./introduction/backend-plugins#resources).
+
+### Do you want to add Github CI and Release workflows?
+
+Add [Github workflows](/create-a-plugin/develop-a-plugin/set-up-github-workflows) to your development cycle to help catch issues early or release your plugin to the community.
+
+### Do you want to add a Github workflow to automatically check Grafana API compatibility on PRs?
+
+Add a [Github workflow](/create-a-plugin/develop-a-plugin/set-up-github-workflows#the-compatibility-check-is-compatibleyml) to regularly check that your plugin is compatible with the latest version of Grafana.
+
+## CLI commands
+
+### <SyncCommand cmd="run build" />
+
+Compiles and bundles the project using Webpack in production mode.
+
+### <SyncCommand cmd="run dev" />
+
+Runs Webpack in watch mode for development, continually monitoring for changes.
+
+### <SyncCommand cmd="run e2e" />
+
+Runs Grafana end-to-end tests using Cypress.
+
+### <SyncCommand cmd="run e2e:update" />
+
+Runs Grafana end-to-end tests and tests any test screenshots, using Cypress.
+
+### <SyncCommand cmd="run lint" />
+
+Lints the frontend codebase using ESLint with the `.gitignore` file to ignore certain files. Results are cached locally to speed up future linting tasks.
+
+### <SyncCommand cmd="run lint:fix" />
+
+Lints the frontend codebase using ESLint and automatically fixes detected issues.
+
+### <SyncCommand cmd="run typecheck" />
+
+Performs a type-checking process on the frontend code using TypeScript.
+
+## <SyncCommand cmd="run server" />
+
+Launches the https://grafana.com/developers/plugin-tools/get-started/set-up-development-environment using Docker.
+
+## <SyncCommand cmd="run sign" />
+
+Signs the Grafana plugin using the latest version of `@grafana/sign-plugin`.
+
+### <SyncCommand cmd="run test" />
+
+Executes frontend tests, running only the tests that have changed, and enables a watch mode for ongoing testing.
+
+### <SyncCommand cmd="run test:ci" />
+
+Runs frontend tests for CI, ensuring it passes even with no tests, and utilizes a maximum of four workers for parallel execution.

--- a/docusaurus/docs/shared/plugin-anatomy.md
+++ b/docusaurus/docs/shared/plugin-anatomy.md
@@ -10,7 +10,7 @@ While certain plugin types can have specific configuration options, let's look a
 - `name` is what users will see in the list of plugins. If you're creating a data source, this is typically the name of the database it connects to, such as Prometheus, PostgreSQL, or Stackdriver.
 - `id` uniquely identifies your plugin and should follow this naming convention: `<$organization-name>-<$plugin-name>-<$plugin-type>`. The create-plugin tool correctly configures this based on your responses to its prompts.
 
-To see all the available configuration settings for the `plugin.json`, refer to the [plugin.json Schema](../metadata.md).
+To see all the available configuration settings for the `plugin.json`, refer to the [plugin.json Schema](../reference/metadata.md).
 
 ### `module.ts`
 

--- a/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
@@ -12,7 +12,6 @@ keywords:
   - datasource
 ---
 
-
 # Build a logs data source plugin
 
 Grafana data source plugins support metrics, logs, and other data types. The steps to build a logs data source plugin are largely the same as for a metrics data source, but there are a few differences which we will explain in this guide.
@@ -32,7 +31,7 @@ When these steps are done, then you can improve the user experience with one or 
 
 ### Step 1: Enable logs support
 
-Tell Grafana that your data source plugin can return log data, by adding `"logs": true` to the [plugin.json](../metadata.md) file.
+Tell Grafana that your data source plugin can return log data, by adding `"logs": true` to the [plugin.json](../reference/metadata.md) file.
 
 ```json
 {
@@ -135,7 +134,7 @@ const result = createDataFrame({
 
 :::note
 
-This feature must be implemented in the data frame as a meta attribute. 
+This feature must be implemented in the data frame as a meta attribute.
 
 :::
 

--- a/packages/create-plugin/templates/app/README.md
+++ b/packages/create-plugin/templates/app/README.md
@@ -18,5 +18,5 @@ App plugins can let you create a custom out-of-the-box monitoring experience by 
 Below you can find source code for existing app plugins and other related documentation.
 
 - [Basic app plugin example](https://github.com/grafana/grafana-plugin-examples/tree/master/examples/app-basic#readme)
-- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json)
+- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference/reference-plugin-json)
 - [How to sign a plugin?](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin)

--- a/packages/create-plugin/templates/common/src/README.md
+++ b/packages/create-plugin/templates/common/src/README.md
@@ -33,7 +33,7 @@ Consider other [badges](https://shields.io/badges) as you feel appropriate for y
 Provide one or more paragraphs as an introduction to your plugin to help users understand why they should use it.  
 
 Consider including screenshots:
-- in [plugin.json](https://grafana.com/developers/plugin-tools/reference-plugin-json#info) include them as relative links.
+- in [plugin.json](https://grafana.com/developers/plugin-tools/reference/reference-plugin-json#info) include them as relative links.
 - in the README ensure they are absolute URLs.
 
 ## Requirements

--- a/packages/create-plugin/templates/datasource/README.md
+++ b/packages/create-plugin/templates/datasource/README.md
@@ -18,5 +18,5 @@ Grafana supports a wide range of data sources, including Prometheus, MySQL, and 
 Below you can find source code for existing app plugins and other related documentation.
 
 - [Basic data source plugin example](https://github.com/grafana/grafana-plugin-examples/tree/master/examples/datasource-basic#readme)
-- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json)
+- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference/reference-plugin-json)
 - [How to sign a plugin?](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin)

--- a/packages/create-plugin/templates/panel/README.md
+++ b/packages/create-plugin/templates/panel/README.md
@@ -19,5 +19,5 @@ Use panel plugins when you want to do things like visualize data returned by dat
 Below you can find source code for existing app plugins and other related documentation.
 
 - [Basic panel plugin example](https://github.com/grafana/grafana-plugin-examples/tree/master/examples/panel-basic#readme)
-- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference-plugin-json)
+- [`plugin.json` documentation](https://grafana.com/developers/plugin-tools/reference/reference-plugin-json)
 - [How to sign a plugin?](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin)


### PR DESCRIPTION
- Refactor 'Get started' guide based on David/Joe discussion and notes
- Minor updates to 'Folder structure' and 'Docker' files
- Add index pages for Create a plugin, Develop a plugin, Extend a plugin, and References so that these could be linked to from 'Get started' guide
- Refactor 'References' section to include prompts and CLI commands
- Fix links in docs and packages broken by refactoring of 'References'

Note: Upon publication of this PR, links and redirects to plugin.json reference doc in Grafana repo must be updated.