### PR TITLE
Mention new alerting extension point PR in docs

### DIFF
--- a/docusaurus/docs/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/ui-extensions/register-an-extension.md
@@ -122,5 +122,6 @@ new AppPlugin().configureExtensionLink({
 
 An _extension point_ is a location within the Grafana UI where a plugin can insert links. The IDs of all extension points within Grafana start with `grafana/`. For example, you can use the following extension point ID:
 
+- `grafana/alerting/instance/action`: extension point for actions in alert instance table in alerting
 - `grafana/dashboard/panel/menu`: extension point for all panel dropdown menus in dashboards
 - `grafana/explore/toolbar/action`: extension point for toolbar actions in explore


### PR DESCRIPTION
If/when https://github.com/grafana/grafana/pull/77900 is merged there will be a new extension point which plugin developers can register against. This PR adds the ID of the extension point to the `register-an-extension` docs.