### PR TITLE
Create Plugin: Fix wrongly named files when upgrading/migrating

### DIFF
--- a/packages/create-plugin/src/commands/generate.plopfile.ts
+++ b/packages/create-plugin/src/commands/generate.plopfile.ts
@@ -10,6 +10,7 @@ import { printGenerateSuccessMessage } from './generate-actions/print-success-me
 import { updateGoSdkAndModules } from './generate-actions/update-go-sdk-and-packages';
 import { prettifyFiles } from './generate-actions/prettify-files';
 import { CliArgs, TemplateData } from './types';
+import { getExportFileName } from '../utils/utils.files';
 
 // Plopfile API documentation: https://plopjs.com/documentation/#plopfile-api
 export default function (plop: NodePlopAPI) {
@@ -236,16 +237,6 @@ function getActionsForTemplateFolder({
     files = files.filter((file) => path.basename(file) !== 'npmrc');
   }
 
-  function getExportFileName(f: string) {
-    const baseName = path.basename(f);
-
-    if (Object.keys(configFileNamesMap).includes(baseName)) {
-      return configFileNamesMap[baseName];
-    }
-
-    return path.extname(f) === '.hbs' ? path.basename(f, '.hbs') : baseName;
-  }
-
   function getExportPath(f: string) {
     return path.relative(folderPath, path.dirname(f));
   }
@@ -265,16 +256,6 @@ function getActionsForTemplateFolder({
     },
   }));
 }
-
-// yarn and npm packing will not include `.gitignore` files
-// so we have to manually rename them to add the dot prefix
-// other config files trip up the tooling in the plugin-tools monorepo
-const configFileNamesMap: Record<string, string> = {
-  gitignore: '.gitignore',
-  npmrc: '.npmrc',
-  _eslintrc: '.eslintrc',
-  '_package.json': 'package.json',
-};
 
 function isFile(path: string) {
   try {

--- a/packages/create-plugin/src/utils/utils.files.ts
+++ b/packages/create-plugin/src/utils/utils.files.ts
@@ -50,6 +50,26 @@ export function removeFilesInCwd(files: string[]) {
   }
 }
 
+export function getExportFileName(f: string) {
+  const baseName = path.basename(f);
+
+  if (Object.keys(configFileNamesMap).includes(baseName)) {
+    return configFileNamesMap[baseName];
+  }
+
+  return path.extname(f) === '.hbs' ? path.basename(f, '.hbs') : baseName;
+}
+
+// yarn and npm packing will not include `.gitignore` files
+// so we have to manually rename them to add the dot prefix
+// other config files trip up the tooling in the plugin-tools monorepo
+const configFileNamesMap: Record<string, string> = {
+  gitignore: '.gitignore',
+  npmrc: '.npmrc',
+  _eslintrc: '.eslintrc',
+  '_package.json': 'package.json',
+};
+
 /**
  * Returns TRUE if the file is starting with any of the provided string filters.
  *

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -7,6 +7,7 @@ import { renderHandlebarsTemplate } from './utils.handlebars';
 import { getPluginJson } from './utils.plugin';
 import { TEMPLATE_PATHS, EXPORT_PATH_PREFIX, EXTRA_TEMPLATE_VARIABLES } from '../constants';
 import { getPackageManagerWithFallback } from './utils.packageManager';
+import { getExportFileName } from '../utils/utils.files';
 
 /**
  *
@@ -52,7 +53,7 @@ export function compileSingleTemplateFile(pluginType: string, templateFile: stri
 
   const rendered = renderTemplateFromFile(templateFile, data);
   const relativeExportPath = templateFile.replace(TEMPLATE_PATHS.common, '').replace(TEMPLATE_PATHS[pluginType], '');
-  const exportPath = path.join(EXPORT_PATH_PREFIX, relativeExportPath);
+  const exportPath = path.join(EXPORT_PATH_PREFIX, path.dirname(relativeExportPath), getExportFileName(templateFile));
 
   mkdirp.sync(path.dirname(exportPath));
   fs.writeFileSync(exportPath, rendered);


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR fixes a bug that was introduced in #481 causing .eslintrc file to be created as _eslintrc file. To fix it I've shared the code from the generate command that caters for this renaming and updated the export paths when generating each template file.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@2.2.3-canary.490.926cf14.0
  # or 
  yarn add @grafana/create-plugin@2.2.3-canary.490.926cf14.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
