### PR TITLE
create-plugin: update grafana version to `v10.3.3`

### DIFF
--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -43,7 +43,7 @@ export enum PLUGIN_TYPES {
 // and will be available to use in the templates.
 // Example: "@grafana/ui": "{{ grafanaVersion }}"
 export const EXTRA_TEMPLATE_VARIABLES = {
-  grafanaVersion: '10.3.1',
+  grafanaVersion: '10.3.3',
   grafanaImage: 'grafana-enterprise',
 };
 

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -43,7 +43,7 @@ export enum PLUGIN_TYPES {
 // and will be available to use in the templates.
 // Example: "@grafana/ui": "{{ grafanaVersion }}"
 export const EXTRA_TEMPLATE_VARIABLES = {
-  grafanaVersion: '10.0.3',
+  grafanaVersion: '10.2.3',
   grafanaImage: 'grafana-enterprise',
 };
 

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -43,7 +43,7 @@ export enum PLUGIN_TYPES {
 // and will be available to use in the templates.
 // Example: "@grafana/ui": "{{ grafanaVersion }}"
 export const EXTRA_TEMPLATE_VARIABLES = {
-  grafanaVersion: '10.2.3',
+  grafanaVersion: '10.3.1',
   grafanaImage: 'grafana-enterprise',
 };
 

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -64,7 +64,7 @@
     "@grafana/runtime": "{{ grafanaVersion }}",
     "@grafana/ui": "{{ grafanaVersion }}",
     "@grafana/schema": "{{ grafanaVersion }}",{{#if_eq pluginType "scenesapp"}}
-    "@grafana/scenes": "^1.28.0",{{/if_eq}}
+    "@grafana/scenes": "^3.6.0",{{/if_eq}}
     "react": "18.2.0",
     "react-dom": "18.2.0",{{#if isAppType}}
     "react-router-dom": "^{{ reactRouterVersion }}",

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -68,7 +68,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",{{#if isAppType}}
     "react-router-dom": "^{{ reactRouterVersion }}",
-    "rxjs": "7.8.0",{{/if}}
+    "rxjs": "7.8.1",{{/if}}
     "tslib": "2.5.3"
   },
   "packageManager": "{{ packageManagerName }}@{{ packageManagerVersion }}"


### PR DESCRIPTION
### What changed?

- [x] Updated the underlying Grafana version to the latest (`10.3.3`). This is mostly updating the `@grafana` npm packages and the docker image.
- [x] Update to use the latest scenes package - `3.6.0` _(This was one necessary, as the latest version supports the latest Grafana versions as a peer dependency)_
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.1.0-canary.674.b3dfedb.0
  # or 
  yarn add @grafana/create-plugin@4.1.0-canary.674.b3dfedb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
