### PR TITLE
create-plugin: adds archive option for CI workflow

### DIFF
--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GRAFANA_ACCESS_POLICY_TOKEN: \${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+      GRAFANA_ACCESS_POLICY_TOKEN: $\{{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 {{#if_eq packageManagerName "pnpm"}}
@@ -99,7 +99,7 @@ jobs:
 
       - name: Sign plugin
         run: {{ packageManagerName }} run sign
-        if: \${{ env.GRAFANA_ACCESS_POLICY_TOKEN != '' }}
+        if: $\{{ env.GRAFANA_ACCESS_POLICY_TOKEN != '' }}
 
       - name: Get plugin metadata
         id: metadata
@@ -117,12 +117,12 @@ jobs:
       - name: Package plugin
         id: package-plugin
         run: |
-          mv dist \${{ steps.metadata.outputs.plugin-id }}
-          zip \${{ steps.metadata.outputs.archive }} \${{ steps.metadata.outputs.plugin-id }} -r
+          mv dist $\{{ steps.metadata.outputs.plugin-id }}
+          zip $\{{ steps.metadata.outputs.archive }} $\{{ steps.metadata.outputs.plugin-id }} -r
 
       - name: Archive Build
         uses: actions/upload-artifact@v3
         with:
-          name: \${{ steps.metadata.outputs.plugin-id }}-\${{ steps.metadata.outputs.plugin-version }}
-          path: \${{ steps.metadata.outputs.plugin-id }}
+          name: $\{{ steps.metadata.outputs.plugin-id }}-$\{{ steps.metadata.outputs.plugin-version }}
+          path: $\{{ steps.metadata.outputs.plugin-id }}
           retention-days: 5

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      GRAFANA_ACCESS_POLICY_TOKEN: \${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
     steps:
       - uses: actions/checkout@v3
 {{#if_eq packageManagerName "pnpm"}}
@@ -93,4 +95,34 @@ jobs:
         with:
           name: cypress-videos
           path: cypress/videos
+          retention-days: 5
+
+      - name: Sign plugin
+        run: {{ packageManagerName }} run sign
+        if: \${{ env.GRAFANA_ACCESS_POLICY_TOKEN != '' }}
+
+      - name: Get plugin metadata
+        id: metadata
+        run: |
+          sudo apt-get install jq
+
+          export GRAFANA_PLUGIN_ID=$(cat dist/plugin.json | jq -r .id)
+          export GRAFANA_PLUGIN_VERSION=$(cat dist/plugin.json | jq -r .info.version)
+          export GRAFANA_PLUGIN_ARTIFACT=${GRAFANA_PLUGIN_ID}-${GRAFANA_PLUGIN_VERSION}.zip
+
+          echo "plugin-id=${GRAFANA_PLUGIN_ID}" >> $GITHUB_OUTPUT
+          echo "plugin-version=${GRAFANA_PLUGIN_VERSION}" >> $GITHUB_OUTPUT
+          echo "archive=${GRAFANA_PLUGIN_ARTIFACT}" >> $GITHUB_OUTPUT
+
+      - name: Package plugin
+        id: package-plugin
+        run: |
+          mv dist \${{ steps.metadata.outputs.plugin-id }}
+          zip \${{ steps.metadata.outputs.archive }} \${{ steps.metadata.outputs.plugin-id }} -r
+
+      - name: Archive Build
+        uses: actions/upload-artifact@v3
+        with:
+          name: \${{ steps.metadata.outputs.plugin-id }}-\${{ steps.metadata.outputs.plugin-version }}
+          path: \${{ steps.metadata.outputs.plugin-id }}
           retention-days: 5


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds archiving of build so it can be downloaded/tested locally or through other automation methods.

The build will be signed if the key is present, otherwise it is just packaged as-is.

A "working" example can be found here:

https://github.com/briangann/grafana-gauge-panel/actions/runs/7617166961

![image](https://github.com/grafana/plugin-tools/assets/7364245/a5e5ccd8-ce8c-478d-98dd-f91ed9c95ec4)

doc referenced in #664