### PR TITLE
Docs: Add FAQ on toolkit to publishing section

### DIFF
--- a/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
+++ b/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
@@ -107,6 +107,10 @@ For more information on plugin deprecation and how to request your plugin to be 
 
 - No. We will not accept any new plugin submissions written in Angular. For more information, refer to our [Angular support deprecation documentation](https://grafana.com/docs/grafana/latest/developers/angular_deprecation/).
 
+### Can I submit plugins built with Toolkit?
+
+- The Toolkit is deprecated. Please [migrate to `create-plugin`](../migration-guides/migrate-from-toolkit.mdx). In the future, we will reject submissions based on Toolkit as it becomes increasingly out-of-date.
+
 ### Do plugin signatures expire?
 
 - Plugin signatures do not currently expire.

--- a/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
+++ b/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
@@ -109,7 +109,7 @@ For more information on plugin deprecation and how to request your plugin to be 
 
 ### Can I submit plugins built with Toolkit?
 
-- The Toolkit is deprecated. Please [migrate to `create-plugin`](../migration-guides/migrate-from-toolkit.mdx). In the future, we will reject submissions based on Toolkit as it becomes increasingly out-of-date.
+- The @grafana/toolkit tool is deprecated. Please [migrate to `create-plugin`](../migration-guides/migrate-from-toolkit.mdx). In the future, we will reject submissions based on @grafana/toolkit as it becomes increasingly out-of-date.
 
 ### Do plugin signatures expire?
 


### PR DESCRIPTION
Add new FAQ on toolkit deprecation to https://grafana.com/developers/plugin-tools/publish-a-plugin/publish-a-plugin

Fixes https://github.com/grafana/grafana/issues/68635

Note: Issue 68635 requests adding a note to the "Sign a plugin" page, but I didn't see a specific relevance to signing. Open to suggestions though for a specific note/location.