### PR TITLE
Create Plugin: Replace 'master' with 'main' on  ref

### DIFF
--- a/packages/create-plugin/fixtures/test-template/src/plugin.json
+++ b/packages/create-plugin/fixtures/test-template/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ normalize_id pluginName orgName 'app' }}",

--- a/packages/create-plugin/templates/app/src/plugin.json
+++ b/packages/create-plugin/templates/app/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ normalize_id pluginName orgName 'app' }}",{{#if hasBackend}}

--- a/packages/create-plugin/templates/datasource/src/plugin.json
+++ b/packages/create-plugin/templates/datasource/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ normalize_id pluginName orgName 'datasource' }}",

--- a/packages/create-plugin/templates/panel/src/plugin.json
+++ b/packages/create-plugin/templates/panel/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "panel",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ normalize_id pluginName orgName 'panel' }}",

--- a/packages/create-plugin/templates/scenes-app/src/plugin.json
+++ b/packages/create-plugin/templates/scenes-app/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "app",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ normalize_id pluginName orgName 'app' }}",{{#if hasBackend}}


### PR DESCRIPTION
**What this PR does / why we need it**:

While starting to write a new plugin using the `@grafana/create-plugin` tool, I realized the boilerplate it generates includes a reference to the `master` branch as the source of the schema definition for the `plugin.json` file.

So, I decided to open this PR which updates the `$schema` reference in `plugin.json` templates to replace `master` with `main`, which is the correct one, I think. Otherwise, just feel free to dismiss it.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A
