### PR TITLE
Plugin E2E: Add expect matcher for alert box

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -192,7 +192,13 @@ export type Components = {
   AlertTab: {
     content: string;
   };
-  Alert: {};
+  Alert: {
+    /**
+     * @deprecated use alertV2 from Grafana 8.3 instead
+     */
+    alert: (severity: string) => string;
+    alertV2: (severity: string) => string;
+  };
   TransformTab: {
     content: string;
   };

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -11,7 +11,7 @@ export type APIs = {
     queryPattern: string;
     query: string;
     health: (uid: string, id: string) => string;
-    delete: (uid: string) => string;
+    datasourceByUID: (uid: string) => string;
   };
   Dashboard: {
     delete: (uid: string) => string;

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/apis.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/apis.ts
@@ -19,7 +19,7 @@ export const versionedAPIs = {
       ['9.5.0']: (uid: string, _: string) => `/api/datasources/uid/${uid}/health`,
       [MIN_GRAFANA_VERSION]: (_: string, id: string) => `/api/datasources/${id}/health`,
     },
-    delete: {
+    datasourceByUID: {
       [MIN_GRAFANA_VERSION]: (uid: string) => `/api/datasources/uid/${uid}`,
     },
   },

--- a/packages/plugin-e2e/src/matchers/index.ts
+++ b/packages/plugin-e2e/src/matchers/index.ts
@@ -1,9 +1,11 @@
 import toBeOK from './toBeOK';
 import toHavePanelError from './toHavePanelError';
 import toDisplayPreviews from './toDisplayPreviews';
+import toHaveAlert from './toHaveAlert';
 
 export default {
   toBeOK,
   toHavePanelError,
   toDisplayPreviews,
+  toHaveAlert,
 };

--- a/packages/plugin-e2e/src/matchers/toHaveAlert.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveAlert.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test';
+import { getMessage } from './utils';
+import { GrafanaPage } from '../models';
+import { AlertPageOptions } from '../types';
+
+export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
+const toHaveAlert = async (grafanaPage: GrafanaPage, severity: AlertVariant, options?: AlertPageOptions) => {
+  let pass = true;
+  let message: any = `An alert of variant ${severity} to be displayed on the page`;
+
+  try {
+    const filteredAlerts = grafanaPage
+      .getByTestIdOrAriaLabel(grafanaPage.ctx.selectors.components.Alert.alertV2(severity))
+      .filter({ hasText: options?.hasText });
+    await expect(filteredAlerts.first()).toBeVisible({ timeout: options?.timeout });
+  } catch (err: unknown) {
+    message = getMessage(message, `No alert was found on the page: ${err instanceof Error ? err.toString() : ''}`);
+    pass = false;
+  }
+
+  return {
+    message: () => message,
+    pass,
+  };
+};
+
+export default toHaveAlert;

--- a/packages/plugin-e2e/src/matchers/toHaveAlert.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveAlert.ts
@@ -11,7 +11,12 @@ const toHaveAlert = async (grafanaPage: GrafanaPage, severity: AlertVariant, opt
   try {
     const filteredAlerts = grafanaPage
       .getByTestIdOrAriaLabel(grafanaPage.ctx.selectors.components.Alert.alertV2(severity))
-      .filter({ hasText: options?.hasText });
+      .filter({
+        hasText: options?.hasText,
+        hasNotText: options?.hasNotText,
+        has: options?.has,
+        hasNot: options?.hasNot,
+      });
     await expect(filteredAlerts.first()).toBeVisible({ timeout: options?.timeout });
   } catch (err: unknown) {
     message = getMessage(message, `No alert was found on the page: ${err instanceof Error ? err.toString() : ''}`);

--- a/packages/plugin-e2e/src/models/DataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/models/DataSourceConfigPage.ts
@@ -1,11 +1,10 @@
-import { DataSource, PluginTestCtx } from '../types';
+import { DataSource, PluginTestCtx, TriggerQueryOptions } from '../types';
 import { GrafanaPage } from './GrafanaPage';
 
 export class DataSourceConfigPage extends GrafanaPage {
   constructor(ctx: PluginTestCtx, private datasource: DataSource) {
     super(ctx);
   }
-
   async deleteDataSource() {
     await this.ctx.request.delete(this.ctx.selectors.apis.DataSource.delete(this.datasource.uid));
   }
@@ -27,7 +26,11 @@ export class DataSourceConfigPage extends GrafanaPage {
     });
   }
 
-  async saveAndTest() {
+  async saveAndTest(options?: TriggerQueryOptions) {
+    if (options?.skipWaitForResponse) {
+      return this.getByTestIdOrAriaLabel(this.ctx.selectors.pages.DataSource.saveAndTest).click();
+    }
+
     const responsePromise = this.ctx.page.waitForResponse((resp) =>
       resp
         .url()

--- a/packages/plugin-e2e/src/models/DataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/models/DataSourceConfigPage.ts
@@ -21,9 +21,12 @@ export class DataSourceConfigPage extends GrafanaPage {
    * @param status the HTTP status code to return. Defaults to 200
    */
   async mockHealthCheckResponse<T = any>(json: T, status = 200) {
-    await this.ctx.page.route(`${this.ctx.selectors.apis.DataSource.health}`, async (route) => {
-      await route.fulfill({ json, status });
-    });
+    await this.ctx.page.route(
+      `${this.ctx.selectors.apis.DataSource.health(this.datasource.uid ?? '', this.datasource.id.toString() ?? '')}`,
+      async (route) => {
+        await route.fulfill({ json, status });
+      }
+    );
   }
 
   /**

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -139,6 +139,13 @@ export type NavigateOptions = {
   queryParams?: URLSearchParams;
 };
 
+export type TriggerQueryOptions = {
+  /**
+   * Set this to true to skip waiting for the response. Defaults to false.
+   */
+  skipWaitForResponse: boolean;
+};
+
 /**
  * Panel visualization types
  */
@@ -161,6 +168,8 @@ export type Visualization =
   | 'Time series'
   | 'Worldmap Panel';
 
+export type AlertVariant = 'success' | 'warning' | 'error' | 'info';
+
 /**
  * Implement this interface in a POM in case you want to enable the `toHavePanelError` matcher for the page.
  * Only applicable to pages that have one panel only, such as the explore page or panel edit page.
@@ -170,4 +179,52 @@ export type Visualization =
 export interface PanelError {
   ctx: PluginTestCtx;
   getPanelError: () => Locator;
+}
+
+export interface AlertPageOptions {
+  /**
+   * Maximum wait time in milliseconds, defaults to 30 seconds, pass `0` to disable the timeout. The default value can
+   * be changed by using the
+   * [browserContext.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-browsercontext#browser-context-set-default-timeout)
+   * or [page.setDefaultTimeout(timeout)](https://playwright.dev/docs/api/class-page#page-set-default-timeout) methods.
+   */
+  timeout?: number;
+  /**
+   * Matches elements containing an element that matches an inner locator. Inner locator is queried against the outer
+   * one. For example, `article` that has `text=Playwright` matches `<article><div>Playwright</div></article>`.
+   *
+   * Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@link
+   * FrameLocator}s.
+   */
+  has?: Locator;
+
+  /**
+   * Matches elements that do not contain an element that matches an inner locator. Inner locator is queried against the
+   * outer one. For example, `article` that does not have `div` matches `<article><span>Playwright</span></article>`.
+   *
+   * Note that outer and inner locators must belong to the same frame. Inner locator must not contain {@link
+   * FrameLocator}s.
+   */
+  hasNot?: Locator;
+
+  /**
+   * Matches elements that do not contain specified text somewhere inside, possibly in a child or a descendant element.
+   * When passed a [string], matching is case-insensitive and searches for a substring.
+   */
+  hasNotText?: string | RegExp;
+
+  /**
+   * Matches elements containing specified text somewhere inside, possibly in a child or a descendant element. When
+   * passed a [string], matching is case-insensitive and searches for a substring. For example, `"Playwright"` matches
+   * `<article><div>Playwright</div></article>`.
+   */
+  hasText?: string | RegExp;
+}
+
+/**
+ * @internal
+ */
+export interface AlertPage {
+  ctx: PluginTestCtx;
+  hasAlert: (severity: AlertVariant, options?: AlertPageOptions) => Promise<Locator>;
 }

--- a/packages/plugin-e2e/tests/datasource/configEditor.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/configEditor.spec.ts
@@ -14,3 +14,12 @@ test('valid credentials should return a 200 status code', async ({ createDataSou
   await page.getByTestId('Configuration text area').fill(process.env.GOOGLE_JWT_FILE!.replace(/'/g, ''));
   await expect(configPage.saveAndTest()).toBeOK();
 });
+
+test('frontend data source - valid credentials should return a 200 status code', async ({
+  createDataSourceConfigPage,
+  page,
+}) => {
+  const configPage = await createDataSourceConfigPage({ type: 'testdata' });
+  await configPage.saveAndTest({ skipWaitForResponse: true });
+  await expect(configPage).toHaveAlert('success', { hasNotText: 'Datasource updated' });
+});

--- a/packages/plugin-e2e/tests/datasource/configEditor.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/configEditor.spec.ts
@@ -15,10 +15,7 @@ test('valid credentials should return a 200 status code', async ({ createDataSou
   await expect(configPage.saveAndTest()).toBeOK();
 });
 
-test('frontend data source - valid credentials should return a 200 status code', async ({
-  createDataSourceConfigPage,
-  page,
-}) => {
+test('valid credentials should display a success alert on the page', async ({ createDataSourceConfigPage, page }) => {
   const configPage = await createDataSourceConfigPage({ type: 'testdata' });
   await configPage.saveAndTest({ skipWaitForResponse: true });
   await expect(configPage).toHaveAlert('success', { hasNotText: 'Datasource updated' });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Ideally in the data source config page, we'd want to assert that a config is valid by looking at the response for the call to the `health` endpoint in the plugin backend. However, not all data source plugins has a backend, and in the case they don't make use of a ds proxy either, we need another way of asserting that data source config was successful or not. This PR adds an expect matcher to assert that a certain alert box is present in the page. 

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/plugin-tools/issues/576

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.0.3-canary.610.b925ceb.0
  # or 
  yarn add @grafana/plugin-e2e@0.0.3-canary.610.b925ceb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
