### PR TITLE
Templates: import DataQuery from `@grafana/schema` instead of `@grafana/data`

### DIFF
--- a/packages/create-plugin/templates/datasource/src/types.ts
+++ b/packages/create-plugin/templates/datasource/src/types.ts
@@ -1,4 +1,5 @@
-import { DataQuery, DataSourceJsonData } from '@grafana/data';
+import { DataSourceJsonData } from '@grafana/data';
+import { DataQuery } from '@grafana/schema';
 
 export interface MyQuery extends DataQuery {
   queryText?: string;


### PR DESCRIPTION
**What this PR does / why we need it**:

The import of `DataQuery` from `@grafana/data` is marked as deprecated.
This PR imports it from `@grafana/schema` instead, which is the suggested solution.
This removes a warning from the code editor.

**Which issue(s) this PR fixes**:

Fixes #389 

**Special notes for your reviewer**:
