### PR TITLE
Create-plugin: Add command to package plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6483,6 +6483,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-6.0.1.tgz",
+      "integrity": "sha512-F2+JkmDYvtQrtb2YldwL0apRB1/WB6ub+1zVF/bKp3TOygUMFqfOLuw5Fj62Q+DPwJUFz1eocMxJMu7yVpplZA==",
+      "dev": true,
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.1.19",
       "dev": true,
@@ -6802,6 +6811,15 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-trCChHpWDGCJCUPJRwD62eapW4KOru6h4S7n9KUIESaxhyBM/2Jh20P3XrFRQQ6Df78E/rq2DbUCVZlI8CXPnA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -7688,6 +7706,78 @@
       "version": "2.0.0",
       "license": "ISC"
     },
+    "node_modules/archiver": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.1.tgz",
+      "integrity": "sha512-CXGy4poOLBKptiZH//VlWdFuUC1RESbdZjGjILwBuZ73P7WkAUN0htfSfBq/7k6FRFlpu7bg4JOkj1vU9G6jcQ==",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^5.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-4.0.1.tgz",
+      "integrity": "sha512-Q4Q99idbvzmgCTEAAhi32BkOyq8iVI5EwdO0PmBDSGIzzjYNdcFn7Q7k3OzbLy4kLUPXfJtG6fO2RjftXbobBg==",
+      "dependencies": {
+        "glob": "^8.0.0",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
       "dev": true,
@@ -7924,7 +8014,6 @@
     },
     "node_modules/async": {
       "version": "3.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/asynckit": {
@@ -8052,6 +8141,11 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
     },
     "node_modules/babel-loader": {
       "version": "8.3.0",
@@ -8652,6 +8746,14 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -9774,6 +9876,20 @@
       "version": "1.3.0",
       "license": "MIT"
     },
+    "node_modules/compress-commons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-5.0.1.tgz",
+      "integrity": "sha512-MPh//1cERdLtqwO3pOFLeXtpuai0Y2WCd5AhtKxznqM7WtaMYaOEMSgn45d9D10sIHSfIKE603HlOp8OPGrvag==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^5.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "license": "MIT",
@@ -10254,6 +10370,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-5.0.0.tgz",
+      "integrity": "sha512-B0EPa1UK+qnpBZpG+7FgPCu0J2ETLpXq09o9BkLkEAhdB6Z61Qo4pJ3JYu0c+Qi+/SAL7QThqnzS06pmSSyZaw==",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/create-require": {
@@ -12326,6 +12465,11 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -16454,6 +16598,31 @@
       "dependencies": {
         "picocolors": "^1.0.0",
         "shell-quote": "^1.7.3"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/lerna": {
@@ -22663,6 +22832,11 @@
       ],
       "license": "MIT"
     },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
+    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "dev": true,
@@ -23211,6 +23385,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -24901,6 +25094,15 @@
       "license": "MIT",
       "dependencies": {
         "duplexer": "~0.1.1"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.2.tgz",
+      "integrity": "sha512-b62pAV/aeMjUoRN2C/9F0n+G8AfcJjNC0zw/ZmOHeFsIe4m4GzjVW9m6VHXVjk536NbdU9JRwKMJRfkc+zUFTg==",
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
       }
     },
     "node_modules/string_decoder": {
@@ -27649,6 +27851,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zip-stream": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-5.0.1.tgz",
+      "integrity": "sha512-UfZ0oa0C8LI58wJ+moL46BDIMgCQbnsb+2PoiJYtonhBsMh2bq1eRBVkvjfVsqbEHd9/EgKPUuL9saSSsec8OA==",
+      "dependencies": {
+        "archiver-utils": "^4.0.1",
+        "compress-commons": "^5.0.1",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/zwitch": {
       "version": "1.0.5",
       "license": "MIT",
@@ -27666,6 +27881,7 @@
         "@types/mkdirp": "^1.0.2",
         "@types/semver": "^7.3.9",
         "@types/which": "^2.0.2",
+        "archiver": "^6.0.1",
         "enquirer": "^2.3.6",
         "find-up": "^5.0.0",
         "glob": "^7.1.7",
@@ -27680,6 +27896,7 @@
         "create-plugin": "dist/bin/run.js"
       },
       "devDependencies": {
+        "@types/archiver": "^6.0.1",
         "@types/glob": "^7.0.0",
         "eslint-plugin-react": "^7.26.1",
         "eslint-plugin-react-hooks": "^4.2.0"

--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -97,7 +97,7 @@ For more information see [here](https://grafana.com/developers/plugin-tools/migr
 
 ## Package your plugin
 
-You can use the `package` command to [package](https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin) automatically.
+You can use the `package` command to [package](https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin) your plugin automatically.
 
 1. Build your plugin: e.g. `npm run build` or `yarn build` and `mage` if your plugin has a backend.
 2. [Sign your plugin](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin).

--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -95,6 +95,14 @@ For more information see [here](https://grafana.com/developers/plugin-tools/migr
 
 ---
 
+## Package your plugin
+
+You can use the `package` command to [package](https://grafana.com/developers/plugin-tools/publish-a-plugin/package-a-plugin) automatically.
+
+1. Build your plugin: e.g. `npm run build` or `yarn build` and `mage` if your plugin has a backend.
+2. [Sign your plugin](https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin).
+3. Run `npx @grafana/create-plugin@latest package` to package your plugin. A zip file with your plugin will be created.
+
 ## Customizing or extending the basic configs
 
 You can read more about customizing or extending the basic configuration [here](https://grafana.com/developers/plugin-tools/create-a-plugin/extend-a-plugin/extend-configurations)

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -38,6 +38,7 @@
     "@types/mkdirp": "^1.0.2",
     "@types/semver": "^7.3.9",
     "@types/which": "^2.0.2",
+    "archiver": "^6.0.1",
     "enquirer": "^2.3.6",
     "find-up": "^5.0.0",
     "glob": "^7.1.7",
@@ -49,6 +50,7 @@
     "which": "^3.0.0"
   },
   "devDependencies": {
+    "@types/archiver": "^6.0.1",
     "@types/glob": "^7.0.0",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0"

--- a/packages/create-plugin/src/bin/run.ts
+++ b/packages/create-plugin/src/bin/run.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import minimist from 'minimist';
-import { generate, update, migrate, version } from '../commands';
+import { generate, update, migrate, version, packagePlugin } from '../commands';
 import { isUnsupportedPlatform } from '../utils/utils.os';
 
 // Exit early if operating system isn't supported.
@@ -18,6 +18,7 @@ const commands: Record<string, (argv: minimist.ParsedArgs) => void> = {
   migrate,
   generate,
   update,
+  package: packagePlugin,
   version,
 };
 const command = commands[argv._[0]] || commands.generate;

--- a/packages/create-plugin/src/commands/index.ts
+++ b/packages/create-plugin/src/commands/index.ts
@@ -2,3 +2,4 @@ export * from './generate.command';
 export * from './update.command';
 export * from './migrate.command';
 export * from './version.command';
+export * from './package.command';

--- a/packages/create-plugin/src/commands/package.command.ts
+++ b/packages/create-plugin/src/commands/package.command.ts
@@ -40,13 +40,19 @@ export const packagePlugin = async (argv: minimist.ParsedArgs) => {
 
   const pluginJsonContent = require(PLUGIN_JSON_PATH);
   const pluginId = pluginJsonContent.id;
+  const pluginVersion = pluginJsonContent.info?.version;
 
   if (typeof pluginId !== 'string' || pluginId.length === 0) {
     printErrorMessage(`Could not find 'id' in 'plugin.json'`);
     process.exit(1);
   }
 
-  const zipFileName = `${pluginId}.zip`;
+  if (typeof pluginVersion !== 'string' || pluginVersion.length === 0) {
+    printErrorMessage(`Could not find 'version' in 'plugin.json'`);
+    process.exit(1);
+  }
+
+  const zipFileName = `${pluginId}-${pluginVersion}.zip`;
   const zipFilePath = path.join(CWD, zipFileName);
 
   // if zip file already exists, warn user and confirm if wish to continue

--- a/packages/create-plugin/src/commands/package.command.ts
+++ b/packages/create-plugin/src/commands/package.command.ts
@@ -8,12 +8,12 @@ export const packagePlugin = async (argv: minimist.ParsedArgs) => {
   const nonInteractive = argv['non-interactive'];
 
   const CWD = process.cwd();
-  const DIS_PATH = path.join(CWD, 'dist');
-  const PLUGIN_JSON = path.join(DIS_PATH, 'plugin.json');
-  const MANIFEST_TXT = path.join(DIS_PATH, 'MANIFEST.txt');
+  const DIST_PATH = path.join(CWD, 'dist');
+  const PLUGIN_JSON = path.join(DIST_PATH, 'plugin.json');
+  const MANIFEST_TXT = path.join(DIST_PATH, 'MANIFEST.txt');
 
   // validate DIS_PATH exists
-  if (!fs.existsSync(DIS_PATH) || !fs.statSync(DIS_PATH).isDirectory()) {
+  if (!fs.existsSync(DIST_PATH) || !fs.statSync(DIST_PATH).isDirectory()) {
     printErrorMessage(
       "Could not find 'dist' directory. Please build your plugin before running this command. e.g.: `yarn build` or `npm run build`"
     );
@@ -70,7 +70,7 @@ export const packagePlugin = async (argv: minimist.ParsedArgs) => {
   }
 
   try {
-    await zipDistPath(DIS_PATH, zipFilePath, pluginId);
+    await zipDistPath(DIST_PATH, zipFilePath, pluginId);
     printSuccessMessage(`Successfully created zip archive at ${zipFileName}`);
   } catch (error) {
     printErrorMessage(`Could not create zip file: ${error}`);

--- a/packages/create-plugin/src/commands/package.command.ts
+++ b/packages/create-plugin/src/commands/package.command.ts
@@ -41,6 +41,11 @@ export const packagePlugin = async (argv: minimist.ParsedArgs) => {
   const pluginJsonContent = require(PLUGIN_JSON);
   const pluginId = pluginJsonContent.id;
 
+  if (typeof pluginId !== 'string' || pluginId.length === 0) {
+    printErrorMessage(`Could not find 'id' in 'plugin.json'`);
+    process.exit(1);
+  }
+
   const zipFileName = `${pluginId}.zip`;
   const zipFilePath = path.join(CWD, zipFileName);
 

--- a/packages/create-plugin/src/commands/package.command.ts
+++ b/packages/create-plugin/src/commands/package.command.ts
@@ -1,0 +1,93 @@
+import minimist from 'minimist';
+import fs from 'fs';
+import { confirmPrompt, printErrorMessage, printSuccessMessage } from '../utils/utils.console';
+import archiver from 'archiver';
+import path from 'path';
+
+export const packagePlugin = async (argv: minimist.ParsedArgs) => {
+  const CWD = process.cwd();
+
+  const nonInteractive = argv['non-interactive'];
+
+  const DIS_PATH = path.join(CWD, 'dist');
+  const PLUGIN_JSON = path.join(DIS_PATH, 'plugin.json');
+  const MANIFEST_TXT = path.join(DIS_PATH, 'MANIFEST.txt');
+
+  // validate DIS_PATH exists
+  if (!fs.existsSync(DIS_PATH) || !fs.statSync(DIS_PATH).isDirectory()) {
+    printErrorMessage(
+      "Could not find 'dist' directory. Please build your plugin before running this command. e.g.: `yarn build` or `npm run build`"
+    );
+    process.exit(1);
+  }
+
+  // validate PLUGIN_JSON exists
+  if (!fs.existsSync(PLUGIN_JSON)) {
+    printErrorMessage(
+      "Could not find 'plugin.json' inside 'dist' directory. Please build your plugin before running this command. e.g.: `yarn build` or `npm run build`"
+    );
+    process.exit(1);
+  }
+
+  // if no manifest file, warn user and confirm if wish to continue
+  if (!fs.existsSync(MANIFEST_TXT) && !nonInteractive) {
+    const confirm = await confirmPrompt(
+      `Could not find a 'MANIFEST.txt' file inside 'dist' directory. This means that the plugin is not signed. Would you like to continue generating an unsigned archive file?`
+    );
+    if (!confirm) {
+      process.exit(1);
+    }
+  }
+
+  const pluginJsonContent = require(PLUGIN_JSON);
+  const pluginId = pluginJsonContent.id;
+
+  const zipFileName = `${pluginId}.zip`;
+  const zipFilePath = path.join(CWD, zipFileName);
+
+  // if zip file already exists, warn user and confirm if wish to continue
+  if (fs.existsSync(zipFilePath)) {
+    const confirm =
+      nonInteractive ||
+      (await confirmPrompt(
+        `A zip file with the name '${zipFileName}' already exists. Do you want to continue and overwrite it?`
+      ));
+
+    if (confirm) {
+      try {
+        fs.unlinkSync(zipFilePath);
+      } catch (error) {
+        printErrorMessage(`Could not delete existing zip file: ${error}`);
+        process.exit(1);
+      }
+    } else {
+      process.exit(1);
+    }
+  }
+
+  try {
+    await zipDistPath(DIS_PATH, zipFilePath, pluginId);
+    printSuccessMessage(`Successfully created zip archive at ${zipFileName}`);
+  } catch (error) {
+    printErrorMessage(`Could not create zip file: ${error}`);
+  }
+};
+
+function zipDistPath(path: string, destination: string, pathName: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(destination);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+
+    output.on('close', () => {
+      resolve(destination);
+    });
+
+    archive.on('error', (err) => {
+      reject(err);
+    });
+
+    archive.pipe(output);
+    archive.directory(path, pathName);
+    archive.finalize();
+  });
+}

--- a/packages/create-plugin/src/commands/package.command.ts
+++ b/packages/create-plugin/src/commands/package.command.ts
@@ -9,8 +9,8 @@ export const packagePlugin = async (argv: minimist.ParsedArgs) => {
 
   const CWD = process.cwd();
   const DIST_PATH = path.join(CWD, 'dist');
-  const PLUGIN_JSON = path.join(DIST_PATH, 'plugin.json');
-  const MANIFEST_TXT = path.join(DIST_PATH, 'MANIFEST.txt');
+  const PLUGIN_JSON_PATH = path.join(DIST_PATH, 'plugin.json');
+  const MANIFEST_TXT_PATH = path.join(DIST_PATH, 'MANIFEST.txt');
 
   // validate DIS_PATH exists
   if (!fs.existsSync(DIST_PATH) || !fs.statSync(DIST_PATH).isDirectory()) {
@@ -21,7 +21,7 @@ export const packagePlugin = async (argv: minimist.ParsedArgs) => {
   }
 
   // validate PLUGIN_JSON exists
-  if (!fs.existsSync(PLUGIN_JSON)) {
+  if (!fs.existsSync(PLUGIN_JSON_PATH)) {
     printErrorMessage(
       "Could not find 'plugin.json' inside 'dist' directory. Please build your plugin before running this command. e.g.: `yarn build` or `npm run build`"
     );
@@ -29,7 +29,7 @@ export const packagePlugin = async (argv: minimist.ParsedArgs) => {
   }
 
   // if no manifest file, warn user and confirm if wish to continue
-  if (!fs.existsSync(MANIFEST_TXT) && !nonInteractive) {
+  if (!fs.existsSync(MANIFEST_TXT_PATH) && !nonInteractive) {
     const confirm = await confirmPrompt(
       `Could not find a 'MANIFEST.txt' file inside 'dist' directory. This means that the plugin is not signed. Would you like to continue generating an unsigned archive file?`
     );
@@ -38,7 +38,7 @@ export const packagePlugin = async (argv: minimist.ParsedArgs) => {
     }
   }
 
-  const pluginJsonContent = require(PLUGIN_JSON);
+  const pluginJsonContent = require(PLUGIN_JSON_PATH);
   const pluginId = pluginJsonContent.id;
 
   if (typeof pluginId !== 'string' || pluginId.length === 0) {

--- a/packages/create-plugin/src/commands/package.command.ts
+++ b/packages/create-plugin/src/commands/package.command.ts
@@ -5,10 +5,9 @@ import archiver from 'archiver';
 import path from 'path';
 
 export const packagePlugin = async (argv: minimist.ParsedArgs) => {
-  const CWD = process.cwd();
-
   const nonInteractive = argv['non-interactive'];
 
+  const CWD = process.cwd();
   const DIS_PATH = path.join(CWD, 'dist');
   const PLUGIN_JSON = path.join(DIS_PATH, 'plugin.json');
   const MANIFEST_TXT = path.join(DIS_PATH, 'MANIFEST.txt');

--- a/packages/create-plugin/src/utils/utils.console.ts
+++ b/packages/create-plugin/src/utils/utils.console.ts
@@ -22,6 +22,14 @@ export function printSuccessMessage(msg: string) {
   console.log(displayAsMarkdown(`\n✔ ${msg}`));
 }
 
+export function printWarningMessage(msg: string) {
+  console.log(displayAsMarkdown(`\n⚠ ${msg}`));
+}
+
+export function printErrorMessage(msg: string) {
+  console.log(displayAsMarkdown(`\n❌ ${msg}`));
+}
+
 export function confirmPrompt(message: string): Promise<boolean> {
   const prompt = new Confirm({
     name: 'question',


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces a new command to `create-plugin`: "package".

The `package` command is a helper command to create a zip archive from your dist files with the correct file structure.

You should sign your plugin before running it.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/plugin-tools/issues/491

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@2.7.0-canary.528.42bb84a.0
  # or 
  yarn add @grafana/create-plugin@2.7.0-canary.528.42bb84a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
