### PR TITLE
Docs: Add example for component extensions

### DIFF
--- a/docusaurus/docs/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/ui-extensions/register-an-extension.md
@@ -123,7 +123,7 @@ new AppPlugin().configureExtensionLink({
 Using React components as extensions is a powerful way to extend the functionality of an existing UI either in core Grafana or in an other plugin.
 
 ```ts title="src/module.ts"
-new AppPlugin().configureExtensionLink({
+new AppPlugin().configureExtensionComponent({
   title: 'My component extension',
   description: 'Renders a button at a pre-defined extension point.',
   extensionPointId: 'grafana/<extension-point-id>',
@@ -135,6 +135,35 @@ new AppPlugin().configureExtensionLink({
 export const MyExtension = () => (
   <Button onClick={() => {}} variant="secondary" type="button">
     Extend UI
+  </Button>
+);
+```
+
+### Example: Use the context of the extension point in a component
+
+Extension points can pass contextual information to the extensions they render, we refer to this data as `context`.
+In case it is a core extension point (defined in core Grafana), there is also always a type definition available for these context objects. In the following example we will cover how to use this `context` in our component extension and also get the static types right.
+
+```ts title="src/module.ts"
+// This could also come from another plugin or defined manually if a plugin doesn't expose it.
+import { PluginExtensionSampleContext } from '@grafana/data';
+
+new AppPlugin().configureExtensionComponent<PluginExtensionSampleContext>({
+  title: 'My component extension',
+  description: 'Renders a button at a pre-defined extension point.',
+  extensionPointId: 'grafana/<extension-point-id>',
+  component: MyExtension,
+});
+```
+
+```tsx title="src/components/MyExtension.tsx"
+type Props = {
+  context: PluginExtensionSampleContext;
+};
+
+export const MyExtension = ({ context }: Props) => (
+  <Button onClick={() => {}} variant="secondary" type="button">
+    Create incident from {context.name}
   </Button>
 );
 ```

--- a/docusaurus/docs/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/ui-extensions/register-an-extension.md
@@ -118,6 +118,27 @@ new AppPlugin().configureExtensionLink({
 });
 ```
 
+### Example: Display a React component
+
+Using React components as extensions is a powerful way to extend the functionality of an existing UI either in core Grafana or in an other plugin.
+
+```ts title="src/module.ts"
+new AppPlugin().configureExtensionLink({
+  title: 'My component extension',
+  description: 'Renders a button at a pre-defined extension point.',
+  extensionPointId: 'grafana/<extension-point-id>',
+  component: MyExtension,
+});
+```
+
+```tsx title="src/components/MyExtension.tsx"
+export const MyExtension = () => (
+  <Button onClick={() => {}} variant="secondary" type="button">
+    Extend UI
+  </Button>
+);
+```
+
 ## Available extension points within Grafana
 
 An _extension point_ is a location within the Grafana UI where a plugin can insert links. The IDs of all extension points within Grafana start with `grafana/`. For example, you can use the following extension point ID:

--- a/docusaurus/docs/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/ui-extensions/register-an-extension.md
@@ -168,6 +168,36 @@ export const MyExtension = ({ context }: Props) => (
 );
 ```
 
+### Example: Access plugin information in a component extension
+
+It can happen that we would like to access some meta information of our plugin inside the component extension dynamically. `@grafana/data` exposes some helper hooks to make it possible:
+
+```ts title="src/module.ts"
+new AppPlugin().configureExtensionComponent({
+  title: 'My component extension',
+  description: 'Renders a button at a pre-defined extension point.',
+  extensionPointId: 'grafana/<extension-point-id>',
+  component: MyExtension,
+});
+```
+
+```tsx title="src/components/MyExtension.tsx"
+import { usePluginMeta, usePluginJsonData } from '@grafana/data';
+
+export const MyExtension = () => (
+  const meta = usePluginMeta();
+  const jsonData = usePluginJsonData();
+
+  if (meta.info.version !== '1.0.0') {
+    return null;
+  }
+
+  <Button onClick={() => {}} variant="secondary" type="button">
+    Create incident ({jsonData.postFix})
+  </Button>
+);
+```
+
 ## Available extension points within Grafana
 
 An _extension point_ is a location within the Grafana UI where a plugin can insert links. The IDs of all extension points within Grafana start with `grafana/`. For example, you can use the following extension point ID:


### PR DESCRIPTION
**Dependant on:** https://github.com/grafana/grafana/pull/78111

### What changed?

Added examples about how to register component type extensions.