### PR TITLE
Docs: Replace DocCardLists with DocLinkLists

### DIFF
--- a/docusaurus/docs/create-a-plugin/_category_.json
+++ b/docusaurus/docs/create-a-plugin/_category_.json
@@ -1,6 +1,9 @@
 {
   "position": 20,
   "label": "Create a plugin",
+  "customProps": {
+    "description": "Guides for taking your plugin from bare essentials to robustly feature-enabled."
+  },
   "collapsible": true,
   "collapsed": true
 }

--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/_category_.json
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/_category_.json
@@ -1,6 +1,9 @@
 {
-    "position": 1,
-    "label": "Develop a plugin",
-    "collapsible": true,
-    "collapsed": true
-  }
+  "position": 1,
+  "label": "Develop a plugin",
+  "customProps": {
+    "description": "Guides for learning the fundamentals of Grafana plugin development."
+  },
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/index.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/index.md
@@ -1,0 +1,13 @@
+---
+id: develop-a-plugin
+title: Develop Grafana plugins
+description: Learn about Grafana plugin development.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - develop
+  - development
+---
+
+<DocLinkList />

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/_category_.json
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/_category_.json
@@ -2,7 +2,7 @@
   "position": 2,
   "label": "Extend a plugin",
   "customProps": {
-    "description": "Guides for extending a Grafana plugin with features such as authentication, query editor help, and annotations."
+    "description": "Guides for extending your Grafana plugin with additional features to improve its quality."
   },
   "collapsible": true,
   "collapsed": true

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/_category_.json
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/_category_.json
@@ -1,6 +1,9 @@
 {
-    "position": 2,
-    "label": "Extend a plugin",
-    "collapsible": true,
-    "collapsed": true
-  }
+  "position": 2,
+  "label": "Extend a plugin",
+  "customProps": {
+    "description": "Guides for extending a Grafana plugin with features such as authentication, query editor help, and annotations."
+  },
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/index.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/index.md
@@ -1,0 +1,13 @@
+---
+id: extend-a-plugin
+title: Exend Grafana plugins
+description: Learn how to extend or customize Grafana plugins.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - develop
+  - development
+---
+
+<DocLinkList />

--- a/docusaurus/docs/create-a-plugin/index.md
+++ b/docusaurus/docs/create-a-plugin/index.md
@@ -12,6 +12,4 @@ keywords:
   - enhance
 ---
 
-import DocCardList from '@theme/DocCardList';
-
-<DocCardList />
+<DocLinkList />

--- a/docusaurus/docs/introduction/index.md
+++ b/docusaurus/docs/introduction/index.md
@@ -10,6 +10,4 @@ keywords:
   - development
 ---
 
-import DocCardList from '@theme/DocCardList';
-
-<DocCardList />
+<DocLinkList />

--- a/docusaurus/docs/migration-guides/angular-react/_category_.json
+++ b/docusaurus/docs/migration-guides/angular-react/_category_.json
@@ -2,7 +2,7 @@
   "position": 10,
   "label": "Migrate from AngularJS to React",
   "customProps": {
-    "description": "How to migrate your plugin from Angular to ReactJS."
+    "description": "How to migrate your plugin from the legacy AngularJS framework to our React based platform."
   },
   "collapsible": true,
   "collapsed": true

--- a/docusaurus/docs/migration-guides/angular-react/_category_.json
+++ b/docusaurus/docs/migration-guides/angular-react/_category_.json
@@ -1,6 +1,9 @@
 {
-    "position": 10,
-    "label": "Migrate from AngularJS to React",
-    "collapsible": true,
-    "collapsed": true
-  }
+  "position": 10,
+  "label": "Migrate from AngularJS to React",
+  "customProps": {
+    "description": "How to migrate your plugin from Angular to ReactJS."
+  },
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docusaurus/docs/migration-guides/index.md
+++ b/docusaurus/docs/migration-guides/index.md
@@ -1,5 +1,5 @@
 ---
-id: migration-guides 
+id: migration-guides
 title: Grafana plugin migration guides
 description: How to upgrade or migrate a Grafana plugin.
 keywords:
@@ -12,6 +12,4 @@ keywords:
   - migration
 ---
 
-import DocCardList from '@theme/DocCardList';
-
-<DocCardList />
+<DocLinkList />

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/_category_.json
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/_category_.json
@@ -1,6 +1,9 @@
 {
-    "position": 1,
-    "label": "Update from Grafana versions",
-    "collapsible": true,
-    "collapsed": true
-  }
+  "position": 1,
+  "label": "Update from Grafana versions",
+  "customProps": {
+    "description": "How to update your plugin from one version of Grafana to another."
+  },
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/_category_.json
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/_category_.json
@@ -2,7 +2,7 @@
   "position": 1,
   "label": "Update from Grafana versions",
   "customProps": {
-    "description": "How to update your plugin from one version of Grafana to another."
+    "description": "How to handle breaking changes between Grafana versions in your plugin."
   },
   "collapsible": true,
   "collapsed": true

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/index.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/index.md
@@ -1,0 +1,14 @@
+---
+id: migration-from-grafana
+title: Update plugins from Grafana versions
+description: How to migrate plugins from specific Grafana versions.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - develop
+  - migrate
+  - migration
+---
+
+<DocLinkList />

--- a/docusaurus/docs/tutorials/_category_.json
+++ b/docusaurus/docs/tutorials/_category_.json
@@ -1,6 +1,9 @@
 {
   "position": 15,
   "label": "Tutorials",
+  "customProps": {
+    "description": "Start your building journey with one of our tutorials for learning the essentials of plugin development."
+  },
   "collapsible": true,
   "collapsed": true
 }

--- a/docusaurus/docs/tutorials/build-a-data-source-backend-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-backend-plugin.md
@@ -2,7 +2,7 @@
 id: build-a-data-source-backend-plugin
 title: Build a data source backend plugin
 sidebar_position: 10
-description: Create a backend for your data source plugin.
+description: Learn how to create a backend for your data source plugin.
 keywords:
   - grafana
   - plugins

--- a/docusaurus/docs/tutorials/build-a-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-plugin.md
@@ -2,7 +2,7 @@
 id: build-a-data-source-plugin
 title: Build a data source plugin
 sidebar_position: 1
-description: Create a plugin to add support for your own data sources.
+description: Learn how to create a plugin to add support for your own data sources.
 keywords:
   - grafana
   - plugins

--- a/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
@@ -2,7 +2,7 @@
 id: build-a-logs-data-source-plugin
 title: Build a logs data source plugin
 sidebar_position: 20
-description: How to build a logs data source plugin.
+description: Learn how to build a logs data source plugin.
 keywords:
   - grafana
   - plugins

--- a/docusaurus/docs/tutorials/build-a-panel-plugin-with-d3.md
+++ b/docusaurus/docs/tutorials/build-a-panel-plugin-with-d3.md
@@ -2,7 +2,7 @@
 id: build-a-panel-plugin-with-d3
 title: Build a panel plugin with D3.js
 sidebar_position: 7
-description: How to use D3.js in your panel plugins.
+description: Learn how to use D3.js in your panel plugins.
 draft: true
 keywords:
   - grafana

--- a/docusaurus/docs/tutorials/build-a-streaming-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-streaming-data-source-plugin.md
@@ -2,7 +2,7 @@
 id: build-a-streaming-data-source-plugin
 title: Build a streaming data source plugin
 sidebar_position: 9
-description: How to build a streaming data source plugin.
+description: Learn how to build a streaming data source plugin.
 draft: true
 keywords:
   - grafana

--- a/docusaurus/docs/tutorials/index.md
+++ b/docusaurus/docs/tutorials/index.md
@@ -1,5 +1,5 @@
 ---
-id: tutorials 
+id: tutorials
 title: Tutorials for Grafana plugin development
 description: Guides for developing Grafana data source plugins, logs plugins, panel plugins, and other plugins.
 keywords:
@@ -12,6 +12,4 @@ keywords:
   - migration
 ---
 
-import DocCardList from '@theme/DocCardList';
-
-<DocCardList />
+<DocLinkList />

--- a/docusaurus/website/src/components/DocLinkList/DocLinkList.tsx
+++ b/docusaurus/website/src/components/DocLinkList/DocLinkList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useCurrentSidebarCategory, filterDocCardListItems } from '@docusaurus/theme-common';
-import { useDocById } from '@docusaurus/theme-common/internal';
+import { useDocById, findFirstSidebarItemLink } from '@docusaurus/theme-common/internal';
 import Link from '@docusaurus/Link';
 import type { Props } from '@theme/DocCardList';
 import styles from './styles.module.css';
@@ -19,7 +19,14 @@ export default function DocLinkList(props: Props): JSX.Element {
 
   return (
     <ul className={className}>
-      {filteredItems.map((item) => item.type === 'link' && <DocLink key={item.docId} item={item} />)}
+      {filteredItems.map((item) => {
+        if (item.type === 'link') {
+          return <DocLink key={item.docId} item={item} />;
+        }
+        if (item.type === 'category') {
+          return <DocCategoryLink key={item.href} category={item} />;
+        }
+      })}
     </ul>
   );
 }
@@ -30,6 +37,19 @@ function DocLink({ item }) {
   return (
     <li key={item.docId} className="margin-bottom--md">
       <Link to={item.href}>{item.label}</Link>
+      {description && <small className={styles.description}>{description}</small>}
+    </li>
+  );
+}
+
+function DocCategoryLink({ category }) {
+  const categoryHref = findFirstSidebarItemLink(category);
+  const doc = useDocById(category.docId ?? undefined);
+  const description = category.description || category.customProps?.description || doc?.description;
+
+  return (
+    <li key={category.docId} className="margin-bottom--md">
+      <Link to={categoryHref}>{category.label}</Link>
       {description && <small className={styles.description}>{description}</small>}
     </li>
   );


### PR DESCRIPTION
This PR utilizes the DocLinkLists added in https://github.com/grafana/plugin-tools/pull/493 to the site's index pages. Add two index pages for develop-a-plugin and extend-a-plugin.