### PR TITLE
Github workflows: Add correct permissions to the release workflow

### DIFF
--- a/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 {{!-- /* 🚨 The `$\{{ }}` Github workflow expressions need to be escaped so they are not being interpreted by Handlebars. (this comment is going to be removed after scaffolding) 🚨 */ --}}
+# This GitHub Action automates the process of building Grafana plugins.
+# (For more information, see https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md)
 name: Release
 
 on:
@@ -6,16 +8,19 @@ on:
     tags:
       - 'v*' # Run workflow on version tags, e.g. v1.0.0.
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: grafana/plugin-actions/build-plugin@release
-        # uncomment to enable plugin sign in
+        # Uncomment to enable plugin signing
+        # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
         #with:
-          # see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token to generate it
-          # save the value in your repository secrets
+          # Make sure to save the token in your repository secrets
           #policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-          #usage of GRAFANA_API_KEY is deprecated prefer policy_token
+          # Usage of GRAFANA_API_KEY is deprecated, prefer `policy_token` option above
           #grafana_token: ${{ secrets.GRAFANA_API_KEY }}


### PR DESCRIPTION
### What changed?

It looks like the scaffolded github workflow for generating a release didn't have the correct permissions, and because of that couldn't create the release (it seems to be correct [in our action docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md#workflow-example)). This PR is aiming to fix that.

**Example failure in a community plugin:** 
https://github.com/lucas-bremond/satellite-visualizer/actions/runs/7412943386/job/20170819761#step:3:931
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@2.10.2-canary.642.a61597c.0
  # or 
  yarn add @grafana/create-plugin@2.10.2-canary.642.a61597c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
