### PR TITLE
Create Plugin: Allow users to adopt CI/CD during update

### DIFF
--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/set-up-github-workflows.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/set-up-github-workflows.md
@@ -16,6 +16,13 @@ sidebar_position: 4
 
 Automate your development process to minimize errors and make it faster and more cost-efficient. The `create-plugin` tool helps you to configure your GitHub actions workflows to help automate your development process.
 
+:::tip
+
+Want to add the `create-plugin` Github workflows to your existing plugin? Run `npx @grafana/create-plugin@latest cicd` in an existing plugin to generate the `ci.yml` and `release.yml`
+workflows.
+
+:::
+
 ## The CI workflow
 
 The CI (`ci.yml`) workflow is designed to lint, type check, and build the frontend and backend. It is also used to run tests on your plugin every time you push changes to your repository. The `create-plugin` tool helps to catch any issues early in the development process, before they become bigger problems.

--- a/packages/create-plugin/src/bin/run.ts
+++ b/packages/create-plugin/src/bin/run.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import minimist from 'minimist';
-import { generate, update, migrate, version, provisioning } from '../commands/index.js';
+import { generate, update, migrate, version, provisioning, cicd } from '../commands/index.js';
 import { isUnsupportedPlatform } from '../utils/utils.os.js';
 import { argv, commandName } from '../utils/utils.cli.js';
 
@@ -19,6 +19,7 @@ const commands: Record<string, (argv: minimist.ParsedArgs) => void> = {
   update,
   version,
   provisioning,
+  cicd,
 };
 const command = commands[commandName] || 'generate';
 

--- a/packages/create-plugin/src/commands/cicd.command.ts
+++ b/packages/create-plugin/src/commands/cicd.command.ts
@@ -1,0 +1,12 @@
+import { TEXT } from '../constants';
+import { adoptCI } from '../utils/utils.templates';
+import { confirmPrompt, printMessage, printSuccessMessage } from '../utils/utils.console';
+
+export const cicd = async () => {
+  if (await confirmPrompt(TEXT.adoptCIPrompt)) {
+    adoptCI();
+    printSuccessMessage(TEXT.adoptCISuccess);
+  } else {
+    printMessage(TEXT.adoptCIAborted);
+  }
+};

--- a/packages/create-plugin/src/commands/cicd.command.ts
+++ b/packages/create-plugin/src/commands/cicd.command.ts
@@ -1,6 +1,6 @@
-import { TEXT } from '../constants';
-import { adoptCI } from '../utils/utils.templates';
-import { confirmPrompt, printMessage, printSuccessMessage } from '../utils/utils.console';
+import { TEXT } from '../constants.js';
+import { adoptCI } from '../utils/utils.templates.js';
+import { confirmPrompt, printMessage, printSuccessMessage } from '../utils/utils.console.js';
 
 export const cicd = async () => {
   if (await confirmPrompt(TEXT.adoptCIPrompt)) {

--- a/packages/create-plugin/src/commands/index.ts
+++ b/packages/create-plugin/src/commands/index.ts
@@ -3,4 +3,4 @@ export * from './update.command.js';
 export * from './migrate.command.js';
 export * from './version.command.js';
 export * from './provisioning.command.js';
-export * from './cicd.command';
+export * from './cicd.command.js';

--- a/packages/create-plugin/src/commands/index.ts
+++ b/packages/create-plugin/src/commands/index.ts
@@ -3,3 +3,4 @@ export * from './update.command.js';
 export * from './migrate.command.js';
 export * from './version.command.js';
 export * from './provisioning.command.js';
+export * from './cicd.command';

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -121,6 +121,10 @@ export const TEXT = {
   updateNpmScriptsSuccess: 'NPM scripts updated successfully.',
   updateNpmScriptsAborted: 'No NPM scripts have been added or updated.',
 
+  adoptCIPrompt: '**Do you want to adopt the Github CI and Release workflows?\nThis will replace any existing files in the `github` directory.**',
+  adoptCISuccess: 'Github CI and Release workflows adopted successfully.',
+  adoptCIAborted: 'No Github CI and Release workflows have been adopted.',
+  
   migrationCommandWarning:  '**⚠️  Warning!**\nThis is going to change files in your current project to make it up-to-date with the latest plugin configuration.\nPlease make sure that you have backed up your changes.',
   migrationCommandSuccess: `
 ## What's next?

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -119,3 +119,12 @@ export function getTemplateData(): TemplateData {
 
   return templateData;
 }
+
+export function adoptCI() {
+  const data = getTemplateData();
+  const ciFiles = glob.sync(`${TEMPLATE_PATHS.ciWorkflows}/**/*.yml`, { dot: true });
+  ciFiles.forEach((file) => {
+    const fileData = renderTemplateFromFile(file, data);
+    fs.writeFileSync(`.github/workflows/${path.basename(file)}`, fileData);
+  });
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently the GitHub workflow files are only generated during the `generate` command. Running `update` doesn't do anything with workflows and for good reason since users who run `update` _probably_ have CI/CD configured already. However, I ran into a situation recently where a datasource would have benefited from being able to "adopt" the workflow files.

#541 and #543 will potentially make this less destructive and we could explore just printing the necessary `yml` config to `stdout` at that point since the line count of the config will be much smaller.

With this change users can now run `npx @grafana/create-plugin@latest cicd` to explicitly adopt the Github Actions workflows.