### PR TITLE
update to use sha1sum and minor workflow updates

### DIFF
--- a/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
+++ b/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
@@ -45,7 +45,7 @@ Follow these steps to publish your plugin for the first time.
        This can lead to faster downloads since users can select the specific architecture on which they want to install the plugin.
    - **URL:** A URL that points to a ZIP archive of your packaged plugin.
    - **Source code URL:** A URL that points to a public Git repository or ZIP archive of your complete plugin source code.
-   - **MD5:** The MD5 hash of the plugin specified by the **URL**.
+   - **SHA1:** The SHA1 hash of the plugin specified by the **URL**.
    - The remaining questions help us determine the [signature level](./sign-a-plugin#plugin-signature-levels) for your plugin.
 1. Click **Submit**.
    After you submit your plugin, we run an automated validation to make sure it adheres to our guidelines.

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           node-version: '20'
           cache: '{{ packageManagerName }}'
+{{#if_eq packageManagerName "pnpm"}}
+          cache-dependency-path: pnpm-lock.yaml
+{{/if_eq}}
 
       - name: Install dependencies
         run: {{ packageManagerInstallCmd }}
@@ -51,7 +54,7 @@ jobs:
         if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
         with:
           node-version: '20'
           cache: '{{ packageManagerName }}'
-{{#if_eq packageManagerName "pnpm"}}
-          cache-dependency-path: pnpm-lock.yaml
-{{/if_eq}}
 
       - name: Install dependencies
         run: {{ packageManagerInstallCmd }}

--- a/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           node-version: '20'
           cache: '{{ packageManagerName }}'
-{{#if_eq packageManagerName "pnpm"}}
-          cache-dependency-path: pnpm-lock.yaml
-{{/if_eq}}
 
       - name: Setup Go environment
         uses: actions/setup-go@v3

--- a/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
@@ -25,11 +25,14 @@ jobs:
         with:
           node-version: '20'
           cache: '{{ packageManagerName }}'
+{{#if_eq packageManagerName "pnpm"}}
+          cache-dependency-path: pnpm-lock.yaml
+{{/if_eq}}
 
       - name: Setup Go environment
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.21'
 
       - name: Install dependencies
         run: {{ packageManagerInstallCmd }}
@@ -78,13 +81,13 @@ jobs:
           export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
           export GRAFANA_PLUGIN_TYPE=$(cat dist/plugin.json | jq -r .type)
           export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
-          export GRAFANA_PLUGIN_ARTIFACT_CHECKSUM=${GRAFANA_PLUGIN_ARTIFACT}.md5
+          export GRAFANA_PLUGIN_ARTIFACT_SHA1SUM=${GRAFANA_PLUGIN_ARTIFACT}.sha1
 
           echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
           echo "plugin-version=${GRAFANA_PLUGIN_VERSION}" >> $GITHUB_OUTPUT
           echo "plugin-type=${GRAFANA_PLUGIN_TYPE}" >> $GITHUB_OUTPUT
           echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
-          echo "archive-checksum=${GRAFANA_PLUGIN_ARTIFACT_CHECKSUM}" >> $GITHUB_OUTPUT
+          echo "archive-sha1sum=${GRAFANA_PLUGIN_ARTIFACT_SHA1SUM}" >> $GITHUB_OUTPUT
 
           echo "github-tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
 
@@ -102,8 +105,7 @@ jobs:
         run: |
           mv dist $\{{ steps.metadata.outputs.plugin-id }}
           zip $\{{ steps.metadata.outputs.archive }} $\{{ steps.metadata.outputs.plugin-id }} -r
-          md5sum $\{{ steps.metadata.outputs.archive }} > $\{{ steps.metadata.outputs.archive-checksum }}
-          echo "checksum=$(cat ./$\{{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          sha1sum $\{{ steps.metadata.outputs.archive }} | cut -f1 -d' ' > $\{{ steps.metadata.outputs.archive-sha1sum }}
 
       - name: Validate plugin
         run: |
@@ -120,7 +122,7 @@ jobs:
           generate_release_notes: true
           files: |
             ./$\{{ steps.metadata.outputs.archive }}
-            ./$\{{ steps.metadata.outputs.archive-checksum }}
+            ./$\{{ steps.metadata.outputs.archive-sha1sum }}
           body: |
             **This Github draft release has been created for your plugin.**
 
@@ -134,6 +136,6 @@ jobs:
             - Click the **Submit Plugin** button
             - Fill in the Plugin Submission form:
               - Paste this [.zip asset link](https://github.com/$\{{ github.repository }}/releases/download/v$\{{ steps.metadata.outputs.plugin-version }}/$\{{ steps.metadata.outputs.archive }}) in the Plugin URL field
-              - Paste this [.zip.md5 link](https://github.com/$\{{ github.repository }}/releases/download/v$\{{ steps.metadata.outputs.plugin-version }}/$\{{ steps.metadata.outputs.archive-checksum }}) in the MD5 field
+              - Paste this [.zip.sha1 link](https://github.com/${{ github.repository }}/releases/download/v${{ steps.metadata.outputs.plugin-version }}/${{ steps.metadata.outputs.archive-sha1sum }}) in the SHA1 field
 
             Once done please remove these instructions and publish this release.


### PR DESCRIPTION
**What this PR does / why we need it**:

- Updates release workflow to generate a sha1sum file that GCOM can use, docs updated also to not reference non-preferred MD5 option

- Updates go to 1.21

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@2.5.0-canary.503.d548172.0
  # or 
  yarn add @grafana/create-plugin@2.5.0-canary.503.d548172.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
