### PR TITLE
add plugin build automation doc

### DIFF
--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -54,7 +54,7 @@ After you push the tag, you can create the same tag again.
 
 Access the final release zip file directly from the GitHub repository release path.
 
-[Link to generated ZIP](https://github.com/briangann/grafana-gauge-panel/releases/download/v2.0.1/briangann-gauge-panel-2.0.1.zip)
+[Link to generated zip file](https://github.com/briangann/grafana-gauge-panel/releases/download/v2.0.1/briangann-gauge-panel-2.0.1.zip)
 
 ## Next steps
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -15,7 +15,7 @@ keywords:
 
 # Automate packaging and signing with CI
 
-If your plugin has been set up to use the supplied [Git workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx),
+If your plugin has been set up to use the supplied [Github workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx),
 the plugin should be built and packaged in the correct format.
 
 If you need to set up the git worklows, see [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md)

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -16,7 +16,7 @@ keywords:
 # Automate packaging and signing with GitHub CI
 
 We recommend setting up your plugin to use the supplied [Github workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx)
-the plugin should be built and packaged in the correct format.
+to ensure that your plugin will be built and packaged in the correct format.
 
 If you need to set up the Github worklows, see [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md)
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -15,7 +15,7 @@ keywords:
 
 # Automate packaging and signing with GitHub CI
 
-If your plugin has been set up to use the supplied [Github workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx),
+We recommend setting up your plugin to use the supplied [Github workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx)
 the plugin should be built and packaged in the correct format.
 
 If you need to set up the Github worklows, see [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md)

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -13,7 +13,7 @@ keywords:
   - builds
 ---
 
-# Automate packaging and signing with Github CI
+# Automate packaging and signing with GitHub CI
 
 If your plugin has been set up to use the supplied [Github workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx),
 the plugin should be built and packaged in the correct format.

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -50,7 +50,7 @@ git pull origin  main
 
 After you push the tag, you can create the same tag again.
 
-## Download the release ZIP file
+## Download the release zip file
 
 Access the final release zip file directly from the Github repository release path.
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -48,7 +48,7 @@ git checkout main
 git pull origin  main
 ```
 
-Once the push is made, you can create the same tag again.
+After you push the tag, you can create the same tag again.
 
 ## Download the release ZIP file
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -52,7 +52,7 @@ After you push the tag, you can create the same tag again.
 
 ## Download the release zip file
 
-Access the final release zip file directly from the Github repository release path.
+Access the final release zip file directly from the GitHub repository release path.
 
 [Link to generated ZIP](https://github.com/briangann/grafana-gauge-panel/releases/download/v2.0.1/briangann-gauge-panel-2.0.1.zip)
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -26,7 +26,7 @@ If a signing key is included in the Git repo, a signed build is automatically cr
 
 By creating a release tag, the whole process becomes automated, resulting in a ZIP file that you can submit for publication in the [Grafana plugin catalog](https://grafana.com/plugins)
 
-## Creating a Release Tag
+## Create a release tag
 
 A tag with the format `vX.X.X` is used to trigger the release workflow. Typically all of your changes will be merged into `main`, and the tag is applied to `main`
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -18,7 +18,7 @@ keywords:
 If your plugin has been set up to use the supplied [Github workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx),
 the plugin should be built and packaged in the correct format.
 
-If you need to set up the git worklows, see [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md)
+If you need to set up the Github worklows, see [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md)
 
 We recommend using the ZIP file produced from this workflow to test the plugin.
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -26,6 +26,8 @@ If a signing key is included in the Git repo, a signed build is automatically cr
 
 By creating a release tag, the whole process becomes automated, resulting in a ZIP file that you can submit for publication in the [Grafana plugin catalog](https://grafana.com/plugins)
 
+The ZIP file can be downloaded from the Summary page of the CI workflow.
+
 ## Create a release tag
 
 A tag with the format `vX.X.X` is used to trigger the release workflow. Typically all of your changes will be merged into `main`, and the tag is applied to `main`

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -18,10 +18,42 @@ keywords:
 If your plugin has been set up to use the supplied [Git workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx),
 the plugin should be built and packaged in the correct format.
 
+If you need to set up the git worklows, see [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md)
+
 We recommend using the ZIP file produced from this workflow to test the plugin.
 
 If a signing key is included in the Git repo, a signed build is automatically created, which you can use to test the plugin locally before submission.
 
 By creating a release tag, the whole process becomes automated, resulting in a ZIP file that you can submit for publication in the [Grafana plugin catalog](https://grafana.com/plugins)
+
+## Creating a Release Tag
+
+A tag with the format `vX.X.X` is used to trigger the release workflow. Typically all of your changes will be merged into `main`, and the tag is applied to `main`
+
+```BASH
+git checkout main
+git pull origin main
+git tag v2.0.1
+git push origin v2.0.1
+```
+
+If you need to re-tag the release, the current tag can be removed by issuing the commands:
+
+```BASH
+git tag -d v2.0.1
+git push --delete origin v2.0.1
+git checkout main
+git pull origin  main
+```
+
+Once the push is made, you can create the same tag again.
+
+## Downloading the release zip file
+
+Access the final release zip file directly from the git repo release path.
+
+[Link to generated ZIP](https://github.com/briangann/grafana-gauge-panel/releases/download/v2.0.1/briangann-gauge-panel-2.0.1.zip)
+
+## Next Steps
 
 When you've packaged your plugin, proceed to [publishing a plugin](./publish-or-update-a-plugin.md) or [installing a packaged plugin](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-packaged-plugin).

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -1,0 +1,27 @@
+---
+id: build-automation
+title: Package a plugin
+sidebar_position: 1
+description: Automating Grafana plugin builds and releases
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - links
+  - package
+  - packaging
+  - packages
+---
+
+# Automated package and signing with CI
+
+If the plugin has been setup to use the supplied git workflows from create-plugin,
+the plugin will be built and packaged in the correct format.
+
+The zip file produced can be used to test the plugin.
+
+If a signing key is included in the git repo, a signed build is automatically created, which can be tested locally before submission.
+
+By creating a release tag, the whole process is automated, resulting in a zip file that can be submitted for review on grafana.com
+
+When you've packaged your plugin, you can proceed to [publishing a plugin](./publish-or-update-a-plugin.md) or [installing a packaged plugin](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-packaged-plugin).

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -18,7 +18,7 @@ keywords:
 We recommend setting up your plugin to use the supplied [Github workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx)
 to ensure that your plugin will be built and packaged in the correct format.
 
-If you need to set up the Github worklows, see [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md)
+To do so, refer to [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md).
 
 We recommend using the ZIP file produced from this workflow to test the plugin.
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -20,7 +20,7 @@ to ensure that your plugin will be built and packaged in the correct format.
 
 To do so, refer to [these docs](https://github.com/grafana/plugin-actions/blob/main/build-plugin/README.md).
 
-We recommend using the ZIP file produced from this workflow to test the plugin.
+Additionally, we recommend using the zip file produced from this workflow to test the plugin.
 
 If a Grafana Access Policy Token is included your [Github repository secrets](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization), a signed build is automatically created, which you can use to test the plugin locally before submission.
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -54,6 +54,6 @@ Access the final release zip file directly from the git repo release path.
 
 [Link to generated ZIP](https://github.com/briangann/grafana-gauge-panel/releases/download/v2.0.1/briangann-gauge-panel-2.0.1.zip)
 
-## Next Steps
+## Next steps
 
 When you've packaged your plugin, proceed to [publishing a plugin](./publish-or-update-a-plugin.md) or [installing a packaged plugin](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-packaged-plugin).

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -13,7 +13,7 @@ keywords:
   - builds
 ---
 
-# Automate packaging and signing with CI
+# Automate packaging and signing with Github CI
 
 If your plugin has been set up to use the supplied [Github workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx),
 the plugin should be built and packaged in the correct format.

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -39,7 +39,7 @@ git tag v2.0.1
 git push origin v2.0.1
 ```
 
-If you need to re-tag the release, the current tag can be removed by issuing the commands:
+If you need to re-tag the release, the current tag can be removed with these commands:
 
 ```BASH
 git tag -d v2.0.1

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -52,7 +52,7 @@ Once the push is made, you can create the same tag again.
 
 ## Download the release ZIP file
 
-Access the final release zip file directly from the git repo release path.
+Access the final release zip file directly from the Github repository release path.
 
 [Link to generated ZIP](https://github.com/briangann/grafana-gauge-panel/releases/download/v2.0.1/briangann-gauge-panel-2.0.1.zip)
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -48,7 +48,7 @@ git pull origin  main
 
 Once the push is made, you can create the same tag again.
 
-## Downloading the release zip file
+## Download the release ZIP file
 
 Access the final release zip file directly from the git repo release path.
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -13,15 +13,15 @@ keywords:
   - builds
 ---
 
-# Automated package and signing with CI
+# Automate packaging and signing with CI
 
-If the plugin has been setup to use the supplied git workflows from create-plugin,
-the plugin will be built and packaged in the correct format.
+If your plugin has been set up to use the supplied [Git workflows](../create-a-plugin/develop-a-plugin/set-up-github-workflows.md) from [create-plugin](../get-started/get-started.mdx),
+the plugin should be built and packaged in the correct format.
 
-The zip file produced can be used to test the plugin.
+We recommend using the ZIP file produced from this workflow to test the plugin.
 
-If a signing key is included in the git repo, a signed build is automatically created, which can be tested locally before submission.
+If a signing key is included in the Git repo, a signed build is automatically created, which you can use to test the plugin locally before submission.
 
-By creating a release tag, the whole process is automated, resulting in a zip file that can be submitted for review on grafana.com
+By creating a release tag, the whole process becomes automated, resulting in a ZIP file that you can submit for publication in the [Grafana plugin catalog](https://grafana.com/plugins)
 
-When you've packaged your plugin, you can proceed to [publishing a plugin](./publish-or-update-a-plugin.md) or [installing a packaged plugin](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-packaged-plugin).
+When you've packaged your plugin, proceed to [publishing a plugin](./publish-or-update-a-plugin.md) or [installing a packaged plugin](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-packaged-plugin).

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -1,16 +1,16 @@
 ---
 id: build-automation
-title: Package a plugin
+title: Automate plugin builds
 sidebar_position: 1
-description: Automating Grafana plugin builds and releases
+description: Automate Grafana plugin builds and releases
 keywords:
   - grafana
   - plugins
   - plugin
-  - links
-  - package
-  - packaging
-  - packages
+  - automation
+  - build
+  - automate
+  - builds
 ---
 
 # Automated package and signing with CI

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -22,7 +22,7 @@ If you need to set up the Github worklows, see [these docs](https://github.com/g
 
 We recommend using the ZIP file produced from this workflow to test the plugin.
 
-If a signing key is included in the Git repo, a signed build is automatically created, which you can use to test the plugin locally before submission.
+If a Grafana Access Policy Token is included your [Github repository secrets](https://docs.github.com/en/codespaces/managing-codespaces-for-your-organization/managing-development-environment-secrets-for-your-repository-or-organization), a signed build is automatically created, which you can use to test the plugin locally before submission.
 
 By creating a release tag, the whole process becomes automated, resulting in a ZIP file that you can submit for publication in the [Grafana plugin catalog](https://grafana.com/plugins)
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Adds info about the workflows provided by `create-plugin` vs having to perform the manual steps.

