### PR TITLE
Plugin E2E: Tidy up selectors

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/resolver.test.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/resolver.test.ts
@@ -16,12 +16,6 @@ describe('resolveSelectors', () => {
     versionedSelectors = originalVersionedSelectors;
   });
 
-  test('handles selector without version', () => {
-    versionedSelectors.components.PanelEditor.General.content = 'Panel editor content';
-    const selectors = resolveSelectors(versionedSelectors, GRAFANA_VERSION);
-    expect(selectors.components.PanelEditor.General.content).toBe('Panel editor content');
-  });
-
   test('returns the right selector value when it has multiple versions', () => {
     versionedSelectors.components.CodeEditor.container = {
       '10.2.3': 'data-testid Code editor container',

--- a/packages/plugin-e2e/src/e2e-selectors/resolver.test.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/resolver.test.ts
@@ -4,7 +4,6 @@ import { versionedAPIs } from './versioned/apis';
 import { MIN_GRAFANA_VERSION } from './versioned/constants';
 import { VersionedSelectors } from './versioned/types';
 
-const GRAFANA_VERSION = '10.2.0';
 let versionedSelectors: VersionedSelectors = {
   components: versionedComponents,
   pages: versionedPages,

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -19,245 +19,43 @@ export type APIs = {
 };
 
 export type Components = {
-  Breadcrumbs: {
-    breadcrumb: (title: string) => string;
-  };
   TimePicker: {
     openButton: string;
     fromField: string;
     toField: string;
     applyTimeRange: string;
-    calendar: {
-      label: string;
-      openButton: string;
-      closeButton: string;
-    };
     absoluteTimeRangeTitle: string;
-  };
-  DataSourcePermissions: {
-    roleType: string;
-    rolePicker: string;
-    permissionLevel: string;
-  };
-  DataSource: {
-    TestData: {
-      QueryTab: {
-        scenarioSelectContainer: string;
-        scenarioSelect: string;
-        max: string;
-        min: string;
-        noise: string;
-        seriesCount: string;
-        spread: string;
-        startValue: string;
-        drop: string;
-      };
-    };
-    DataSourceHttpSettings: {
-      urlInput: string;
-    };
-    Jaeger: {
-      traceIDInput: string;
-    };
-    Prometheus: {
-      configPage: {
-        connectionSettings: string;
-        exemplarsAddButton: string;
-        internalLinkSwitch: string;
-      };
-      exemplarMarker: string;
-    };
-  };
-  Menu: {
-    SubMenu: {
-      container: string;
-      icon: string;
-    };
   };
   Panels: {
     Panel: {
-      title: (title: string) => string;
-      headerItems: (item: string) => string;
-      menuItems: (item: string) => string;
-      menu: (title: string) => string;
-      containerByTitle: (title: string) => string;
       headerCornerInfo: (mode: string) => string;
       status: (status: string) => string;
-      loadingBar: () => string;
-      HoverWidget: {
-        container: string;
-        dragIcon: string;
-      };
-    };
-    Visualization: {
-      Graph: {
-        container: string;
-        VisualizationTab: {
-          legendSection: string;
-        };
-        Legend: {
-          showLegendSwitch: string;
-        };
-        xAxis: {};
-      };
-      BarGauge: {
-        value: string;
-        valueV2: string;
-      };
-      PieChart: {
-        svgSlice: string;
-      };
-      Text: {};
-      Table: {
-        header: string;
-        footer: string;
-        body: string;
-      };
-    };
-  };
-  VizLegend: {
-    seriesName: (name: string) => string;
-  };
-  Drawer: {
-    General: {
-      expand: string;
-      contract: string;
-      close: string;
     };
   };
   PanelEditor: {
     General: {
       content: string;
     };
-    OptionsPane: {
-      content: string;
-      select: string;
-    };
-    DataPane: {
-      content: string;
-    };
     applyButton: string;
     toggleVizPicker: string;
-    toggleVizOptions: string;
-    toggleTableView: string;
-    showZoomField: string;
-    showAttributionField: string;
-    showScaleField: string;
-    showMeasureField: string;
-    showDebugField: string;
-    measureButton: string;
-  };
-  PanelInspector: {
-    Data: {
-      content: string;
-    };
-    Stats: {
-      content: string;
-    };
-    Json: {
-      content: string;
-    };
-    Query: {
-      content: string;
-      refreshButton: string;
-    };
-  };
-  Tab: {
-    title: (title: string) => string;
-    active: () => string;
   };
   RefreshPicker: {
-    runButton: string;
-    intervalButton: string;
     runButtonV2: string;
-    intervalButtonV2: string;
-  };
-  QueryTab: {
-    content: string;
-    queryInspectorButton: string;
-    queryHistoryButton: string;
-    addQuery: string;
-  };
-  QueryHistory: {
-    queryText: string;
   };
   QueryEditorRows: {
     rows: string;
   };
   QueryEditorRow: {
-    actionButton: (title: string) => string;
     title: (refId: string) => string;
-    container: (refId: string) => string;
-  };
-  AlertTab: {
-    content: string;
   };
   Alert: {
-    /**
-     * @deprecated use alertV2 from Grafana 8.3 instead
-     */
-    alert: (severity: string) => string;
     alertV2: (severity: string) => string;
-  };
-  TransformTab: {
-    content: string;
-  };
-  Transforms: {
-    Reduce: {
-      modeLabel: string;
-      calculationsLabel: string;
-    };
-    SpatialOperations: {
-      actionLabel: string;
-      locationLabel: string;
-      location: {
-        autoOption: string;
-        coords: {
-          option: string;
-          latitudeFieldLabel: string;
-          longitudeFieldLabel: string;
-        };
-        geohash: {
-          option: string;
-          geohashFieldLabel: string;
-        };
-        lookup: {
-          option: string;
-          lookupFieldLabel: string;
-          gazetteerFieldLabel: string;
-        };
-      };
-    };
-    searchInput: string;
-    addTransformationButton: string;
-  };
-  NavBar: {
-    Configuration: {
-      button: string;
-    };
-    Toggle: {
-      button: string;
-    };
-    Reporting: {
-      button: string;
-    };
-  };
-  NavMenu: {
-    item: string;
-  };
-  NavToolbar: {
-    container: string;
   };
   PageToolbar: {
     item: (tooltip: string) => string;
     shotMoreItems: string;
-    container: string;
     itemButton: (title: string) => string;
     itemButtonTitle: string;
-  };
-  QueryEditorToolbarItem: {};
-  BackButton: {
-    backArrow: string;
   };
   OptionsGroup: {
     group: (title?: string) => string;
@@ -265,109 +63,16 @@ export type Components = {
     groupTitle: string;
   };
   PluginVisualization: {
-    current: string;
     item: (title: string) => string;
-  };
-  Select: {
-    option: string;
-  };
-  FieldConfigEditor: {
-    content: string;
-  };
-  OverridesConfigEditor: {
-    content: string;
-  };
-  FolderPicker: {
-    container: string;
-    containerV2: string;
-    input: string;
-  };
-  ReadonlyFolderPicker: {
-    container: string;
   };
   DataSourcePicker: {
     container: string;
-    inputV2: string;
   };
   TimeZonePicker: {
-    container: string;
     containerV2: string;
-  };
-  WeekStartPicker: {
-    container: string;
-    containerV2: string;
-    placeholder: string;
-  };
-  TraceViewer: {
-    spanBar: string;
-  };
-  QueryField: {
-    container: string;
-  };
-  QueryBuilder: {
-    queryPatterns: string;
-    labelSelect: string;
-    valueSelect: string;
-    matchOperatorSelect: string;
-  };
-  ValuePicker: {};
-  Search: {
-    section: string;
-    sectionV2: string;
-    items: string;
-    itemsV2: string;
-    cards: string;
-    dashboardItems: string;
-  };
-  DashboardLinks: {
-    container: string;
-    dropDown: string;
-    link: string;
-  };
-  LoadingIndicator: {
-    icon: string;
-  };
-  CallToActionCard: {};
-  DataLinksContextMenu: {
-    singleLink: string;
   };
   CodeEditor: {
     container: string;
-  };
-  DashboardImportPage: {
-    textarea: string;
-    submit: string;
-  };
-  ImportDashboardForm: {
-    name: string;
-    submit: string;
-  };
-  PanelAlertTabContent: {
-    content: string;
-  };
-  VisualizationPreview: {};
-  ColorSwatch: {
-    name: string;
-  };
-  DashboardRow: {};
-  UserProfile: {
-    profileSaveButton: string;
-    preferencesSaveButton: string;
-    orgsTable: string;
-    sessionsTable: string;
-  };
-  FileUpload: {
-    inputField: string;
-    fileNameSpan: string;
-  };
-  DebugOverlay: {
-    wrapper: string;
-  };
-  OrgRolePicker: {
-    input: string;
-  };
-  AnalyticsToolbarButton: {
-    button: string;
   };
   Variables: {
     variableOption: string;
@@ -382,13 +87,6 @@ export type Components = {
 };
 
 export type Pages = {
-  Login: {
-    url: string;
-    username: string;
-    password: string;
-    submit: string;
-    skip: string;
-  };
   Home: {
     url: string;
   };
@@ -399,29 +97,13 @@ export type Pages = {
     saveAndTest: string;
     alert: string;
   };
-  DataSources: {
-    url: string;
-    dataSources: (dataSourceName: string) => string;
-  };
   EditDataSource: {
     url: (dataSourceUid: string) => string;
-    settings: string;
-  };
-  AddDataSource: {
-    url: string;
-    /** @deprecated Use dataSourcePluginsV2 */
-    dataSourcePlugins: (pluginName: string) => string;
-    dataSourcePluginsV2: (pluginName: string) => string;
-  };
-  ConfirmModal: {
-    delete: string;
   };
   AddDashboard: {
     url: string;
     itemButton: (title: string) => string;
     addNewPanel: string;
-    addNewRow: string;
-    addNewPanelLibrary: string;
     itemButtonAddViz: string;
     Settings: {
       Annotations: {
@@ -444,36 +126,7 @@ export type Pages = {
   };
   Dashboard: {
     url: (uid: string) => string;
-    DashNav: {
-      nav: string;
-      navV2: string;
-      publicDashboardTag: string;
-    };
-    SubMenu: {
-      submenu: string;
-      submenuItem: string;
-      submenuItemLabels: (item: string) => string;
-      submenuItemValueDropDownValueLinkTexts: (item: string) => string;
-      submenuItemValueDropDownDropDown: string;
-      submenuItemValueDropDownOptionTexts: (item: string) => string;
-      Annotations: {
-        annotationsWrapper: string;
-        annotationLabel: (label: string) => string;
-        annotationToggle: (label: string) => string;
-      };
-    };
     Settings: {
-      Actions: {
-        close: string;
-      };
-      General: {
-        deleteDashBoard: string;
-        sectionItems: (item: string) => string;
-        saveDashBoard: string;
-        saveAsDashBoard: string;
-        timezone: string;
-        title: string;
-      };
       Annotations: {
         Edit: {
           url: (dashboardUid: string, annotationIndex: string) => string;
@@ -486,231 +139,26 @@ export type Pages = {
           addAnnotationCTA: string;
           addAnnotationCTAV2: string;
         };
-        Settings: {
-          name: string;
-        };
-        NewAnnotation: {
-          panelFilterSelect: string;
-          showInLabel: string;
-          previewInDashboard: string;
-        };
       };
       Variables: {
         List: {
           url: (dashboardUid: string) => string;
           newButton: string;
-          table: string;
-          tableRowNameFields: (variableName: string) => string;
-          tableRowDefinitionFields: (variableName: string) => string;
-          tableRowArrowUpButtons: (variableName: string) => string;
-          tableRowArrowDownButtons: (variableName: string) => string;
-          tableRowDuplicateButtons: (variableName: string) => string;
-          tableRowRemoveButtons: (variableName: string) => string;
           addVariableCTAV2: (variableName: string) => string;
           addVariableCTAV2Item: string;
         };
         Edit: {
           url: (dashboardUid: string, editIndex: string) => string;
           General: {
-            headerLink: string;
-            modeLabelNew: string;
-            modeLabelEdit: string;
-            generalNameInput: string;
-            generalNameInputV2: string;
-            generalTypeSelect: string;
             generalTypeSelectV2: string;
-            generalLabelInput: string;
-            generalLabelInputV2: string;
-            generalHideSelect: string;
-            generalHideSelectV2: string;
-            selectionOptionsMultiSwitch: string;
-            selectionOptionsIncludeAllSwitch: string;
-            selectionOptionsCustomAllInput: string;
-            selectionOptionsCustomAllInputV2: string;
             previewOfValuesOption: string;
             submitButton: string;
-            applyButton: string;
-          };
-          QueryVariable: {
-            queryOptionsRefreshSelect: string;
-            queryOptionsRefreshSelectV2: string;
-            queryOptionsRegExInput: string;
-            queryOptionsRegExInputV2: string;
-            queryOptionsSortSelect: string;
-            queryOptionsSortSelectV2: string;
-            queryOptionsQueryInput: string;
-            valueGroupsTagsEnabledSwitch: string;
-            valueGroupsTagsTagsQueryInput: string;
-            valueGroupsTagsTagsValuesQueryInput: string;
-          };
-          ConstantVariable: {
-            constantOptionsQueryInput: string;
-            constantOptionsQueryInputV2: string;
-          };
-          DatasourceVariable: {
-            datasourceSelect: string;
-          };
-          TextBoxVariable: {
-            textBoxOptionsQueryInput: string;
-            textBoxOptionsQueryInputV2: string;
-          };
-          CustomVariable: {
-            customValueInput: string;
-          };
-          IntervalVariable: {
-            intervalsValueInput: string;
           };
         };
       };
     };
-    Annotations: {
-      marker: string;
-    };
-    Rows: {
-      Repeated: {
-        ConfigSection: {
-          warningMessage: string;
-        };
-      };
-    };
-  };
-  Dashboards: {
-    url: string;
-    dashboards: (title: string) => string;
-  };
-  SaveDashboardAsModal: {
-    newName: string;
-    save: string;
-  };
-  SaveDashboardModal: {
-    save: string;
-    saveVariables: string;
-    saveTimerange: string;
-  };
-  SharePanelModal: {
-    linkToRenderedImage: string;
-  };
-  ShareDashboardModal: {
-    shareButton: string;
-    PublicDashboard: {
-      Tab: string;
-      WillBePublicCheckbox: string;
-      LimitedDSCheckbox: string;
-      CostIncreaseCheckbox: string;
-      PauseSwitch: string;
-      EnableAnnotationsSwitch: string;
-      CreateButton: string;
-      DeleteButton: string;
-      CopyUrlInput: string;
-      CopyUrlButton: string;
-      SettingsDropdown: string;
-      TemplateVariablesWarningAlert: string;
-      UnsupportedDataSourcesWarningAlert: string;
-      NoUpsertPermissionsWarningAlert: string;
-      EnableTimeRangeSwitch: string;
-      EmailSharingConfiguration: {
-        Container: string;
-        ShareType: string;
-        EmailSharingInput: string;
-        EmailSharingInviteButton: string;
-        EmailSharingList: string;
-        DeleteEmail: string;
-        ReshareLink: string;
-      };
-    };
-  };
-  PublicDashboard: {
-    page: string;
-    NotAvailable: {
-      container: string;
-      title: string;
-      pausedDescription: string;
-    };
-  };
-  RequestViewAccess: {
-    form: string;
-    recipientInput: string;
-    submitButton: string;
   };
   Explore: {
-    url: string;
-    General: {
-      container: string;
-      graph: string;
-      table: string;
-      scrollView: string;
-    };
-  };
-  SoloPanel: {
-    url: (page: string) => string;
-  };
-  PluginsList: {
-    page: string;
-    list: string;
-    listItem: string;
-    signatureErrorNotice: string;
-  };
-  PluginPage: {
-    page: string;
-    signatureInfo: string;
-    disabledInfo: string;
-  };
-  PlaylistForm: {
-    name: string;
-    interval: string;
-    itemDelete: string;
-  };
-  BrowseDashboards: {
-    table: {
-      body: string;
-      row: (uid: string) => string;
-      checkbox: (uid: string) => string;
-    };
-  };
-  Search: {
-    url: string;
-    FolderView: {
-      url: string;
-    };
-  };
-  PublicDashboards: {
-    ListItem: {
-      linkButton: string;
-      configButton: string;
-      trashcanButton: string;
-      pauseSwitch: string;
-    };
-  };
-  UserListPage: {
-    tabs: {
-      allUsers: string;
-      orgUsers: string;
-      publicDashboardsUsers: string;
-      users: string;
-    };
-    org: {
-      url: string;
-    };
-    admin: {
-      url: string;
-    };
-    publicDashboards: {
-      container: string;
-    };
-    UserListAdminPage: {
-      container: string;
-    };
-    UsersListPage: {
-      container: string;
-    };
-    UsersListPublicDashboardsPage: {
-      container: string;
-      DashboardsListModal: {
-        listItem: (uid: string) => string;
-      };
-    };
-  };
-  ProfilePage: {
     url: string;
   };
 };

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/README.md
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/README.md
@@ -1,0 +1,5 @@
+# Versioned selectors
+
+All selectors defined in this directory should be associated with a minimum Grafana version. If for example the value of the DataSourcePicker.container selector was changed in Grafana 10.0.0, a new key-value pair for the combination of Grafana version and selector value needs to be added. Beware that the minimum version resolver follow strict semver, so if you've introduced the change in 10.0.0 but it's been backported to 9.5.6, you should specify 9.5.6 as the minimum Grafana version.
+
+You can find more information about versioned selectors in the [contributing guidelines](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/CONTRIBUTING.md#fix-broken-e2e-selectors).

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -1,12 +1,6 @@
 import { MIN_GRAFANA_VERSION } from './constants';
 
 export const versionedComponents = {
-  Breadcrumbs: {
-    breadcrumb: {
-      // did not exist prior to 9.4.0
-      '9.4.0': (title: string) => `data-testid ${title} breadcrumb`,
-    },
-  },
   TimePicker: {
     openButton: {
       '8.1.0': 'data-testid TimePicker Open Button',
@@ -20,317 +14,98 @@ export const versionedComponents = {
       '10.2.3': 'data-testid Time Range to field',
       [MIN_GRAFANA_VERSION]: 'Time Range to field',
     },
-    applyTimeRange: 'data-testid TimePicker submit button',
-    calendar: {
-      label: 'Time Range calendar',
-      openButton: 'Open time range calendar',
-      closeButton: 'Close time range Calendar',
+    applyTimeRange: {
+      '8.1.0': 'data-testid TimePicker submit button',
+      [MIN_GRAFANA_VERSION]: 'TimePicker submit button',
     },
-    absoluteTimeRangeTitle: 'data-testid-absolute-time-range-narrow',
-  },
-  DataSourcePermissions: {
-    form: () => 'form[name="addPermission"]',
-    roleType: 'Role to add new permission to',
-    rolePicker: 'Built-in role picker',
-    permissionLevel: 'Permission Level',
-  },
-  DataSource: {
-    TestData: {
-      QueryTab: {
-        scenarioSelectContainer: 'Test Data Query scenario select container',
-        scenarioSelect: 'Test Data Query scenario select',
-        max: 'TestData max',
-        min: 'TestData min',
-        noise: 'TestData noise',
-        seriesCount: 'TestData series count',
-        spread: 'TestData spread',
-        startValue: 'TestData start value',
-        drop: 'TestData drop values',
-      },
-    },
-    DataSourceHttpSettings: {
-      urlInput: 'Datasource HTTP settings url',
-    },
-    Jaeger: {
-      traceIDInput: 'Trace ID',
-    },
-    Prometheus: {
-      configPage: {
-        connectionSettings: 'Data source connection URL',
-        exemplarsAddButton: 'Add exemplar config button',
-        internalLinkSwitch: 'Internal link switch',
-      },
-      exemplarMarker: 'Exemplar marker',
-    },
-  },
-  Menu: {
-    MenuComponent: (title: string) => `${title} menu`,
-    MenuGroup: (title: string) => `${title} menu group`,
-    MenuItem: (title: string) => `${title} menu item`,
-    SubMenu: {
-      container: 'SubMenu container',
-      icon: 'SubMenu icon',
+    absoluteTimeRangeTitle: {
+      [MIN_GRAFANA_VERSION]: 'data-testid-absolute-time-range-narrow',
     },
   },
   Panels: {
     Panel: {
-      title: (title: string) => `data-testid Panel header ${title}`,
-      headerItems: (item: string) => `data-testid Panel header item ${item}`,
-      menuItems: (item: string) => `data-testid Panel menu item ${item}`,
-      menu: (title: string) => `data-testid Panel menu ${title}`,
-      containerByTitle: (title: string) => `${title} panel`,
-      headerCornerInfo: (mode: string) => `Panel header ${mode}`,
+      headerCornerInfo: {
+        [MIN_GRAFANA_VERSION]: (mode: string) => `Panel header ${mode}`,
+      },
       status: {
         ['10.2.0']: (status: string) => `data-testid Panel status ${status}`,
         [MIN_GRAFANA_VERSION]: (_: string) => 'Panel status',
       },
-      loadingBar: () => `Panel loading bar`,
-      HoverWidget: {
-        container: 'data-testid hover-header-container',
-        dragIcon: 'data-testid drag-icon',
-      },
-    },
-    Visualization: {
-      Graph: {
-        container: 'Graph container',
-        VisualizationTab: {
-          legendSection: 'Legend section',
-        },
-        Legend: {
-          legendItemAlias: (name: string) => `gpl alias ${name}`,
-          showLegendSwitch: 'gpl show legend',
-        },
-        xAxis: {
-          labels: () => 'div.flot-x-axis > div.flot-tick-label',
-        },
-      },
-      BarGauge: {
-        /**
-         * @deprecated use valueV2 from Grafana 8.3 instead
-         */
-        value: 'Bar gauge value',
-        valueV2: 'data-testid Bar gauge value',
-      },
-      PieChart: {
-        svgSlice: 'Pie Chart Slice',
-      },
-      Text: {
-        container: () => '.markdown-html',
-      },
-      Table: {
-        header: 'table header',
-        footer: 'table-footer',
-        body: {
-          // did not exist prior to 10.2.0
-          '10.2.0': 'data-testid table body',
-        },
-      },
-    },
-  },
-  VizLegend: {
-    seriesName: (name: string) => `VizLegend series ${name}`,
-  },
-  Drawer: {
-    General: {
-      title: (title: string) => `Drawer title ${title}`,
-      expand: 'Drawer expand',
-      contract: 'Drawer contract',
-      close: 'Drawer close',
-      rcContentWrapper: () => '.rc-drawer-content-wrapper',
     },
   },
   PanelEditor: {
     General: {
-      content: 'Panel editor content',
+      content: {
+        [MIN_GRAFANA_VERSION]: 'Panel editor content',
+      },
     },
-    OptionsPane: {
-      content: 'Panel editor option pane content',
-      select: 'Panel editor option pane select',
-      fieldLabel: (type: string) => `${type} field property editor`,
+    applyButton: {
+      '9.2.0': 'data-testid Apply changes and go back to dashboard',
+      [MIN_GRAFANA_VERSION]: 'Apply changes and go back to dashboard',
     },
-    // not sure about the naming *DataPane*
-    DataPane: {
-      content: 'Panel editor data pane content',
-    },
-    applyButton: 'data-testid Apply changes and go back to dashboard',
     toggleVizPicker: {
       '10.0.0': 'data-testid toggle-viz-picker',
       [MIN_GRAFANA_VERSION]: 'toggle-viz-picker',
     },
-    toggleVizOptions: 'data-testid toggle-viz-options',
-    toggleTableView: 'toggle-table-view',
-
-    // [Geomap] Map controls
-    showZoomField: 'Map controls Show zoom control field property editor',
-    showAttributionField: 'Map controls Show attribution field property editor',
-    showScaleField: 'Map controls Show scale field property editor',
-    showMeasureField: 'Map controls Show measure tools field property editor',
-    showDebugField: 'Map controls Show debug field property editor',
-
-    measureButton: 'show measure tools',
-  },
-  PanelInspector: {
-    Data: {
-      content: 'Panel inspector Data content',
-    },
-    Stats: {
-      content: 'Panel inspector Stats content',
-    },
-    Json: {
-      content: 'Panel inspector Json content',
-    },
-    Query: {
-      content: 'Panel inspector Query content',
-      refreshButton: 'Panel inspector Query refresh button',
-      jsonObjectKeys: () => '.json-formatter-key',
-    },
-  },
-  Tab: {
-    title: (title: string) => `Tab ${title}`,
-    active: () => '[class*="-activeTabStyle"]',
   },
   RefreshPicker: {
-    /**
-     * @deprecated use runButtonV2 from Grafana 8.3 instead
-     */
-    runButton: 'RefreshPicker run button',
-    /**
-     * @deprecated use intervalButtonV2 from Grafana 8.3 instead
-     */
-    intervalButton: 'RefreshPicker interval button',
-    runButtonV2: 'data-testid RefreshPicker run button',
-    intervalButtonV2: 'data-testid RefreshPicker interval button',
-  },
-  QueryTab: {
-    content: 'Query editor tab content',
-    queryInspectorButton: 'Query inspector button',
-    queryHistoryButton: 'data-testid query-history-button',
-    addQuery: 'data-testid query-tab-add-query',
-  },
-  QueryHistory: {
-    queryText: 'Query text',
+    runButtonV2: {
+      ['8.3.0']: 'data-testid RefreshPicker run button',
+      [MIN_GRAFANA_VERSION]: 'RefreshPicker run button',
+    },
   },
   QueryEditorRows: {
-    rows: 'Query editor row',
+    rows: {
+      [MIN_GRAFANA_VERSION]: 'Query editor row',
+    },
   },
   QueryEditorRow: {
-    actionButton: (title: string) => `${title}`,
-    title: (refId: string) => `Query editor row title ${refId}`,
-    container: (refId: string) => `Query editor row ${refId}`,
-  },
-  AlertTab: {
-    content: 'Alert editor tab content',
+    title: {
+      [MIN_GRAFANA_VERSION]: (refId: string) => `Query editor row title ${refId}`,
+    },
   },
   Alert: {
-    /**
-     * @deprecated use alertV2 from Grafana 8.3 instead
-     */
-    alert: (severity: string) => `Alert ${severity}`,
-    alertV2: (severity: string) => `data-testid Alert ${severity}`,
-  },
-  TransformTab: {
-    content: 'data-testid Transform editor tab content',
-    newTransform: (name: string) => `data-testid New transform ${name}`,
-    transformationEditor: (name: string) => `data-testid Transformation editor ${name}`,
-    transformationEditorDebugger: (name: string) => `data-testid Transformation editor debugger ${name}`,
-  },
-  Transforms: {
-    card: (name: string) => `data-testid New transform ${name}`,
-    Reduce: {
-      modeLabel: 'Transform mode label',
-      calculationsLabel: 'Transform calculations label',
+    alertV2: {
+      '8.3.0': (severity: string) => `data-testid Alert ${severity}`,
+      [MIN_GRAFANA_VERSION]: (severity: string) => `Alert ${severity}`,
     },
-    SpatialOperations: {
-      actionLabel: 'root Action field property editor',
-      locationLabel: 'root Location Mode field property editor',
-      location: {
-        autoOption: 'Auto location option',
-        coords: {
-          option: 'Coords location option',
-          latitudeFieldLabel: 'root Latitude field field property editor',
-          longitudeFieldLabel: 'root Longitude field field property editor',
-        },
-        geohash: {
-          option: 'Geohash location option',
-          geohashFieldLabel: 'root Geohash field field property editor',
-        },
-        lookup: {
-          option: 'Lookup location option',
-          lookupFieldLabel: 'root Lookup field field property editor',
-          gazetteerFieldLabel: 'root Gazetteer field property editor',
-        },
-      },
-    },
-    searchInput: 'search transformations',
-    addTransformationButton: 'data-testid add transformation button',
-  },
-  NavBar: {
-    Configuration: {
-      button: 'Configuration',
-    },
-    Toggle: {
-      button: 'Toggle menu',
-    },
-    Reporting: {
-      button: 'Reporting',
-    },
-  },
-  NavMenu: {
-    item: 'data-testid Nav menu item',
-  },
-  NavToolbar: {
-    container: 'data-testid Nav toolbar',
   },
   PageToolbar: {
-    container: () => '.page-toolbar',
-    item: (tooltip: string) => `${tooltip}`,
+    item: {
+      [MIN_GRAFANA_VERSION]: (tooltip: string) => `${tooltip}`,
+    },
     shotMoreItems: {
       [MIN_GRAFANA_VERSION]: 'Show more items',
     },
-    itemButton: (title: string) => `data-testid ${title}`,
+    itemButton: {
+      //did not exist prior to 9.5.0
+      ['9.5.0']: (title: string) => `data-testid ${title}`,
+    },
     itemButtonTitle: {
       '10.1.0': 'Add button',
       [MIN_GRAFANA_VERSION]: 'Add panel button',
     },
   },
   QueryEditorToolbarItem: {
-    button: (title: string) => `QueryEditor toolbar item button ${title}`,
-  },
-  BackButton: {
-    backArrow: 'Go Back',
+    button: {
+      [MIN_GRAFANA_VERSION]: (title: string) => `QueryEditor toolbar item button ${title}`,
+    },
   },
   OptionsGroup: {
-    group: (title?: string) => (title ? `Options group ${title}` : 'Options group'),
-    toggle: (title?: string) => (title ? `Options group ${title} toggle` : 'Options group toggle'),
+    group: {
+      [MIN_GRAFANA_VERSION]: (title?: string) => (title ? `Options group ${title}` : 'Options group'),
+    },
+    toggle: {
+      [MIN_GRAFANA_VERSION]: (title?: string) => (title ? `Options group ${title} toggle` : 'Options group toggle'),
+    },
     groupTitle: {
       [MIN_GRAFANA_VERSION]: 'Panel options',
     },
   },
   PluginVisualization: {
-    item: (title: string) => `Plugin visualization item ${title}`,
-    current: () => '[class*="-currentVisualizationItem"]',
-  },
-  Select: {
-    option: 'Select option',
-    input: () => 'input[id*="time-options-input"]',
-    singleValue: () => 'div[class*="-singleValue"]',
-  },
-  FieldConfigEditor: {
-    content: 'Field config editor content',
-  },
-  OverridesConfigEditor: {
-    content: 'Field overrides editor content',
-  },
-  FolderPicker: {
-    /**
-     * @deprecated use containerV2 from Grafana 8.3 instead
-     */
-    container: 'Folder picker select container',
-    containerV2: 'data-testid Folder picker select container',
-    input: 'Select a folder',
-  },
-  ReadonlyFolderPicker: {
-    container: 'data-testid Readonly folder picker select container',
+    item: {
+      [MIN_GRAFANA_VERSION]: (title: string) => `Plugin visualization item ${title}`,
+    },
   },
   DataSourcePicker: {
     container: {
@@ -338,131 +113,17 @@ export const versionedComponents = {
       // did not exist prior to 8.3.0
       '8.3.0': 'Data source picker select container',
     },
-    /**
-     * @deprecated use inputV2 instead
-     */
-    input: () => 'input[id="data-source-picker"]',
-    inputV2: 'data-testid Select a data source',
   },
   TimeZonePicker: {
-    /**
-     * @deprecated use TimeZonePicker.containerV2 from Grafana 8.3 instead
-     */
-    container: 'Time zone picker select container',
-    containerV2: 'data-testid Time zone picker select container',
-  },
-  WeekStartPicker: {
-    /**
-     * @deprecated use WeekStartPicker.containerV2 from Grafana 8.3 instead
-     */
-    container: 'Choose starting day of the week',
-    containerV2: 'data-testid Choose starting day of the week',
-    placeholder: 'Choose starting day of the week',
-  },
-  TraceViewer: {
-    spanBar: 'data-testid SpanBar--wrapper',
-  },
-  QueryField: { container: 'Query field' },
-  QueryBuilder: {
-    queryPatterns: 'Query patterns',
-    labelSelect: 'Select label',
-    valueSelect: 'Select value',
-    matchOperatorSelect: 'Select match operator',
-  },
-  ValuePicker: {
-    button: (name: string) => `Value picker button ${name}`,
-    select: (name: string) => `Value picker select ${name}`,
-  },
-  Search: {
-    /**
-     * @deprecated use sectionV2 from Grafana 8.3 instead
-     */
-    section: 'Search section',
-    sectionV2: 'data-testid Search section',
-    /**
-     * @deprecated use itemsV2 from Grafana 8.3 instead
-     */
-    items: 'Search items',
-    itemsV2: 'data-testid Search items',
-    cards: 'data-testid Search cards',
-    collapseFolder: (sectionId: string) => `data-testid Collapse folder ${sectionId}`,
-    expandFolder: (sectionId: string) => `data-testid Expand folder ${sectionId}`,
-    dashboardCard: (item: string) => `data-testid Search card ${item}`,
-    folderHeader: (folderName: string) => `data-testid Folder header ${folderName}`,
-    folderContent: (folderName: string) => `data-testid Folder content ${folderName}`,
-    dashboardItems: 'data-testid Dashboard search item',
-  },
-  DashboardLinks: {
-    container: 'data-testid Dashboard link container',
-    dropDown: 'data-testid Dashboard link dropdown',
-    link: 'data-testid Dashboard link',
-  },
-  LoadingIndicator: {
-    icon: 'Loading indicator',
-  },
-  CallToActionCard: {
-    /**
-     * @deprecated use buttonV2 from Grafana 8.3 instead
-     */
-    button: (name: string) => `Call to action button ${name}`,
-    buttonV2: (name: string) => `data-testid Call to action button ${name}`,
-  },
-  DataLinksContextMenu: {
-    singleLink: 'Data link',
+    containerV2: {
+      '8.3.0': 'data-testid Time zone picker select container',
+      [MIN_GRAFANA_VERSION]: 'Folder picker select container',
+    },
   },
   CodeEditor: {
     container: {
       '10.2.3': 'data-testid Code editor container',
       [MIN_GRAFANA_VERSION]: 'Code editor container',
     },
-  },
-  DashboardImportPage: {
-    textarea: 'data-testid-import-dashboard-textarea',
-    submit: 'data-testid-load-dashboard',
-  },
-  ImportDashboardForm: {
-    name: 'data-testid-import-dashboard-title',
-    submit: 'data-testid-import-dashboard-submit',
-  },
-  PanelAlertTabContent: {
-    content: 'Unified alert editor tab content',
-  },
-  VisualizationPreview: {
-    card: (name: string) => `data-testid suggestion-${name}`,
-  },
-  ColorSwatch: {
-    name: `data-testid-colorswatch`,
-  },
-  DashboardRow: {
-    title: (title: string) => `data-testid dashboard-row-title-${title}`,
-  },
-  UserProfile: {
-    profileSaveButton: 'data-testid-user-profile-save',
-    preferencesSaveButton: 'data-testid-shared-prefs-save',
-    orgsTable: 'data-testid-user-orgs-table',
-    sessionsTable: 'data-testid-user-sessions-table',
-  },
-  FileUpload: {
-    inputField: 'data-testid-file-upload-input-field',
-    fileNameSpan: 'data-testid-file-upload-file-name',
-  },
-  DebugOverlay: {
-    wrapper: 'debug-overlay',
-  },
-  OrgRolePicker: {
-    input: 'Role',
-  },
-  AnalyticsToolbarButton: {
-    button: 'Dashboard insights',
-  },
-  Variables: {
-    variableOption: 'data-testid variable-option',
-  },
-  Annotations: {
-    annotationsTypeInput: 'annotations-type-input',
-    annotationsChoosePanelInput: 'choose-panels-input',
-  },
-  Tooltip: {
-    container: 'data-testid tooltip',
   },
 };

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
@@ -1,156 +1,103 @@
 import { MIN_GRAFANA_VERSION } from './constants';
 
-/**
- * Selectors grouped/defined in Pages
- *
- * @alpha
- */
 export const versionedPages = {
-  Login: {
-    url: '/login',
-    username: 'Username input field',
-    password: 'Password input field',
-    submit: 'Login button',
-    skip: 'Skip change password button',
-  },
   Home: {
-    url: '/',
+    url: {
+      [MIN_GRAFANA_VERSION]: '/',
+    },
   },
   DataSource: {
-    name: 'Data source settings page name input field',
-    delete: 'Data source settings page Delete button',
-    readOnly: 'Data source settings page read only message',
     saveAndTest: {
       '10.0.0': 'data-testid Data source settings page Save and Test button',
       [MIN_GRAFANA_VERSION]: 'Data source settings page Save and Test button',
     },
-    alert: 'Data source settings page Alert',
-  },
-  DataSources: {
-    url: '/datasources',
-    dataSources: (dataSourceName: string) => `Data source list item ${dataSourceName}`,
   },
   EditDataSource: {
     url: {
       '10.2.0': (dataSourceUid: string) => `/connections/datasources/edit/${dataSourceUid}`,
       [MIN_GRAFANA_VERSION]: (dataSourceUid: string) => `/datasources/edit/${dataSourceUid}`,
     },
-    settings: 'Datasource settings page basic settings',
-  },
-  AddDataSource: {
-    url: {
-      '8.5.0': '/datasources/new',
-      '10.1.0': '/connections/datasources/new',
-    },
-    /** @deprecated Use dataSourcePluginsV2 */
-    dataSourcePlugins: {
-      '8.5.0': (pluginName: string) => `Data source plugin item ${pluginName}`,
-      '9.5.0': (pluginName: string) => `Add new data source ${pluginName}`,
-    },
-    dataSourcePluginsV2: (pluginName: string) => `Add new data source ${pluginName}`,
-  },
-  ConfirmModal: {
-    delete: 'data-testid Confirm Modal Danger Button',
   },
   AddDashboard: {
-    url: '/dashboard/new',
-    itemButton: (title: string) => `data-testid ${title}`,
-    addNewPanel: 'Add new panel',
-    addNewRow: 'Add new row',
-    addNewPanelLibrary: 'Add new panel from panel library',
+    url: {
+      [MIN_GRAFANA_VERSION]: '/dashboard/new',
+    },
+    itemButton: {
+      //did not exist prior to 9.5.0
+      '9.5.0': (title: string) => `data-testid ${title}`,
+    },
+    addNewPanel: {
+      [MIN_GRAFANA_VERSION]: 'Add new panel',
+    },
     itemButtonAddViz: {
       [MIN_GRAFANA_VERSION]: 'Add new visualization menu item',
     },
     Settings: {
       Annotations: {
         List: {
-          url: '/dashboard/new?orgId=1&editview=annotations',
+          url: {
+            [MIN_GRAFANA_VERSION]: '/dashboard/new?orgId=1&editview=annotations',
+          },
         },
         Edit: {
-          url: (annotationIndex: string) => `/dashboard/new?editview=annotations&editIndex=${annotationIndex}`,
+          url: {
+            [MIN_GRAFANA_VERSION]: (annotationIndex: string) =>
+              `/dashboard/new?editview=annotations&editIndex=${annotationIndex}`,
+          },
         },
       },
       Variables: {
         List: {
-          url: '/dashboard/new?orgId=1&editview=templating',
+          url: {
+            [MIN_GRAFANA_VERSION]: '/dashboard/new?orgId=1&editview=templating',
+          },
         },
         Edit: {
-          url: (annotationIndex: string) => `/dashboard/new?orgId=1&editview=templating&editIndex=${annotationIndex}`,
+          url: {
+            [MIN_GRAFANA_VERSION]: (annotationIndex: string) =>
+              `/dashboard/new?orgId=1&editview=templating&editIndex=${annotationIndex}`,
+          },
         },
       },
     },
   },
   Dashboard: {
-    url: (uid: string) => `/d/${uid}`,
-    DashNav: {
-      /**
-       * @deprecated use navV2 from Grafana 8.3 instead
-       */
-      nav: 'Dashboard navigation',
-      navV2: 'data-testid Dashboard navigation',
-      publicDashboardTag: 'data-testid public dashboard tag',
-    },
-    SubMenu: {
-      submenu: 'Dashboard submenu',
-      submenuItem: 'data-testid template variable',
-      submenuItemLabels: (item: string) => `data-testid Dashboard template variables submenu Label ${item}`,
-      submenuItemValueDropDownValueLinkTexts: (item: string) =>
-        `data-testid Dashboard template variables Variable Value DropDown value link text ${item}`,
-      submenuItemValueDropDownDropDown: 'Variable options',
-      submenuItemValueDropDownOptionTexts: (item: string) =>
-        `data-testid Dashboard template variables Variable Value DropDown option text ${item}`,
-      Annotations: {
-        annotationsWrapper: 'data-testid annotation-wrapper',
-        annotationLabel: (label: string) => `data-testid Dashboard annotations submenu Label ${label}`,
-        annotationToggle: (label: string) => `data-testid Dashboard annotations submenu Toggle ${label}`,
-      },
+    url: {
+      [MIN_GRAFANA_VERSION]: (uid: string) => `/d/${uid}`,
     },
     Settings: {
-      Actions: {
-        close: 'data-testid dashboard-settings-close',
-      },
-      General: {
-        deleteDashBoard: 'Dashboard settings page delete dashboard button',
-        sectionItems: (item: string) => `Dashboard settings section item ${item}`,
-        saveDashBoard: 'Dashboard settings aside actions Save button',
-        saveAsDashBoard: 'Dashboard settings aside actions Save As button',
-        /**
-         * @deprecated use components.TimeZonePicker.containerV2 from Grafana 8.3 instead
-         */
-        timezone: 'Time zone picker select container',
-        title: 'Tab General',
-      },
       Annotations: {
         Edit: {
-          url: (dashboardUid: string, annotationIndex: string) =>
-            `${versionedPages.Dashboard.url(dashboardUid)}?editview=annotations&editIndex=${annotationIndex}`,
+          url: {
+            [MIN_GRAFANA_VERSION]: (dashboardUid: string, annotationIndex: string) =>
+              `/d/${dashboardUid}?editview=annotations&editIndex=${annotationIndex}`,
+          },
         },
         List: {
-          url: (dashboardUid: string) => `${versionedPages.Dashboard.url(dashboardUid)}?editview=annotations`,
+          url: {
+            [MIN_GRAFANA_VERSION]: (dashboardUid: string) => `/d/${dashboardUid}?editview=annotations`,
+          },
           addAnnotationCTA: 'Call to action button Add annotation query',
-          addAnnotationCTAV2: 'data-testid Call to action button Add annotation query',
-        },
-        Settings: {
-          name: 'Annotations settings name input',
-        },
-        NewAnnotation: {
-          panelFilterSelect: 'data-testid annotations-panel-filter',
-          showInLabel: 'show-in-label',
-          previewInDashboard: 'data-testid annotations-preview',
+          addAnnotationCTAV2: {
+            //did not exist prior to 8.3.0
+            '8.3.0': 'data-testid Call to action button Add annotation query',
+          },
         },
       },
       Variables: {
         List: {
-          url: (dashboardUid: string) => `${versionedPages.Dashboard.url(dashboardUid)}?editview=templating`,
-          newButton: 'Variable editor New variable button',
-          table: 'Variable editor Table',
-          tableRowNameFields: (variableName: string) => `Variable editor Table Name field ${variableName}`,
-          tableRowDefinitionFields: (variableName: string) => `Variable editor Table Definition field ${variableName}`,
-          tableRowArrowUpButtons: (variableName: string) => `Variable editor Table ArrowUp button ${variableName}`,
-          tableRowArrowDownButtons: (variableName: string) => `Variable editor Table ArrowDown button ${variableName}`,
-          tableRowDuplicateButtons: (variableName: string) => `Variable editor Table Duplicate button ${variableName}`,
-          tableRowRemoveButtons: (variableName: string) => `Variable editor Table Remove button ${variableName}`,
-          addVariableCTAV2: (name: string) => `data-testid Call to action button ${name}`,
+          url: {
+            [MIN_GRAFANA_VERSION]: (dashboardUid: string) => `/d/${dashboardUid}?editview=templating`,
+          },
+          newButton: {
+            [MIN_GRAFANA_VERSION]: 'Variable editor New variable button',
+          },
+          table: {
+            [MIN_GRAFANA_VERSION]: 'Variable editor Table',
+          },
+          addVariableCTAV2: {
+            [MIN_GRAFANA_VERSION]: (name: string) => `data-testid Call to action button ${name}`,
+          },
           addVariableCTAV2Item: {
             [MIN_GRAFANA_VERSION]: 'Add variable',
           },
@@ -158,214 +105,27 @@ export const versionedPages = {
         Edit: {
           url: {
             [MIN_GRAFANA_VERSION]: (dashboardUid: string, editIndex: string) =>
-              `${versionedPages.Dashboard.url(dashboardUid)}?editview=templating&editIndex=${editIndex}`,
+              `/d/${dashboardUid}?editview=templating&editIndex=${editIndex}`,
           },
           General: {
-            headerLink: 'Variable editor Header link',
-            modeLabelNew: 'Variable editor Header mode New',
-            /**
-             * @deprecated
-             */
-            modeLabelEdit: 'Variable editor Header mode Edit',
-            generalNameInput: 'Variable editor Form Name field',
-            generalNameInputV2: 'data-testid Variable editor Form Name field',
-            generalTypeSelect: 'Variable editor Form Type select',
-            generalTypeSelectV2: 'data-testid Variable editor Form Type select',
-            generalLabelInput: 'Variable editor Form Label field',
-            generalLabelInputV2: 'data-testid Variable editor Form Label field',
-            generalHideSelect: 'Variable editor Form Hide select',
-            generalHideSelectV2: 'data-testid Variable editor Form Hide select',
-            selectionOptionsMultiSwitch: 'Variable editor Form Multi switch',
-            selectionOptionsIncludeAllSwitch: 'Variable editor Form IncludeAll switch',
-            selectionOptionsCustomAllInput: 'Variable editor Form IncludeAll field',
-            selectionOptionsCustomAllInputV2: 'data-testid Variable editor Form IncludeAll field',
-            previewOfValuesOption: 'Variable editor Preview of Values option',
-            submitButton: 'Variable editor Submit button',
-            applyButton: 'data-testid Variable editor Apply button',
-          },
-          QueryVariable: {
-            queryOptionsRefreshSelect: 'Variable editor Form Query Refresh select',
-            queryOptionsRefreshSelectV2: 'data-testid Variable editor Form Query Refresh select',
-            queryOptionsRegExInput: 'Variable editor Form Query RegEx field',
-            queryOptionsRegExInputV2: 'data-testid Variable editor Form Query RegEx field',
-            queryOptionsSortSelect: 'Variable editor Form Query Sort select',
-            queryOptionsSortSelectV2: 'data-testid Variable editor Form Query Sort select',
-            queryOptionsQueryInput: 'Variable editor Form Default Variable Query Editor textarea',
-            valueGroupsTagsEnabledSwitch: 'Variable editor Form Query UseTags switch',
-            valueGroupsTagsTagsQueryInput: 'Variable editor Form Query TagsQuery field',
-            valueGroupsTagsTagsValuesQueryInput: 'Variable editor Form Query TagsValuesQuery field',
-          },
-          ConstantVariable: {
-            constantOptionsQueryInput: 'Variable editor Form Constant Query field',
-            constantOptionsQueryInputV2: 'data-testid Variable editor Form Constant Query field',
-          },
-          DatasourceVariable: {
-            datasourceSelect: 'data-testid datasource variable datasource type',
-          },
-          TextBoxVariable: {
-            textBoxOptionsQueryInput: 'Variable editor Form TextBox Query field',
-            textBoxOptionsQueryInputV2: 'data-testid Variable editor Form TextBox Query field',
-          },
-          CustomVariable: {
-            customValueInput: 'data-testid custom-variable-input',
-          },
-          IntervalVariable: {
-            intervalsValueInput: 'data-testid interval variable intervals input',
+            generalTypeSelectV2: {
+              '8.5.0': 'data-testid Variable editor Form Type select',
+              [MIN_GRAFANA_VERSION]: 'Variable editor Form Type select',
+            },
+            previewOfValuesOption: {
+              [MIN_GRAFANA_VERSION]: 'Variable editor Preview of Values option',
+            },
+            submitButton: {
+              [MIN_GRAFANA_VERSION]: 'Variable editor Submit button',
+            },
           },
         },
       },
     },
-    Annotations: {
-      marker: 'data-testid annotation-marker',
-    },
-    Rows: {
-      Repeated: {
-        ConfigSection: {
-          warningMessage: 'data-testid Repeated rows warning message',
-        },
-      },
-    },
-  },
-  Dashboards: {
-    url: '/dashboards',
-    /**
-     * @deprecated use components.Search.dashboardItem from Grafana 8.3 instead
-     */
-    dashboards: (title: string) => `Dashboard search item ${title}`,
-  },
-  SaveDashboardAsModal: {
-    newName: 'Save dashboard title field',
-    save: 'Save dashboard button',
-  },
-  SaveDashboardModal: {
-    save: 'Dashboard settings Save Dashboard Modal Save button',
-    saveVariables: 'Dashboard settings Save Dashboard Modal Save variables checkbox',
-    saveTimerange: 'Dashboard settings Save Dashboard Modal Save timerange checkbox',
-  },
-  SharePanelModal: {
-    linkToRenderedImage: 'Link to rendered image',
-  },
-  ShareDashboardModal: {
-    shareButton: 'Share dashboard',
-    PublicDashboard: {
-      Tab: 'Tab Public dashboard',
-      WillBePublicCheckbox: 'data-testid public dashboard will be public checkbox',
-      LimitedDSCheckbox: 'data-testid public dashboard limited datasources checkbox',
-      CostIncreaseCheckbox: 'data-testid public dashboard cost may increase checkbox',
-      PauseSwitch: 'data-testid public dashboard pause switch',
-      EnableAnnotationsSwitch: 'data-testid public dashboard on off switch for annotations',
-      CreateButton: 'data-testid public dashboard create button',
-      DeleteButton: 'data-testid public dashboard delete button',
-      CopyUrlInput: 'data-testid public dashboard copy url input',
-      CopyUrlButton: 'data-testid public dashboard copy url button',
-      SettingsDropdown: 'data-testid public dashboard settings dropdown',
-      TemplateVariablesWarningAlert: 'data-testid public dashboard disabled template variables alert',
-      UnsupportedDataSourcesWarningAlert: 'data-testid public dashboard unsupported data sources alert',
-      NoUpsertPermissionsWarningAlert: 'data-testid public dashboard no upsert permissions alert',
-      EnableTimeRangeSwitch: 'data-testid public dashboard on off switch for time range',
-      EmailSharingConfiguration: {
-        Container: 'data-testid email sharing config container',
-        ShareType: 'data-testid public dashboard share type',
-        EmailSharingInput: 'data-testid public dashboard email sharing input',
-        EmailSharingInviteButton: 'data-testid public dashboard email sharing invite button',
-        EmailSharingList: 'data-testid public dashboard email sharing list',
-        DeleteEmail: 'data-testid public dashboard delete email button',
-        ReshareLink: 'data-testid public dashboard reshare link button',
-      },
-    },
-  },
-  PublicDashboard: {
-    page: 'public-dashboard-page',
-    NotAvailable: {
-      container: 'public-dashboard-not-available',
-      title: 'public-dashboard-title',
-      pausedDescription: 'public-dashboard-paused-description',
-    },
-  },
-  RequestViewAccess: {
-    form: 'request-view-access-form',
-    recipientInput: 'request-view-access-recipient-input',
-    submitButton: 'request-view-access-submit-button',
   },
   Explore: {
-    url: '/explore',
-    General: {
-      container: 'data-testid Explore',
-      graph: 'Explore Graph',
-      table: 'Explore Table',
-      scrollView: 'data-testid explorer scroll view',
+    url: {
+      [MIN_GRAFANA_VERSION]: '/explore',
     },
-  },
-  SoloPanel: {
-    url: (page: string) => `/d-solo/${page}`,
-  },
-  PluginsList: {
-    page: 'Plugins list page',
-    list: 'Plugins list',
-    listItem: 'Plugins list item',
-    signatureErrorNotice: 'Unsigned plugins notice',
-  },
-  PluginPage: {
-    page: 'Plugin page',
-    signatureInfo: 'Plugin signature info',
-    disabledInfo: 'Plugin disabled info',
-  },
-  PlaylistForm: {
-    name: 'Playlist name',
-    interval: 'Playlist interval',
-    itemDelete: 'data-testid playlist-form-delete-item',
-  },
-  BrowseDashboards: {
-    table: {
-      body: 'data-testid browse-dashboards-table',
-      row: (uid: string) => `data-testid ${uid} row`,
-      checkbox: (uid: string) => `data-testid ${uid} checkbox`,
-    },
-  },
-  Search: {
-    url: '/?search=openn',
-    FolderView: {
-      url: '/?search=open&layout=folders',
-    },
-  },
-  PublicDashboards: {
-    ListItem: {
-      linkButton: 'public-dashboard-link-button',
-      configButton: 'public-dashboard-configuration-button',
-      trashcanButton: 'public-dashboard-remove-button',
-      pauseSwitch: 'data-testid public dashboard pause switch',
-    },
-  },
-  UserListPage: {
-    tabs: {
-      allUsers: 'data-testid all-users-tab',
-      orgUsers: 'data-testid org-users-tab',
-      publicDashboardsUsers: 'data-testid public-dashboards-users-tab',
-      users: 'data-testid users-tab',
-    },
-    org: {
-      url: '/org/users',
-    },
-    admin: {
-      url: '/admin/users',
-    },
-    publicDashboards: {
-      container: 'data-testid public-dashboards-users-list',
-    },
-    UserListAdminPage: {
-      container: 'data-testid user-list-admin-page',
-    },
-    UsersListPage: {
-      container: 'data-testid users-list-page',
-    },
-    UsersListPublicDashboardsPage: {
-      container: 'data-testid users-list-public-dashboards-page',
-      DashboardsListModal: {
-        listItem: (uid: string) => `data-testid dashboards-list-item-${uid}`,
-      },
-    },
-  },
-  ProfilePage: {
-    url: '/profile',
   },
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

In an early stage of this project, all selectors were being copied from the grafana/e2e-selectors package. This PR removes all selectors that are not being used internally in the plugin-e2e package. Also making sure all selectors have a minimum Grafana version associated with it. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.5.0-canary.641.7aa6686.0
  # or 
  yarn add @grafana/plugin-e2e@0.5.0-canary.641.7aa6686.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
