### PR TITLE
Docs: Mention new command palette extension point and add example

### DIFF
--- a/docusaurus/docs/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/ui-extensions/register-an-extension.md
@@ -218,6 +218,28 @@ export const MyExtension = () => {
 };
 ```
 
+### Example: Add an item to Grafana's command palette
+
+:::note
+
+**Available in Grafana >=10.3.0** <br /> (_The `grafana/commandpalette/action` extension point is only available in Grafana 10.3.0 and above._)
+
+:::
+
+```ts title="src/module.ts"
+new AppPlugin().configureExtensionComponent({
+  title: 'Frobnicate dashboards',
+  description: 'Opens a modal where the user can frobnicate dashboards',
+  extensionPointId: 'grafana/commandpalette/action',
+  onClick: (event, { openModal }) => {
+    openModal({
+      title: 'Frobnicate dashboards',
+      body: (props) => <MyModalComponent {...props} />
+    });
+  }
+});
+```
+
 ## Available extension points within Grafana
 
 An _extension point_ is a location within the Grafana UI where a plugin can insert links. The IDs of all extension points within Grafana start with `grafana/`. For example, you can use the following extension point ID:

--- a/docusaurus/docs/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/ui-extensions/register-an-extension.md
@@ -223,6 +223,7 @@ export const MyExtension = () => {
 An _extension point_ is a location within the Grafana UI where a plugin can insert links. The IDs of all extension points within Grafana start with `grafana/`. For example, you can use the following extension point ID:
 
 - `grafana/alerting/instance/action`: extension point for actions in alert instance table in alerting
+- `grafana/commandpalette/action`: extension point for commands in command palette
 - `grafana/dashboard/panel/menu`: extension point for all panel dropdown menus in dashboards
 - `grafana/explore/toolbar/action`: extension point for toolbar actions in explore
 - `grafana/user/profile/tab`: extension point for a tab of content on the `/profile` page


### PR DESCRIPTION
This extension point was added in https://github.com/grafana/grafana/pull/78098.
