### PR TITLE
Plugin E2E: Add first fixtures

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,20 +19,16 @@ jobs:
         uses: actions/setup-node@v3
 
       - name: Install dependencies
-        run: npm i
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
+        run: npm ci
 
       - name: Build frontend
         run: npm run build --w @grafana/plugin-e2e
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
 
       - name: Start Grafana
-        run: docker run --rm -d -p 3001:3000 --name=grafana grafana/grafana:${{ matrix.GRAFANA_VERSION }}; sleep 30
+        run: docker run --rm -d -p 3000:3000 --name=grafana grafana/grafana:${{ matrix.GRAFANA_VERSION }}; sleep 30
 
       - name: Run Playwright tests
         run: npm run playwright:test --w @grafana/plugin-e2e

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,45 @@
+name: E2E tests - Playwright
+on:
+  pull_request:
+    paths:
+      - 'packages/plugin-e2e/**'
+
+jobs:
+  playwright-tests:
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        GRAFANA_VERSION: ['latest', '9.5.5']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        run: npm i --w @grafana/plugin-e2e
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+
+      - name: Build frontend
+        run: npm run build --w @grafana/plugin-e2e
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Start Grafana
+        run: docker run --rm -d -p 3001:3000 --name=grafana grafana/grafana:${{ matrix.GRAFANA_VERSION }}; sleep 30
+
+      - name: Run Playwright tests
+        run: npm run playwright:test --w @grafana/plugin-e2e
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report-${{ matrix.GRAFANA_VERSION }}
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v3
 
       - name: Install dependencies
-        run: npm i --w @grafana/plugin-e2e
+        run: npm i
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
 

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ yarn-error.log*
 
 # Ignore nx cloud env file. Can be used locally for setting a different NX_CLOUD_ACCESS_TOKEN
 nx-cloud.env
+
+# End to End tests
+playwright-report/
+packages/plugin-e2e/playwright/.cache/
+packages/plugin-e2e/playwright/.auth

--- a/package-lock.json
+++ b/package-lock.json
@@ -6148,6 +6148,21 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.39.0.tgz",
+      "integrity": "sha512-3u1iFqgzl7zr004bGPYiN/5EZpRUSFddQBra8Rqll5N0/vfpqlP9I9EXqAoGacuAbX6c9Ulg/Cjqglp5VkK6UQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -25269,6 +25284,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.39.0.tgz",
+      "integrity": "sha512-naE5QT11uC/Oiq0BwZ50gDmy8c8WLPRTEWuSSFVG2egBka/1qMoSqYQcROMT9zLwJ86oPofcTH2jBY/5wWOgIw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.39.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.39.0.tgz",
+      "integrity": "sha512-+k4pdZgs1qiM+OUkSjx96YiKsXsmb59evFoqv8SKO067qBA+Z2s/dCzJij/ZhdQcs2zlTAgRKfeiiLm8PQ2qvw==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/plop": {
       "version": "2.7.6",
       "license": "MIT",
@@ -31910,9 +31955,13 @@
       }
     },
     "packages/plugin-e2e": {
+      "name": "@grafana/plugin-e2e",
       "version": "0.0.1",
       "license": "Apache-2.0",
-      "devDependencies": {},
+      "devDependencies": {
+        "@playwright/test": "^1.39.0",
+        "semver": "^7.5.4"
+      },
       "engines": {
         "node": ">=20"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31964,6 +31964,9 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1.39.0"
       }
     },
     "packages/sign-plugin": {

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -33,5 +33,11 @@
   "engines": {
     "node": ">=20"
   },
-  "devDependencies": {}
+  "peerDependencies": {
+    "@playwright/test": "^1.39.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.39.0",
+    "semver": "^7.5.4"
+  }
 }

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -1,3 +1,5 @@
+// This file is not part of the @grafana/plugin-e2e package. It's only used for testing the plugin-e2e package itself.
+
 import { defineConfig, devices } from '@playwright/test';
 import { PluginOptions } from './src';
 

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+import { PluginOptions } from './src';
+
+export default defineConfig<PluginOptions>({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:3001',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+    httpCredentials: {
+      username: 'admin',
+      password: 'admin',
+    },
+  },
+
+  /* List of projects to run. See https://playwright.dev/docs/test-configuration#projects */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.auth/user.json',
+      },
+    },
+  ],
+});

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -32,7 +32,6 @@ export default defineConfig<PluginOptions>({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        storageState: 'playwright/.auth/user.json',
       },
     },
   ],

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig<PluginOptions>({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3001',
+    baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/packages/plugin-e2e/src/api.ts
+++ b/packages/plugin-e2e/src/api.ts
@@ -1,0 +1,27 @@
+import { test as base } from '@playwright/test';
+import { E2ESelectors } from './e2e-selectors/types';
+import fixtures from './fixtures';
+
+export type PluginOptions = {
+  selectorRegistration: void;
+};
+
+export type PluginFixture = {
+  /**
+   * The current Grafana version.
+   *
+   * If a GRAFANA_VERSION environment variable is set, this will be used. Otherwise,
+   * the version will be picked from window.grafanaBootData.settings.buildInfo.version.
+   */
+  grafanaVersion: string;
+
+  /**
+   * The E2E selectors to use for the current version of Grafana
+   */
+  selectors: E2ESelectors;
+};
+
+// extend Playwright with Grafana plugin specific fixtures
+export const test = base.extend<PluginFixture & PluginOptions>(fixtures);
+
+export { selectors, expect } from '@playwright/test';

--- a/packages/plugin-e2e/src/fixtures/grafanaVersion.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaVersion.ts
@@ -1,0 +1,17 @@
+import { TestFixture } from '@playwright/test';
+import { PluginFixture, PluginOptions } from '../api';
+import { PlaywrightCombinedArgs } from './types';
+
+type GrafanaVersion = TestFixture<string, PluginFixture & PluginOptions & PlaywrightCombinedArgs>;
+
+const grafanaVersion: GrafanaVersion = async ({ page }, use) => {
+  let grafanaVersion = process.env.GRAFANA_VERSION;
+  if (!grafanaVersion) {
+    await page.goto('/');
+    grafanaVersion = await page.evaluate('window.grafanaBootData.settings.buildInfo.version');
+  }
+
+  await use(grafanaVersion.replace(/\-.*/, ''));
+};
+
+export default grafanaVersion;

--- a/packages/plugin-e2e/src/fixtures/index.ts
+++ b/packages/plugin-e2e/src/fixtures/index.ts
@@ -1,0 +1,7 @@
+import grafanaVersion from './grafanaVersion';
+import selectors from './selectors';
+
+export default {
+  selectors,
+  grafanaVersion,
+};

--- a/packages/plugin-e2e/src/fixtures/selectors.ts
+++ b/packages/plugin-e2e/src/fixtures/selectors.ts
@@ -1,0 +1,22 @@
+import { TestFixture } from '@playwright/test';
+import { PluginFixture, PluginOptions } from '../api';
+import { E2ESelectors, resolveSelectors } from '../e2e-selectors';
+import { versionedComponents, versionedPages } from '../e2e-selectors/versioned';
+import { PlaywrightCombinedArgs } from './types';
+import { versionedAPIs } from '../e2e-selectors/versioned/apis';
+
+type SelectorFixture = TestFixture<E2ESelectors, PluginFixture & PluginOptions & PlaywrightCombinedArgs>;
+
+const selectors: SelectorFixture = async ({ grafanaVersion }, use) => {
+  const selectors = resolveSelectors(
+    {
+      components: versionedComponents,
+      pages: versionedPages,
+      apis: versionedAPIs,
+    },
+    grafanaVersion
+  );
+  await use(selectors);
+};
+
+export default selectors;

--- a/packages/plugin-e2e/src/fixtures/types.ts
+++ b/packages/plugin-e2e/src/fixtures/types.ts
@@ -1,0 +1,11 @@
+import {
+  PlaywrightTestArgs,
+  PlaywrightTestOptions,
+  PlaywrightWorkerArgs,
+  PlaywrightWorkerOptions,
+} from '@playwright/test';
+
+export type PlaywrightCombinedArgs = PlaywrightTestArgs &
+  PlaywrightTestOptions &
+  PlaywrightWorkerArgs &
+  PlaywrightWorkerOptions;

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -1,1 +1,3 @@
+export { expect, test, type PluginFixture, type PluginOptions } from './api';
 export * from './e2e-selectors';
+export * from './fixtures';

--- a/packages/plugin-e2e/tests/README.md
+++ b/packages/plugin-e2e/tests/README.md
@@ -1,0 +1,3 @@
+# Playwright E2E Tests
+
+The Playwright tests in this folder are not part of the @grafana/plugin-e2e package. The tests are here to make it easier to test the package without having to make a release of the package or link the package from a plugin.

--- a/packages/plugin-e2e/tests/selectors.spec.ts
+++ b/packages/plugin-e2e/tests/selectors.spec.ts
@@ -1,0 +1,18 @@
+import * as semver from 'semver';
+import { test, expect } from '../src';
+
+test('should resolve ds picker selector with test id for grafana 10 and later', async ({
+  grafanaVersion,
+  selectors,
+}, testInfo) => {
+  testInfo.skip(semver.lt(grafanaVersion, '10.0.0'));
+  expect(selectors.components.DataSourcePicker.container).toBe('data-testid Data source picker select container');
+});
+
+test('should resolve ds picker selector without test id for grafana 10 and later', async ({
+  grafanaVersion,
+  selectors,
+}, testInfo) => {
+  testInfo.skip(semver.gte(grafanaVersion, '10.0.0'));
+  expect(selectors.components.DataSourcePicker.container).toBe('Data source picker select container');
+});


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds two new Playwright fixtures for resolving grafana version and selectors (for the given grafana version). Also added a simple playwright e2e test that showcases how these fixtures can be used in practise. There's a simple GH action that will run the tests in two versions of Grafana, just to demonstrate the resolving of selectors work. 

If you want to run tests on your local machine: 
```bash
GRAFANA_VERSION=<version> npm run server --w @grafana/plugin-e2e
#in another terminal
npm run playwright:test --w @grafana/plugin-e2e
```

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/78078
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Adding an nvmrc file for this workspace only. Is that a bad idea?
