### PR TITLE
Chore: Group updates to docusaurus dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   # Check for updates to GitHub Actions every month
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:      
+    schedule:
       interval: "monthly"
     labels:
         - "github_actions"
@@ -21,3 +21,6 @@ updates:
       - "javascript"
       - "dependencies"
       - "no stalebot"
+    groups:
+    # All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.0.1).
+      - "@docusaurus/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,7 @@ updates:
       - "dependencies"
       - "no stalebot"
     groups:
-    # All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.0.1).
-      - "@docusaurus/*"
+      # All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.0.1).
+      docusaurus:
+        patterns:
+        - "@docusaurus/*"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/deploy-to-developer-portal-prod.yml'
       - '.github/workflows/test-build.yml'
       - 'docusaurus/**'
+      - 'package-lock.json'
 
 jobs:
   deploy:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Trying to test any of the current batch of docusaurus dependency updates results in errors like:

```
> nx run website:start

> website@2.5.0 start
> docusaurus start
[INFO] Starting the development server...
Error: Invalid name=docusaurus-plugin-content-docs version number=3.0.0.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (number=3.0.1).
Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
... some stacktrace
[INFO] Docusaurus version: 3.0.1
Node version: v20.9.0
npm ERR! Lifecycle script `start` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: website@2.5.0 
npm ERR!   at location: /Users/jackwestbrook/dev/grafana/plugin-tools/docusaurus/website 
```

This PR changes the dependabot config to group `@docusaurus/*` updates into a single PR. It also updates the website build ci script to act on changes to `package-lock.json` to catch issues related to dependabot bumping website dependencies.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
