### PR TITLE
Plugin E2E: Harmonise model instantiation and navigation

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -463,7 +463,11 @@ export type Pages = {
         title: string;
       };
       Annotations: {
+        Edit: {
+          url: (dashboardUid: string, annotationIndex: string) => string;
+        };
         List: {
+          url: (uid: string) => string;
           /**
            * @deprecated use addAnnotationCTAV2 from Grafana 8.3 instead
            */

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -426,7 +426,12 @@ export type Pages = {
         };
       };
       Variables: {
-        url: string;
+        List: {
+          url: string;
+        };
+        Edit: {
+          url: (variableIndex: string) => string;
+        };
       };
     };
   };
@@ -485,6 +490,7 @@ export type Pages = {
       };
       Variables: {
         List: {
+          url: (dashboardUid: string) => string;
           newButton: string;
           table: string;
           tableRowNameFields: (variableName: string) => string;
@@ -497,6 +503,7 @@ export type Pages = {
           addVariableCTAV2Item: string;
         };
         Edit: {
+          url: (dashboardUid: string, editIndex: string) => string;
           General: {
             headerLink: string;
             modeLabelNew: string;

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
@@ -116,7 +116,12 @@ export const versionedPages = {
         title: 'Tab General',
       },
       Annotations: {
+        Edit: {
+          url: (dashboardUid: string, annotationIndex: string) =>
+            `${versionedPages.Dashboard.url(dashboardUid)}?editview=annotations&editIndex=${annotationIndex}`,
+        },
         List: {
+          url: (dashboardUid: string) => `${versionedPages.Dashboard.url(dashboardUid)}?editview=annotations`,
           addAnnotationCTA: 'Call to action button Add annotation query',
           addAnnotationCTAV2: 'data-testid Call to action button Add annotation query',
         },

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
@@ -71,7 +71,12 @@ export const versionedPages = {
         },
       },
       Variables: {
-        url: '/dashboard/new?orgId=1&editview=templating',
+        List: {
+          url: '/dashboard/new?orgId=1&editview=templating',
+        },
+        Edit: {
+          url: (annotationIndex: string) => `/dashboard/new?orgId=1&editview=templating&editIndex=${annotationIndex}`,
+        },
       },
     },
   },
@@ -136,6 +141,7 @@ export const versionedPages = {
       },
       Variables: {
         List: {
+          url: (dashboardUid: string) => `${versionedPages.Dashboard.url(dashboardUid)}?editview=templating`,
           newButton: 'Variable editor New variable button',
           table: 'Variable editor Table',
           tableRowNameFields: (variableName: string) => `Variable editor Table Name field ${variableName}`,
@@ -150,6 +156,10 @@ export const versionedPages = {
           },
         },
         Edit: {
+          url: {
+            [MIN_GRAFANA_VERSION]: (dashboardUid: string, editIndex: string) =>
+              `${versionedPages.Dashboard.url(dashboardUid)}?editview=templating&editIndex=${editIndex}`,
+          },
           General: {
             headerLink: 'Variable editor Header link',
             modeLabelNew: 'Variable editor Header mode New',

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -1,3 +1,4 @@
 export { expect, test, type PluginFixture, type PluginOptions } from './api';
 export * from './e2e-selectors';
 export * from './fixtures';
+export * from './models';

--- a/packages/plugin-e2e/src/models/AnnotationEditPage.ts
+++ b/packages/plugin-e2e/src/models/AnnotationEditPage.ts
@@ -4,7 +4,7 @@ import { GrafanaPage } from './GrafanaPage';
 
 export class AnnotationEditPage extends GrafanaPage {
   datasource: DataSourcePicker;
-  constructor(ctx: PluginTestCtx, private args: DashboardEditViewArgs<string>) {
+  constructor(readonly ctx: PluginTestCtx, readonly args: DashboardEditViewArgs<string>) {
     super(ctx);
     this.datasource = new DataSourcePicker(ctx);
   }

--- a/packages/plugin-e2e/src/models/AnnotationEditPage.ts
+++ b/packages/plugin-e2e/src/models/AnnotationEditPage.ts
@@ -1,12 +1,21 @@
 import { DataSourcePicker } from './DataSourcePicker';
-import { PluginTestCtx, RequestOptions } from '../types';
+import { DashboardEditViewArgs, NavigateOptions, PluginTestCtx, RequestOptions } from '../types';
 import { GrafanaPage } from './GrafanaPage';
 
 export class AnnotationEditPage extends GrafanaPage {
   datasource: DataSourcePicker;
-  constructor(ctx: PluginTestCtx) {
+  constructor(ctx: PluginTestCtx, private args: DashboardEditViewArgs<string>) {
     super(ctx);
     this.datasource = new DataSourcePicker(ctx);
+  }
+
+  async goto(options?: NavigateOptions) {
+    const { Dashboard, AddDashboard } = this.ctx.selectors.pages;
+    const url = this.args.dashboard?.uid
+      ? Dashboard.Settings.Annotations.Edit.url(this.args.dashboard.uid, this.args.id)
+      : AddDashboard.Settings.Annotations.Edit.url(this.args.id);
+
+    return super.navigate(url, options);
   }
 
   /**

--- a/packages/plugin-e2e/src/models/AnnotationPage.ts
+++ b/packages/plugin-e2e/src/models/AnnotationPage.ts
@@ -1,27 +1,43 @@
 import * as semver from 'semver';
-import { PluginTestCtx } from '../types';
+import { DashboardPageArgs, NavigateOptions, PluginTestCtx } from '../types';
 import { AnnotationEditPage } from './AnnotationEditPage';
 import { GrafanaPage } from './GrafanaPage';
 
 export class AnnotationPage extends GrafanaPage {
-  constructor(ctx: PluginTestCtx) {
+  constructor(ctx: PluginTestCtx, private dashboard?: DashboardPageArgs) {
     super(ctx);
   }
 
-  async goto() {
-    await this.ctx.page.goto(this.ctx.selectors.pages.AddDashboard.Settings.Annotations.List.url, {
-      waitUntil: 'networkidle',
-    });
+  async goto(options?: NavigateOptions) {
+    const { Dashboard, AddDashboard } = this.ctx.selectors.pages;
+    let url = this.dashboard?.uid
+      ? Dashboard.Settings.Annotations.List.url(this.dashboard.uid)
+      : AddDashboard.Settings.Annotations.List.url;
+
+    return super.navigate(url, options);
   }
 
   async clickAddNew() {
     const { Dashboard } = this.ctx.selectors.pages;
 
-    if (semver.gte(this.ctx.grafanaVersion, '8.3.0')) {
-      await this.getByTestIdOrAriaLabel(Dashboard.Settings.Annotations.List.addAnnotationCTAV2).click();
+    if (!this.dashboard?.uid) {
+      //the dashboard doesn't have any annotations yet (except for the built-in one)
+      if (semver.gte(this.ctx.grafanaVersion, '8.3.0')) {
+        await this.getByTestIdOrAriaLabel(Dashboard.Settings.Annotations.List.addAnnotationCTAV2).click();
+      } else {
+        await this.getByTestIdOrAriaLabel(Dashboard.Settings.Annotations.List.addAnnotationCTA).click();
+      }
     } else {
-      await this.getByTestIdOrAriaLabel(Dashboard.Settings.Annotations.List.addAnnotationCTA).click();
+      //the dashboard already has annotations
+      //TODO: add new selector and use it in grafana/ui
+      await this.ctx.page.getByRole('button', { name: 'New query' }).click();
     }
-    return new AnnotationEditPage(this.ctx);
+
+    const editIndex = await this.ctx.page.evaluate(() => {
+      const urlParams = new URLSearchParams(window.location.search);
+      return urlParams.get('editIndex');
+    });
+
+    return new AnnotationEditPage(this.ctx, { id: editIndex || '1' });
   }
 }

--- a/packages/plugin-e2e/src/models/AnnotationPage.ts
+++ b/packages/plugin-e2e/src/models/AnnotationPage.ts
@@ -4,7 +4,7 @@ import { AnnotationEditPage } from './AnnotationEditPage';
 import { GrafanaPage } from './GrafanaPage';
 
 export class AnnotationPage extends GrafanaPage {
-  constructor(ctx: PluginTestCtx, private dashboard?: DashboardPageArgs) {
+  constructor(readonly ctx: PluginTestCtx, readonly dashboard?: DashboardPageArgs) {
     super(ctx);
   }
 

--- a/packages/plugin-e2e/src/models/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/DashboardPage.ts
@@ -1,5 +1,5 @@
 const gte = require('semver/functions/gte');
-import { GotoDashboardArgs, PluginTestCtx } from '../types';
+import { DashboardPageArgs, NavigateOptions, PluginTestCtx } from '../types';
 import { DataSourcePicker } from './DataSourcePicker';
 import { GrafanaPage } from './GrafanaPage';
 import { PanelEditPage } from './PanelEditPage';
@@ -9,32 +9,30 @@ export class DashboardPage extends GrafanaPage {
   dataSourcePicker: any;
   timeRange: TimeRange;
 
-  constructor(ctx: PluginTestCtx, protected readonly dashboardUid?: string) {
+  constructor(ctx: PluginTestCtx, private dashboard?: DashboardPageArgs) {
     super(ctx);
     this.dataSourcePicker = new DataSourcePicker(ctx);
     this.timeRange = new TimeRange(ctx);
   }
 
-  async goto(opts?: GotoDashboardArgs) {
-    const uid = opts?.uid || this.dashboardUid;
-    let url = uid ? this.ctx.selectors.pages.Dashboard.url(uid) : this.ctx.selectors.pages.AddDashboard.url;
-    if (opts?.queryParams) {
-      url += `?${opts.queryParams.toString()}`;
+  async goto(options?: NavigateOptions) {
+    let url = this.dashboard?.uid
+      ? this.ctx.selectors.pages.Dashboard.url(this.dashboard.uid)
+      : this.ctx.selectors.pages.AddDashboard.url;
+
+    if (this.dashboard?.timeRange) {
+      options.queryParams = options.queryParams ?? new URLSearchParams();
+      options.queryParams.append('from', this.dashboard.timeRange.from);
+      options.queryParams.append('to', this.dashboard.timeRange.to);
     }
-    await this.ctx.page.goto(url, {
-      waitUntil: 'networkidle',
-    });
-    if (opts?.timeRange) {
-      await this.timeRange.set(opts.timeRange);
-    }
+
+    return super.navigate(url, options);
   }
 
   async gotoPanelEditPage(panelId: string) {
-    const url = this.ctx.selectors.pages.Dashboard.url(this.dashboardUid ?? '');
-    await this.ctx.page.goto(`${url}?editPanel=${panelId}`, {
-      waitUntil: 'networkidle',
-    });
-    return new PanelEditPage(this.ctx);
+    const panelEditPage = new PanelEditPage(this.ctx, { dashboard: this.dashboard, id: panelId });
+    await panelEditPage.goto();
+    return panelEditPage;
   }
 
   async addPanel(): Promise<PanelEditPage> {
@@ -48,11 +46,16 @@ export class DashboardPage extends GrafanaPage {
       await this.getByTestIdOrAriaLabel(pages.AddDashboard.addNewPanel).click();
     }
 
-    return new PanelEditPage(this.ctx);
+    const panelId = await this.ctx.page.evaluate(() => {
+      const urlParams = new URLSearchParams(window.location.search);
+      return urlParams.get('editPanel');
+    });
+
+    return new PanelEditPage(this.ctx, { dashboard: this.dashboard, id: panelId });
   }
 
   async deleteDashboard() {
-    await this.ctx.request.delete(this.ctx.selectors.apis.Dashboard.delete(this.dashboardUid));
+    await this.ctx.request.delete(this.ctx.selectors.apis.Dashboard.delete(this.dashboard.uid));
   }
 
   async refreshDashboard() {

--- a/packages/plugin-e2e/src/models/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/DashboardPage.ts
@@ -9,7 +9,7 @@ export class DashboardPage extends GrafanaPage {
   dataSourcePicker: any;
   timeRange: TimeRange;
 
-  constructor(ctx: PluginTestCtx, private dashboard?: DashboardPageArgs) {
+  constructor(readonly ctx: PluginTestCtx, readonly dashboard?: DashboardPageArgs) {
     super(ctx);
     this.dataSourcePicker = new DataSourcePicker(ctx);
     this.timeRange = new TimeRange(ctx);

--- a/packages/plugin-e2e/src/models/DataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/models/DataSourceConfigPage.ts
@@ -1,4 +1,4 @@
-import { DataSource, PluginTestCtx } from '../types';
+import { DataSource, NavigateOptions, PluginTestCtx } from '../types';
 import { GrafanaPage } from './GrafanaPage';
 
 export class DataSourceConfigPage extends GrafanaPage {
@@ -10,10 +10,8 @@ export class DataSourceConfigPage extends GrafanaPage {
     await this.ctx.request.delete(this.ctx.selectors.apis.DataSource.delete(this.datasource.uid));
   }
 
-  async goto() {
-    await this.ctx.page.goto(this.ctx.selectors.pages.EditDataSource.url(this.datasource.uid), {
-      waitUntil: 'load',
-    });
+  async goto(options?: NavigateOptions) {
+    return super.navigate(this.ctx.selectors.pages.EditDataSource.url(this.datasource.uid), options);
   }
 
   /**

--- a/packages/plugin-e2e/src/models/GrafanaPage.ts
+++ b/packages/plugin-e2e/src/models/GrafanaPage.ts
@@ -1,4 +1,4 @@
-import { Locator, Request } from '@playwright/test';
+import { Locator, Request, Response } from '@playwright/test';
 import { NavigateOptions, PluginTestCtx } from '../types';
 
 /**
@@ -68,6 +68,20 @@ export abstract class GrafanaPage {
     return this.ctx.page.waitForRequest((request) => {
       if (request.url().includes(this.ctx.selectors.apis.DataSource.query) && request.method() === 'POST') {
         return cb ? cb(request) : true;
+      }
+      return false;
+    });
+  }
+
+  /**
+   * Waits for a data source query data response
+   *
+   * @param cb optional callback to filter the response. Use this to filter by response body or other response properties
+   */
+  async waitForQueryDataResponse(cb?: (request: Response) => boolean | Promise<boolean>) {
+    return this.ctx.page.waitForResponse((response) => {
+      if (response.url().includes(this.ctx.selectors.apis.DataSource.query)) {
+        return cb ? cb(response) : true;
       }
       return false;
     });

--- a/packages/plugin-e2e/src/models/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/PanelEditPage.ts
@@ -18,7 +18,7 @@ export class PanelEditPage extends GrafanaPage implements PanelError {
   datasource: DataSourcePicker;
   timeRange: TimeRange;
 
-  constructor(ctx: PluginTestCtx, private args: DashboardEditViewArgs<string>) {
+  constructor(readonly ctx: PluginTestCtx, readonly args: DashboardEditViewArgs<string>) {
     super(ctx);
     this.datasource = new DataSourcePicker(ctx);
     this.timeRange = new TimeRange(ctx);

--- a/packages/plugin-e2e/src/models/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/PanelEditPage.ts
@@ -1,6 +1,13 @@
 import { expect, Locator } from '@playwright/test';
 import * as semver from 'semver';
-import { PanelError, PluginTestCtx, RequestOptions, Visualization } from '../types';
+import {
+  DashboardEditViewArgs,
+  NavigateOptions,
+  PanelError,
+  PluginTestCtx,
+  RequestOptions,
+  Visualization,
+} from '../types';
 import { DataSourcePicker } from './DataSourcePicker';
 import { GrafanaPage } from './GrafanaPage';
 import { TimeRange } from './TimeRange';
@@ -11,10 +18,22 @@ export class PanelEditPage extends GrafanaPage implements PanelError {
   datasource: DataSourcePicker;
   timeRange: TimeRange;
 
-  constructor(ctx: PluginTestCtx) {
+  constructor(ctx: PluginTestCtx, private args: DashboardEditViewArgs<string>) {
     super(ctx);
     this.datasource = new DataSourcePicker(ctx);
     this.timeRange = new TimeRange(ctx);
+  }
+
+  async goto(options?: NavigateOptions) {
+    const url = this.args.dashboard?.uid
+      ? this.ctx.selectors.pages.Dashboard.url(this.args.dashboard.uid)
+      : this.ctx.selectors.pages.AddDashboard.url;
+
+    options ??= {};
+    options.queryParams ??= new URLSearchParams();
+    options.queryParams.append('editPanel', this.args.id);
+
+    await super.navigate(url, options);
   }
 
   async setVisualization(visualization: Visualization) {

--- a/packages/plugin-e2e/src/models/VariableEditPage.ts
+++ b/packages/plugin-e2e/src/models/VariableEditPage.ts
@@ -1,6 +1,6 @@
 const gte = require('semver/functions/gte');
 
-import { PluginTestCtx } from '../types';
+import { DashboardEditViewArgs, NavigateOptions, PluginTestCtx } from '../types';
 import { DataSourcePicker } from './DataSourcePicker';
 import { GrafanaPage } from './GrafanaPage';
 import { PanelEditPage } from './PanelEditPage';
@@ -9,9 +9,18 @@ export type VariableType = 'Query' | 'Constant' | 'Custom';
 
 export class VariableEditPage extends GrafanaPage {
   datasource: DataSourcePicker;
-  constructor(ctx: PluginTestCtx) {
+  constructor(ctx: PluginTestCtx, private args: DashboardEditViewArgs<string>) {
     super(ctx);
     this.datasource = new DataSourcePicker(ctx);
+  }
+
+  async goto(options?: NavigateOptions) {
+    const { Dashboard, AddDashboard } = this.ctx.selectors.pages;
+    const url = this.args.dashboard?.uid
+      ? Dashboard.Settings.Variables.Edit.url(this.args.dashboard.uid, this.args.id)
+      : AddDashboard.Settings.Variables.Edit.url(this.args.id);
+
+    await super.navigate(url, options);
   }
 
   async setVariableType(type: VariableType) {

--- a/packages/plugin-e2e/src/models/VariableEditPage.ts
+++ b/packages/plugin-e2e/src/models/VariableEditPage.ts
@@ -9,7 +9,7 @@ export type VariableType = 'Query' | 'Constant' | 'Custom';
 
 export class VariableEditPage extends GrafanaPage {
   datasource: DataSourcePicker;
-  constructor(ctx: PluginTestCtx, private args: DashboardEditViewArgs<string>) {
+  constructor(readonly ctx: PluginTestCtx, readonly args: DashboardEditViewArgs<string>) {
     super(ctx);
     this.datasource = new DataSourcePicker(ctx);
   }

--- a/packages/plugin-e2e/src/models/VariablePage.ts
+++ b/packages/plugin-e2e/src/models/VariablePage.ts
@@ -3,7 +3,7 @@ import { GrafanaPage } from './GrafanaPage';
 import { VariableEditPage } from './VariableEditPage';
 
 export class VariablePage extends GrafanaPage {
-  constructor(ctx: PluginTestCtx, private dashboard?: DashboardPageArgs) {
+  constructor(readonly ctx: PluginTestCtx, readonly dashboard?: DashboardPageArgs) {
     super(ctx);
   }
 

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -29,6 +29,14 @@ export interface DataSource<T = any> {
 }
 
 /**
+ * The dashboard object
+ */
+export interface Dashboard {
+  uid: string;
+  title?: string;
+}
+
+/**
  * The YAML provision file parsed to a javascript object
  */
 export type ProvisionFile<T = DataSource> = {
@@ -89,7 +97,7 @@ export interface TimeRangeArgs {
   zone?: string;
 }
 
-export type GotoDashboardArgs = {
+export type DashboardPageArgs = {
   /**
    * The uid of the dashboard to go to
    */
@@ -102,6 +110,18 @@ export type GotoDashboardArgs = {
    * Query parameters to add to the url
    */
   queryParams?: URLSearchParams;
+};
+
+/**
+ * DashboardEditViewArgs is used to pass arguments to the page object models that represent a dashboard edit view,
+ * such as {@link PanelEditPage}, {@link VariableEditPage} and {@link AnnotationEditPage}.
+ *
+ * If dashboard is not specified, it's assumed that it's a new dashboard. Otherwise, the dashboard uid is used to
+ * navigate to an already existing dashboard.
+ */
+export type DashboardEditViewArgs<T> = {
+  dashboard?: DashboardPageArgs;
+  id: T;
 };
 
 export type ReadProvisionArgs = {

--- a/packages/plugin-e2e/tests/datasource/annotations/annotationQueryRunner.integration.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/annotations/annotationQueryRunner.integration.spec.ts
@@ -1,6 +1,6 @@
 import semverLt from 'semver/functions/lt';
-import { test, expect } from '../../../src';
-import { ProvisionFile } from '../../../src/types';
+import { test, expect, AnnotationEditPage } from '../../../src';
+import { Dashboard, ProvisionFile } from '../../../src/types';
 
 test('should run successfully if valid Redshift query was provided', async ({
   annotationEditPage,
@@ -29,5 +29,21 @@ test('should run successfully if valid Google Sheets query was provided', async 
   await page.getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   await page.keyboard.press('Enter');
+  await expect(annotationEditPage.runQuery()).toBeOK();
+});
+
+test('should run successfully if valid Redshift query was provided in provisioned dashboard', async ({
+  request,
+  page,
+  selectors,
+  grafanaVersion,
+  readProvision,
+}) => {
+  const provision = await readProvision<Dashboard>({ filePath: 'dashboards/redshift.json' });
+  const annotationEditPage = new AnnotationEditPage(
+    { request, page, selectors, grafanaVersion },
+    { dashboard: { uid: provision.uid }, id: '1' }
+  );
+  await annotationEditPage.goto();
   await expect(annotationEditPage.runQuery()).toBeOK();
 });

--- a/packages/plugin-e2e/tests/datasource/variables/customVariableEditor.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/variables/customVariableEditor.spec.ts
@@ -2,12 +2,6 @@ import { expect, test } from '../../../src';
 import { ProvisionFile } from '../../../src/types';
 import { REDSHIFT_SCHEMAS, REDSHIFT_TABLES } from '../mocks/resource';
 
-const toMetricFindOption = (text: string) => ({
-  text,
-  value: text,
-  label: text,
-});
-
 test('should load resources and display them as options when clicking on an input', async ({
   variableEditPage,
   page,

--- a/packages/plugin-e2e/tests/datasource/variables/customVariableQueryRunner.integration.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/variables/customVariableQueryRunner.integration.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '../../../src';
-import { ProvisionFile } from '../../../src/types';
+import { VariableEditPage, expect, test } from '../../../src';
+import { Dashboard, ProvisionFile } from '../../../src/types';
 
 test('custom variable editor query runner should return data when query is valid', async ({
   variableEditPage,
@@ -13,6 +13,27 @@ test('custom variable editor query runner should return data when query is valid
   await page.waitForFunction(() => (window as any).monaco);
   await variableEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).click();
   await page.keyboard.insertText('select distinct(environment) from long_format_example');
+  const queryDataRequest = variableEditPage.waitForQueryDataRequest();
   await variableEditPage.runQuery();
+  await queryDataRequest;
   await expect(variableEditPage).toDisplayPreviews([/stag.*/, 'test']);
+});
+
+test('custom variable editor query runner should return data when valid query from provisioned dashboard is used', async ({
+  request,
+  page,
+  selectors,
+  grafanaVersion,
+  readProvision,
+}) => {
+  const provision = await readProvision<Dashboard>({ filePath: 'dashboards/redshift.json' });
+  const variableEditPage = new VariableEditPage(
+    { request, page, selectors, grafanaVersion },
+    { dashboard: { uid: provision.uid }, id: '2' }
+  );
+  await variableEditPage.goto();
+  const queryDataRequest = variableEditPage.waitForQueryDataRequest();
+  await variableEditPage.runQuery();
+  await queryDataRequest;
+  await expect(variableEditPage).toDisplayPreviews(['staging', 'test']);
 });

--- a/packages/plugin-e2e/tests/datasource/variables/variableInterpolation.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/variables/variableInterpolation.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect, PanelEditPage } from '../../../src';
+import { Dashboard } from '../../../src/types';
+
+test('variable interpolation', async ({ readProvision, request, page, selectors, grafanaVersion }) => {
+  const provision = await readProvision<Dashboard>({ filePath: 'dashboards/redshift.json' });
+  const panelEditPage = new PanelEditPage(
+    { request, page, selectors, grafanaVersion },
+    {
+      id: '5',
+      dashboard: { uid: provision.uid },
+    }
+  );
+  const queryReq = panelEditPage.waitForQueryDataRequest((request) =>
+    (request.postData() ?? '').includes(
+      `"rawSQL":"select * from long_format_example where environment in ('staging') limit 100"`
+    )
+  );
+  await panelEditPage.goto();
+  await expect(await queryReq).toBeTruthy();
+});
+
+test('variable interpolation (navigate to panel from dashboard)', async ({
+  readProvision,
+  request,
+  page,
+  selectors,
+  grafanaVersion,
+}) => {
+  const provision = await readProvision<Dashboard>({ filePath: 'dashboards/redshift.json' });
+  const panelEditPage = new PanelEditPage(
+    { request, page, selectors, grafanaVersion },
+    {
+      id: '5',
+      dashboard: { uid: provision.uid },
+    }
+  );
+  const queryReq = panelEditPage.waitForQueryDataRequest((request) =>
+    (request.postData() ?? '').includes(
+      `"rawSQL":"select * from long_format_example where environment in ('staging') limit 100"`
+    )
+  );
+  await panelEditPage.goto();
+  await expect(await queryReq).toBeTruthy();
+});


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Up until now, it has only been possible to instantiate and navigate to annotations, variables, panels etc for new dashboards (`/dashboard/new`). This is probably all plugin authors need in most cases. However, I want it to be possible to also instantiate all pages with a dashboard uid so it's possible to navigate to an already existing dashboard. This is useful if you for example want to test template variable interpolation in your datasource file, and you want to use a template variable and a query that is using the variable in a provisioned dashboard.

This PR harmonises the constructor method and the `goto` method for all page models. I'm also adding a few tests that showcases how this pages can be instantiated and navigated to also for an existing dashboard. 



**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/plugin-tools/issues/576

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.1.0-canary.603.428a5d1.0
  # or 
  yarn add @grafana/plugin-e2e@0.1.0-canary.603.428a5d1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
