### PR TITLE
Plugin E2E: Re-adding a few selectors

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -32,12 +32,12 @@ export type Components = {
       headerCornerInfo: (mode: string) => string;
       status: (status: string) => string;
     };
-  };
-  Visualization: {
-    Table: {
-      header: string;
-      footer: string;
-      body: string;
+    Visualization: {
+      Table: {
+        header: string;
+        footer: string;
+        body: string;
+      };
     };
   };
   PanelEditor: {

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -28,8 +28,16 @@ export type Components = {
   };
   Panels: {
     Panel: {
+      title: (title: string) => string;
       headerCornerInfo: (mode: string) => string;
       status: (status: string) => string;
+    };
+  };
+  Visualization: {
+    Table: {
+      header: string;
+      footer: string;
+      body: string;
     };
   };
   PanelEditor: {
@@ -64,6 +72,11 @@ export type Components = {
   };
   PluginVisualization: {
     item: (title: string) => string;
+  };
+  Select: {
+    option: string;
+    input: () => string;
+    singleValue: () => string;
   };
   DataSourcePicker: {
     container: string;

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -24,12 +24,30 @@ export const versionedComponents = {
   },
   Panels: {
     Panel: {
+      title: {
+        '8.1.2': (title: string) => `data-testid Panel header ${title}`,
+        [MIN_GRAFANA_VERSION]: (title: string) => `Panel header ${title}`,
+      },
       headerCornerInfo: {
         [MIN_GRAFANA_VERSION]: (mode: string) => `Panel header ${mode}`,
       },
       status: {
         ['10.2.0']: (status: string) => `data-testid Panel status ${status}`,
         [MIN_GRAFANA_VERSION]: (_: string) => 'Panel status',
+      },
+    },
+    Visualization: {
+      Table: {
+        header: {
+          [MIN_GRAFANA_VERSION]: 'table header',
+        },
+        footer: {
+          [MIN_GRAFANA_VERSION]: 'table-footer',
+        },
+        body: {
+          // did not exist prior to 10.2.0
+          '10.2.0': 'data-testid table body',
+        },
       },
     },
   },
@@ -105,6 +123,18 @@ export const versionedComponents = {
   PluginVisualization: {
     item: {
       [MIN_GRAFANA_VERSION]: (title: string) => `Plugin visualization item ${title}`,
+    },
+  },
+  Select: {
+    option: {
+      [MIN_GRAFANA_VERSION]: 'Select option',
+    },
+    input: {
+      '8.3.0': () => 'input[id*="time-options-input"]',
+      [MIN_GRAFANA_VERSION]: () => 'input[id*="react-select-"]',
+    },
+    singleValue: {
+      [MIN_GRAFANA_VERSION]: () => 'div[class*="-singleValue"]',
     },
   },
   DataSourcePicker: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

I was a bit to quick in https://github.com/grafana/plugin-tools/pull/641 and removed a few selectors that were being used [here](https://github.com/grafana/grafana/pull/79969/files) in core grafana. This PR re-adds those selectors. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.6.1-canary.644.c0a1312.0
  # or 
  yarn add @grafana/plugin-e2e@0.6.1-canary.644.c0a1312.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
