### PR TITLE
Fix `CONTRIBUTING.md` link

### DIFF
--- a/packages/create-plugin/README.md
+++ b/packages/create-plugin/README.md
@@ -116,4 +116,4 @@ For more information see our [documentation](https://grafana.com/developers/plug
 
 ## Contributing
 
-We are always grateful for contributions! See [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.
+We are always grateful for contributions! See [CONTRIBUTING.md](../../CONTRIBUTING.md) for more information.

--- a/packages/sign-plugin/README.md
+++ b/packages/sign-plugin/README.md
@@ -64,4 +64,4 @@ yarn dlx @grafana/sign-plugin@latest
 
 ## Contributing
 
-We are always grateful for contribution! See the [CONTRIBUTING.md](../CONTRIBUTING.md) for more information.
+We are always grateful for contribution! See the [CONTRIBUTING.md](../../CONTRIBUTING.md) for more information.


### PR DESCRIPTION
Simply fixing a broken link

I encountered the broken link from here:
https://www.npmjs.com/package/@grafana/create-plugin#contributing