### PR TITLE
Plugin E2E: Publish to NPM

### DIFF
--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@grafana/plugin-e2e",
   "version": "0.0.1",
-  "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-e2e",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-e2e",
-  "version": "0.3.1",
+  "version": "0.0.1",
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the `private: true` prop so that this package is published to npm. Also setting version to 0.0.0. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.0.1-canary.605.3c9f163.0
  # or 
  yarn add @grafana/plugin-e2e@0.0.1-canary.605.3c9f163.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
