### PR TITLE
Adding codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# these will be requested for review when someone opens a pull request.
+* @grafana/plugins-platform-frontend


### PR DESCRIPTION
A lot of dependabot dependency updates do not get auto assigned to anyone and get stale. This adds codeowners file to avoid that.