### PR TITLE
Website: Fix tracking issue with missing canonical links

### DIFF
--- a/docusaurus/website/src/theme/tracking/index.ts
+++ b/docusaurus/website/src/theme/tracking/index.ts
@@ -16,7 +16,7 @@ const isRudderstackSetup = (config: RudderStackTrackingConfig) =>
 // Enqueue all rudderstack requests until it is loaded and consent is granted
 let rudderstack = {};
 let rudderQueue = [];
-const rudderMethods = ["page", "track", "identify", "reset"];
+const rudderMethods = ['page', 'track', 'identify', 'reset'];
 for (const method of rudderMethods) {
   rudderstack[method] = (...args) => {
     rudderQueue.push([method].concat(args));
@@ -48,11 +48,11 @@ export function startTracking(config: RudderStackTrackingConfig) {
       rudderQueue = undefined;
     };
 
-    const el = document.createElement("script");
+    const el = document.createElement('script');
     el.async = true;
     el.src = config.sdkUrl;
     el.onload = initRudderstack;
-    document.getElementsByTagName("head")[0].appendChild(el);
+    document.getElementsByTagName('head')[0].appendChild(el);
   }
 }
 
@@ -61,12 +61,13 @@ export function trackPage() {
   // define it manually.
   if (rudderQueue) {
     const { href, pathname } = location;
+    const url = Boolean(document.querySelector("link[rel='canonical']"))
+      ? document.querySelector("link[rel='canonical']").getAttribute('href')
+      : href;
     const properties = {
-      url:
-        document.querySelector("link[rel='canonical']").getAttribute("href") ||
-        href,
+      url: url,
       path: pathname,
-      referrer: document.referrer || "$direct",
+      referrer: document.referrer || '$direct',
       title: document.title,
       tab_url: href,
     };

--- a/docusaurus/website/src/theme/tracking/index.ts
+++ b/docusaurus/website/src/theme/tracking/index.ts
@@ -65,7 +65,7 @@ export function trackPage() {
       ? document.querySelector("link[rel='canonical']").getAttribute('href')
       : href;
     const properties = {
-      url: url,
+      url,
       path: pathname,
       referrer: document.referrer || '$direct',
       title: document.title,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

@josmperez has reported some odd behaviour with docusaurus crashing in dev. Looking at the stack trace it appears the tracking code will error if it cannot find a canonical link on the page. This PR fixes that by checking the link exists before attempting to get the `href` attribute.

![image](https://github.com/grafana/plugin-tools/assets/73201/93ff9654-1c10-4471-bae5-088cb5c7b1bc)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
