### PR TITLE
Build: Migrate sign-plugin to ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28549,7 +28549,8 @@
         "sign-plugin": "dist/bin/run.js"
       },
       "devDependencies": {
-        "@types/minimist": "^1.2.2"
+        "@types/minimist": "^1.2.2",
+        "vitest": "^1.1.3"
       },
       "engines": {
         "node": ">=20"

--- a/packages/sign-plugin/jest.config.js
+++ b/packages/sign-plugin/jest.config.js
@@ -1,3 +1,0 @@
-const sharedConfig = require('../../jest.config.base');
-
-module.exports = sharedConfig;

--- a/packages/sign-plugin/package.json
+++ b/packages/sign-plugin/package.json
@@ -25,7 +25,8 @@
     "dev": "nodemon --exec 'tsc'",
     "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx ./src",
     "lint:fix": "npm run lint -- --fix",
-    "test": "jest",
+    "test": "vitest",
+    "test:ci": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -33,7 +34,8 @@
     "proxy-agent": "6.3.1"
   },
   "devDependencies": {
-    "@types/minimist": "^1.2.2"
+    "@types/minimist": "^1.2.2",
+    "vitest": "^1.1.3"
   },
   "nodemonConfig": {
     "watch": [

--- a/packages/sign-plugin/package.json
+++ b/packages/sign-plugin/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@grafana/sign-plugin",
   "version": "2.3.0",
-  "main": "index.js",
   "repository": {
     "directory": "packages/sign-plugin",
     "url": "https://github.com/grafana/plugin-tools"
@@ -9,6 +8,13 @@
   "author": "Grafana",
   "license": "Apache-2.0",
   "bin": "./dist/bin/run.js",
+  "type": "module",
+  "exports": {
+    "node": {
+      "import": "./index.js"
+    },
+    "default": "./index.js"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/sign-plugin/package.json
+++ b/packages/sign-plugin/package.json
@@ -25,8 +25,7 @@
     "dev": "nodemon --exec 'tsc'",
     "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx ./src",
     "lint:fix": "npm run lint -- --fix",
-    "test": "vitest",
-    "test:ci": "vitest run",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/sign-plugin/src/bin/run.ts
+++ b/packages/sign-plugin/src/bin/run.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import minimist from 'minimist';
-import { sign, version } from '../commands';
+import { sign, version } from '../commands/index.js';
 
 const args = process.argv.slice(2);
 const argv = minimist(args);

--- a/packages/sign-plugin/src/commands/index.ts
+++ b/packages/sign-plugin/src/commands/index.ts
@@ -1,2 +1,2 @@
-export * from './sign.command';
-export * from './version.command';
+export * from './sign.command.js';
+export * from './version.command.js';

--- a/packages/sign-plugin/src/commands/sign.command.ts
+++ b/packages/sign-plugin/src/commands/sign.command.ts
@@ -1,9 +1,9 @@
 import path from 'path';
 import minimist from 'minimist';
 import { existsSync } from 'fs';
-import { assertRootUrlIsValid } from '../utils/pluginValidation';
-import { buildManifest, signManifest, saveManifest } from '../utils/manifest';
-import { getVersion } from '../utils/getVersion';
+import { assertRootUrlIsValid } from '../utils/pluginValidation.js';
+import { buildManifest, signManifest, saveManifest } from '../utils/manifest.js';
+import { getVersion } from '../utils/getVersion.js';
 
 export const sign = async (argv: minimist.ParsedArgs) => {
   const distDir = argv.distDir ?? 'dist';

--- a/packages/sign-plugin/src/commands/sign.command.ts
+++ b/packages/sign-plugin/src/commands/sign.command.ts
@@ -1,9 +1,9 @@
-import path from 'path';
 import minimist from 'minimist';
-import { existsSync } from 'fs';
-import { assertRootUrlIsValid } from '../utils/pluginValidation.js';
-import { buildManifest, signManifest, saveManifest } from '../utils/manifest.js';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
 import { getVersion } from '../utils/getVersion.js';
+import { buildManifest, saveManifest, signManifest } from '../utils/manifest.js';
+import { assertRootUrlIsValid } from '../utils/pluginValidation.js';
 
 export const sign = async (argv: minimist.ParsedArgs) => {
   const distDir = argv.distDir ?? 'dist';

--- a/packages/sign-plugin/src/commands/version.command.ts
+++ b/packages/sign-plugin/src/commands/version.command.ts
@@ -1,4 +1,4 @@
-import { getVersion } from '../utils/getVersion';
+import { getVersion } from '../utils/getVersion.js';
 
 export const version = async () => {
   try {

--- a/packages/sign-plugin/src/utils/getVersion.ts
+++ b/packages/sign-plugin/src/utils/getVersion.ts
@@ -1,5 +1,8 @@
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export const getVersion = () => {
   const packageJsonPath = resolve(__dirname, '..', '..', 'package.json');

--- a/packages/sign-plugin/src/utils/manifest.ts
+++ b/packages/sign-plugin/src/utils/manifest.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import fs from 'fs/promises';
 import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
-import { postData } from './request';
+import { postData } from './request.js';
 
 const MANIFEST_FILE = 'MANIFEST.txt';
 
@@ -78,13 +78,16 @@ export async function signManifest(manifest: ManifestInfo): Promise<string> {
   const GRAFANA_API_KEY = process.env.GRAFANA_API_KEY;
   const GRAFANA_ACCESS_POLICY_TOKEN = process.env.GRAFANA_ACCESS_POLICY_TOKEN;
 
-  if(!GRAFANA_ACCESS_POLICY_TOKEN && !GRAFANA_API_KEY) {
+  if (!GRAFANA_ACCESS_POLICY_TOKEN && !GRAFANA_API_KEY) {
     throw new Error(
       'You must create a GRAFANA_ACCESS_POLICY_TOKEN env variable to sign plugins. Please see: https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token for instructions.'
     );
   }
   if (GRAFANA_API_KEY) {
-    console.warn(`\x1b[33m%s\x1b[0m`,'The usage of GRAFANA_API_KEY is deprecated, please consider using GRAFANA_ACCESS_POLICY_TOKEN instead. For more info visit https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin')
+    console.warn(
+      `\x1b[33m%s\x1b[0m`,
+      'The usage of GRAFANA_API_KEY is deprecated, please consider using GRAFANA_ACCESS_POLICY_TOKEN instead. For more info visit https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin'
+    );
   }
 
   const GRAFANA_COM_URL = process.env.GRAFANA_COM_URL || 'https://grafana.com/api';

--- a/packages/sign-plugin/src/utils/manifest.ts
+++ b/packages/sign-plugin/src/utils/manifest.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
-import fs from 'fs/promises';
-import { readFileSync, writeFileSync } from 'fs';
-import path from 'path';
+import { readFileSync, writeFileSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { postData } from './request.js';
 
 const MANIFEST_FILE = 'MANIFEST.txt';

--- a/packages/sign-plugin/src/utils/pluginValidation.test.ts
+++ b/packages/sign-plugin/src/utils/pluginValidation.test.ts
@@ -1,4 +1,4 @@
-import { getPluginJson, validatePluginJson } from './pluginValidation';
+import { getPluginJson, validatePluginJson } from './pluginValidation.js';
 
 describe('pluginValidation', () => {
   describe('plugin.json', () => {

--- a/packages/sign-plugin/src/utils/request.ts
+++ b/packages/sign-plugin/src/utils/request.ts
@@ -1,7 +1,6 @@
-import https, { RequestOptions } from 'https';
+import https, { RequestOptions } from 'node:https';
+import { URL } from 'node:url';
 import { ProxyAgent } from 'proxy-agent';
-
-import { URL } from 'url';
 
 interface Headers {
   Authorization: string;

--- a/packages/sign-plugin/tsconfig.json
+++ b/packages/sign-plugin/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "lib": ["es2023", "dom"],
+    "module": "node16",
+    "target": "es2022",
+    "moduleResolution": "node16",
     "outDir": "./dist"
   },
   "exclude": ["node_modules"],

--- a/packages/sign-plugin/vitest.config.ts
+++ b/packages/sign-plugin/vitest.config.ts
@@ -1,0 +1,10 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    root: resolve(__dirname),
+    globals: true,
+    include: ['**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR updates the sign-plugin package to build only as an es module. The following changes have been made with reasoning on approaches:

- Updates Typescript config to output ESM. These changes are in line with [tsconfig/bases/node20](https://github.com/tsconfig/bases/blob/main/bases/node20.json) suggested config. Having found these configs I'm wondering if we should update the entire repo to use them over writing our own.
- Updates all import paths inline with Typescripts requirements by adding `.js` extension to imports. Note that auto barrel file resolution (`from './commands/'` resolved to `from './commands/index.js'`) no longer work with ESM. You have to reference a file. VsCode autocompletion seems to work out the box. I attempted to use a bundler ESbuild to prevent the need to change all these imports but [hit a wall](https://github.com/evanw/esbuild/issues/622#issuecomment-752915822). 
- Replaces Jest with Vitest. Turns out Jest support for ESM is quite poor. Mocking in particular is complicated due to [esm static import analysis](https://jestjs.io/docs/ecmascript-modules#module-mocking-in-esm) and needing to use `unstable_mockModule` which I didn't particularly like the sound of. Vitest migration was quite painless, only the mocks needed some attention.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/sign-plugin@3.0.0-canary.662.8ab45d5.0
  # or 
  yarn add @grafana/sign-plugin@3.0.0-canary.662.8ab45d5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
