### PR TITLE
Plugin E2E: Change signature of custom matcher

### DIFF
--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -18,7 +18,7 @@ declare global {
       /**
        * Await the response of a Playwright request and asserts the response was successful (status in the range 200-299).
        */
-      toBeOK(this: Matchers<unknown, Promise<Response>>): R;
+      toBeOK(this: Matchers<unknown, Response>): R;
 
       /**
        * Asserts that preview text elements are displayed on the Variable Edit Page. You should make sure any variable queries are completed before calling this matcher.

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -16,7 +16,7 @@ declare global {
       [t]: T;
 
       /**
-       * Await the response of a Playwright request and asserts the response was successful (status in the range 200-299).
+       * Asserts that a Playwright response was successful (status in the range 200-299).
        */
       toBeOK(this: Matchers<unknown, Response>): R;
 

--- a/packages/plugin-e2e/src/matchers/toBeOK.ts
+++ b/packages/plugin-e2e/src/matchers/toBeOK.ts
@@ -1,25 +1,12 @@
 import { Response } from '@playwright/test';
 import { getMessage } from './utils';
 
-const toBeOK = async (request: Promise<Response>) => {
-  let pass = false;
-  let actual;
-  let message: any = 'Response status code is within 200..299 range.';
-
-  try {
-    const response = await request;
-    return {
-      message: () => getMessage(message, response.status().toString()),
-      pass: response.ok(),
-      actual: response.status(),
-    };
-  } catch (err: unknown) {
-    return {
-      message: () => getMessage(message, err instanceof Error ? err.toString() : 'Unknown error'),
-      pass,
-      actual,
-    };
-  }
+const toBeOK = async (response: Response) => {
+  return {
+    pass: response.ok(),
+    actual: response.status(),
+    message: () => getMessage('Response status code is within 200..299 range.', response.status().toString()),
+  };
 };
 
 export default toBeOK;

--- a/packages/plugin-e2e/tests/datasource/annotations/annotationQueryRunner.integration.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/annotations/annotationQueryRunner.integration.spec.ts
@@ -15,7 +15,7 @@ test('should run successfully if valid Redshift query was provided', async ({
   await page.waitForFunction(() => (window as any).monaco);
   await annotationEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).click();
   await page.keyboard.insertText('SELECT starttime, eventname FROM event ORDER BY eventname ASC LIMIT 5 ');
-  await expect(annotationEditPage.runQuery()).toBeOK();
+  await expect(await annotationEditPage.runQuery()).toBeOK();
   await expect(page.getByText('.38 Special')).toBeTruthy();
 });
 
@@ -29,7 +29,7 @@ test('should run successfully if valid Google Sheets query was provided', async 
   await page.getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   await page.keyboard.press('Enter');
-  await expect(annotationEditPage.runQuery()).toBeOK();
+  await expect(await annotationEditPage.runQuery()).toBeOK();
 });
 
 test('should run successfully if valid Redshift query was provided in provisioned dashboard', async ({
@@ -45,5 +45,5 @@ test('should run successfully if valid Redshift query was provided in provisione
     { dashboard: { uid: provision.uid }, id: '1' }
   );
   await annotationEditPage.goto();
-  await expect(annotationEditPage.runQuery()).toBeOK();
+  await expect(await annotationEditPage.runQuery()).toBeOK();
 });

--- a/packages/plugin-e2e/tests/datasource/config-editor/configEditor.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/config-editor/configEditor.spec.ts
@@ -6,14 +6,14 @@ test('invalid credentials should return an error', async ({ createDataSourceConf
   const configPage = await createDataSourceConfigPage({ type: 'grafana-googlesheets-datasource' });
   await clickRadioButton(page, 'API Key', { exact: true });
   await page.getByPlaceholder('Enter API key').fill('xyz');
-  await expect(configPage.saveAndTest()).not.toBeOK();
+  await expect(await configPage.saveAndTest()).not.toBeOK();
 });
 
 test('valid credentials should return a 200 status code', async ({ createDataSourceConfigPage, page }) => {
   const configPage = await createDataSourceConfigPage({ type: 'grafana-googlesheets-datasource' });
   await page.getByTestId('Paste JWT button').click();
   await page.getByTestId('Configuration text area').fill(process.env.GOOGLE_JWT_FILE!.replace(/'/g, ''));
-  await expect(configPage.saveAndTest()).toBeOK();
+  await expect(await configPage.saveAndTest()).toBeOK();
 });
 
 test('valid credentials should display a success alert on the page', async ({ createDataSourceConfigPage, page }) => {

--- a/packages/plugin-e2e/tests/datasource/explore/queryEditor.integration.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/explore/queryEditor.integration.spec.ts
@@ -15,7 +15,7 @@ test('should return data and not display panel error when a valid query is provi
   const responsePromise = page.waitForResponse((resp) => resp.url().includes('/api/ds/query'));
   await page.keyboard.press('Tab');
   await responsePromise;
-  await expect(explorePage.runQuery()).toBeOK();
+  await expect(await explorePage.runQuery()).toBeOK();
 });
 
 test('should return an error and display panel error when an invalid query is provided', async ({
@@ -34,5 +34,5 @@ test('should return an error and display panel error when an invalid query is pr
   const responsePromise = page.waitForResponse((resp) => resp.url().includes('/api/ds/query'));
   await page.keyboard.press('Tab');
   await responsePromise;
-  await expect(explorePage.runQuery()).not.toBeOK();
+  await expect(await explorePage.runQuery()).not.toBeOK();
 });

--- a/packages/plugin-e2e/tests/datasource/feature-toggles/queryDataHandler.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/feature-toggles/queryDataHandler.spec.ts
@@ -23,6 +23,6 @@ test('query data handler', async ({ selectors, panelEditPage, page, readProvisio
     await expect(await queryStatedResponse).toBeTruthy();
     await expect(await queryFinishedResponse).toBeTruthy();
   } else {
-    await expect(panelEditPage.refreshPanel()).toBeOK();
+    await expect(await panelEditPage.refreshPanel()).toBeOK();
   }
 });

--- a/packages/plugin-e2e/tests/datasource/query-editor/queryEditor.integration.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/query-editor/queryEditor.integration.spec.ts
@@ -13,7 +13,7 @@ test('should return data and not display panel error when a valid query is provi
   await queryEditorRow.getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   await page.keyboard.press('Enter');
-  await expect(panelEditPage.refreshPanel()).toBeOK();
+  await expect(await panelEditPage.refreshPanel()).toBeOK();
   await expect(panelEditPage).not.toHavePanelError();
 });
 
@@ -30,6 +30,6 @@ test('should return an error and display panel error when an invalid query is pr
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   await page.keyboard.press('Enter');
   await page.getByPlaceholder('Class Data!A2:E').fill('invalid range');
-  await expect(panelEditPage.refreshPanel()).not.toBeOK();
+  await expect(await panelEditPage.refreshPanel()).not.toBeOK();
   await expect(panelEditPage).toHavePanelError();
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Playwright has a [`toBeOK`](https://playwright.dev/docs/api/class-apiresponseassertions#api-response-assertions-to-be-ok) matcher. Unfortunately, it only applies to the [APIResponse](https://playwright.dev/docs/api/class-apiresponse) type, so I have defined a custom matcher with the same name that applies also to `Response` type (which is useful when executing grafana queries). I'd like our custom matchers to align with Playwright matchers if possible, so this PR changes the signature of the custom `toBeOK` matcher to accept a `Response` instead of `Promise<Response>`. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.9.0-canary.655.ce61438.0
  # or 
  yarn add @grafana/plugin-e2e@0.9.0-canary.655.ce61438.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
