### PR TITLE
Log context support: deprecate showContextToggle

### DIFF
--- a/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
@@ -360,7 +360,6 @@ import { catchError, lastValueFrom, of, switchMap, Observable } from 'rxjs';
 
 export class ExampleDatasource
   extends DataSourceApi<ExampleQuery, ExampleOptions>
-  // Implement DataSourceWithLogsContextSupport and its methods
   implements DataSourceWithLogsContextSupport<ExampleQuery>
 {
   // Retrieve context for a given log row

--- a/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
@@ -360,6 +360,7 @@ import { catchError, lastValueFrom, of, switchMap, Observable } from 'rxjs';
 
 export class ExampleDatasource
   extends DataSourceApi<ExampleQuery, ExampleOptions>
+  // Implement DataSourceWithLogsContextSupport and its methods
   implements DataSourceWithLogsContextSupport<ExampleQuery>
 {
   // Retrieve context for a given log row
@@ -394,14 +395,6 @@ export class ExampleDatasource
     query?: ExampleQuery
   ): Promise<ExampleQuery | null> {
     // Data source internal implementation that creates context query based on row, options and original query
-  }
-
-  // This method can be used to show "context" button based on runtime conditions (for example, row model data or plugin settings)
-  showContextToggle(row?: LogRowModel): boolean {
-    // If you want to always show toggle, you can just return true
-    if (row && row.searchWords && row.searchWords.length > 0) {
-      return true;
-    }
   }
 }
 ```


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/pull/77232, where we're deprecating the `showContextToggle` function.

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/grafana/issues/66819