### PR TITLE
Plugin E2E: Update selectors

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/resolver.test.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/resolver.test.ts
@@ -24,7 +24,7 @@ describe('resolveSelectors', () => {
 
   test('returns the right selector value when it has multiple versions', () => {
     versionedSelectors.components.CodeEditor.container = {
-      '10.3.0': 'data-testid Code editor container',
+      '10.2.3': 'data-testid Code editor container',
       [MIN_GRAFANA_VERSION]: 'Code editor container',
     };
 

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -262,6 +262,7 @@ export type Components = {
   OptionsGroup: {
     group: (title?: string) => string;
     toggle: (title?: string) => string;
+    groupTitle: string;
   };
   PluginVisualization: {
     current: string;

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -12,8 +12,14 @@ export const versionedComponents = {
       '8.1.0': 'data-testid TimePicker Open Button',
       [MIN_GRAFANA_VERSION]: 'TimePicker open button',
     },
-    fromField: 'Time Range from field',
-    toField: 'Time Range to field',
+    fromField: {
+      '10.2.3': 'data-testid Time Range from field',
+      [MIN_GRAFANA_VERSION]: 'Time Range from field',
+    },
+    toField: {
+      '10.2.3': 'data-testid Time Range to field',
+      [MIN_GRAFANA_VERSION]: 'Time Range to field',
+    },
     applyTimeRange: 'data-testid TimePicker submit button',
     calendar: {
       label: 'Time Range calendar',
@@ -403,7 +409,7 @@ export const versionedComponents = {
   },
   CodeEditor: {
     container: {
-      '10.3.0': 'data-testid Code editor container',
+      '10.2.3': 'data-testid Code editor container',
       [MIN_GRAFANA_VERSION]: 'Code editor container',
     },
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

As part of https://github.com/grafana/grafana/issues/78412, many of the selectors used in this repo are being changed, causing some of the scenarios to fail. This PR updates some selectors, which should unblock some of the open PRs for plugin e2e. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.2.1-canary.632.f26b2d7.0
  # or 
  yarn add @grafana/plugin-e2e@0.2.1-canary.632.f26b2d7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
