### PR TITLE
Only run ts checker and eslint plugins in webpack dev mode

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -181,18 +181,20 @@ const config = async (env): Promise<Configuration> => {
           ],
         },
       ]),
-      new ForkTsCheckerWebpackPlugin({
-        async: Boolean(env.development),
-        issue: {
-          include: [{ file: '**/*.{ts,tsx}' }],
-        },
-        typescript: { configFile: path.join(process.cwd(), 'tsconfig.json') },
-      }),
-      new ESLintPlugin({
-        extensions: ['.ts', '.tsx'],
-        lintDirtyModulesOnly: Boolean(env.development), // don't lint on start, only lint changed files
-      }),
-      ...(env.development ? [new LiveReloadPlugin()] : []),
+      ...(env.development ? [
+        new LiveReloadPlugin(),
+        new ForkTsCheckerWebpackPlugin({
+          async: Boolean(env.development),
+          issue: {
+            include: [{ file: '**/*.{ts,tsx}' }],
+          },
+          typescript: { configFile: path.join(process.cwd(), 'tsconfig.json') },
+        }),
+        new ESLintPlugin({
+          extensions: ['.ts', '.tsx'],
+          lintDirtyModulesOnly: Boolean(env.development), // don't lint on start, only lint changed files
+        }),
+      ] : []),
     ],
 
     resolve: {


### PR DESCRIPTION
**What this PR does / why we need it**:

Only runs the eslint and tschecker plugins if running webpack in development mode

Benchmark without this change in a generated panel plugin

```
❯ hyperfine -p "rm -rf dist" -r 5 "npm run  build" --warmup 1
Benchmark 1: npm run  build
  Time (mean ± σ):      2.578 s ±  0.021 s    [User: 5.800 s, System: 0.668 s]
  Range (min … max):    2.543 s …  2.596 s    5 runs
```

Benchmark with this change in a generated panel plugin

```
❯ hyperfine -p "rm -rf dist" -r 5 "npm run  build" --warmup 1
Benchmark 1: npm run  build
  Time (mean ± σ):     965.1 ms ±  16.0 ms    [User: 1266.3 ms, System: 377.7 ms]
  Range (min … max):   944.2 ms … 984.0 ms    5 runs
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/plugin-tools/issues/615

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@2.10.3-canary.647.95c92b2.0
  # or 
  yarn add @grafana/create-plugin@2.10.3-canary.647.95c92b2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
