### PR TITLE
CI: Remove custom npm cache for generated plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: npm exec nx run @grafana/create-plugin:${{ matrix.cmd }}
 
       - name: Install generated plugin dependencies
-        run: npm install --prefer-offline --no-audit
+        run: npm ci
         working-directory: ./packages/create-plugin/generated
 
       - name: Lint plugin frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         run: npm exec nx run @grafana/create-plugin:${{ matrix.cmd }}
 
       - name: Install generated plugin dependencies
-        run: npm ci
+        run: npm install --no-audit
         working-directory: ./packages/create-plugin/generated
 
       - name: Lint plugin frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           path: |
             ./packages/create-plugin/generated/package-lock.json
             ./packages/create-plugin/generated/node_modules
-          key: ${{ matrix.cmd }}-${{ hashFiles('./packages/create-plugin/generated/package-lock.json') }}
+          key: ${{ matrix.cmd }}-${{ hashFiles('./packages/create-plugin/generated/package.json') }}
 
       - name: Install generated plugin dependencies
         run: npm install --prefer-offline --no-audit
@@ -126,7 +126,7 @@ jobs:
           path: |
             ./packages/create-plugin/generated/package-lock.json
             ./packages/create-plugin/generated/node_modules
-          key: ${{ matrix.cmd }}-${{ hashFiles('./packages/create-plugin/generated/package-lock.json') }}
+          key: ${{ matrix.cmd }}-${{ hashFiles('./packages/create-plugin/generated/package.json') }}
 
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,6 @@ jobs:
       - name: Generate plugin
         run: npm exec nx run @grafana/create-plugin:${{ matrix.cmd }}
 
-      - name: Restore cached generated plugin dependencies
-        id: cache-generated-deps-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ./packages/create-plugin/generated/package-lock.json
-            ./packages/create-plugin/generated/node_modules
-          key: ${{ matrix.cmd }}-${{ hashFiles('./packages/create-plugin/generated/package.json') }}
-
       - name: Install generated plugin dependencies
         run: npm install --prefer-offline --no-audit
         working-directory: ./packages/create-plugin/generated
@@ -117,16 +108,6 @@ jobs:
           GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
         run: node ../../sign-plugin/dist/bin/run.js --rootUrls http://www.example.com --signatureType private
         working-directory: ./packages/create-plugin/generated
-
-      - name: Save generated plugin dependencies
-        id: cache-generated-deps-save
-        if: ${{ steps.cache-generated-deps-restore.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ./packages/create-plugin/generated/package-lock.json
-            ./packages/create-plugin/generated/node_modules
-          key: ${{ matrix.cmd }}-${{ hashFiles('./packages/create-plugin/generated/package.json') }}
 
       - uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Changes to dependencies in "generated" plugins aren't correctly matched / missed when restoring npm caches. The key appears to fallback to matches that can lead to failed builds if there are peer dependency mismatches. Rather than cause devs bother I'd rather we remove it for the time being.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
