### PR TITLE
Docs: Add doc for event bus of PanelProps

### DIFF
--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
@@ -17,9 +17,7 @@ sidebar_position: 5
 
 # Subscribe to Grafana events
 
-If you’re building a [panel plugin](../../introduction/plugin-types-usage.md#panel-visualization-plugins), Grafana already provides the data you need to configure and render your panel. If not, you can usually retrieve the information you need from any of the runtime services, like `BackendSrv` and `TemplateSrv`.
-
-However, in some cases you may want your plugin to react to changes that occur outside of your plugin. For example, you may want your plugin to react when the user zooms in or out of another panel. In this guide, you’ll learn how to make your plugin react to events in Grafana.
+If you’re building a [panel plugin](../../introduction/plugin-types-usage.md#panel-visualization-plugins), in some cases you may want your plugin to react to changes that occur outside of your plugin. For example, you may want your plugin to react when the user zooms in or out of another panel. In this guide, you’ll learn how to make your plugin react to events in Grafana.
 
 :::tip
 
@@ -29,7 +27,7 @@ For a step-by-step guide to making your own panel plugin, refer to our [Tutorial
 
 ## Access the event bus
 
-The event bus for subscribing to Grafana events is located on the [`PanelProps`](https://github.com/grafana/grafana/blob/57960148e47e4d82e899dbfa3cb9b2d474ad56dc/packages/grafana-data/src/types/panel.ts#L74-L122) interface. This interface exposes runtime information about the panel, such as the panel's dimensions and timing measurements. Refer to the code comments for the property definitions.
+The event bus for subscribing to Grafana events is located in the [`PanelProps`](https://github.com/grafana/grafana/blob/57960148e47e4d82e899dbfa3cb9b2d474ad56dc/packages/grafana-data/src/types/panel.ts#L74-L122) interface. This interface exposes runtime information about the panel, such as the panel's dimensions and timing measurements. Refer to the code comments for the property definitions.
 
 You can access the event bus and other panel properties through the `props` argument of your plugin. For example:
 
@@ -38,12 +36,6 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height }) =
 ```
 
 ## Subscribe to Grafana application events
-
-:::note
-
-If you’ve previously built plugins using Angular, note that you don’t need to subscribe to render events to update your visualization in React. React components automatically re-renders whenever any of its dependencies has changed.
-
-:::
 
 Grafana uses an event bus to publish application events to notify different parts of Grafana when the user performs an action. Your plugin can react to these actions by subscribing to one or more events.
 

--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
@@ -95,4 +95,4 @@ class MyPanelEditEnteredEvent extends BusEventWithPayload<number> {
 }
 ```
 
-We’ll be improving the event bus and adding more events in the future. Let us know how you’re using the event bus, and any events you think would be useful to your plugin!
+We’ll be improving the event bus and adding more events in the future. Let us know how you’re using the event bus in [our Community forum](https://community.grafana.com/c/plugin-development/30), and any events you think would be useful to your plugin!

--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
@@ -93,7 +93,7 @@ Remember to call `unsubscribe()` on your subscriber to avoid memory leaks.
 
 ## What events are supported?
 
-While there’s no official documentation of the supported events at this time, you may be able to extract events based on their usage in other plugins and the functionality the offer.
+While there’s no official documentation of the supported events at this time, you may be able to extract events based on their usage in other plugins and the functionality they offer.
 
 Note that while many event types are available but not yet exported, such as the `PanelEditEnteredEvent`, you can still subscribe to them by re-implementing the event type yourself:
 

--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
@@ -19,7 +19,7 @@ sidebar_position: 5
 
 If you’re building a [panel plugin](../../introduction/plugin-types-usage.md#panel-visualization-plugins), Grafana already provides the data you need to configure and render your panel. If not, you can usually retrieve the information you need from any of the runtime services, like `BackendSrv` and `TemplateSrv`.
 
-However, in some cases you may want your plugin to react to changes that occur outside of your plugin. For example, you may want your plugin to react when the user hovers their cursor over data in another panel. In this guide, you’ll learn how to make your plugin react to events in Grafana.
+However, in some cases you may want your plugin to react to changes that occur outside of your plugin. For example, you may want your plugin to react when the user zooms in or out of another panel. In this guide, you’ll learn how to make your plugin react to events in Grafana.
 
 :::tip
 
@@ -93,7 +93,7 @@ Remember to call `unsubscribe()` on your subscriber to avoid memory leaks.
 
 ## What events are supported?
 
-While there’s no official documentation of the supported events, you can figure out which events are available for subscription. To do so, search for `static type = '.*';` in the Grafana GitHub repository.
+While there’s no official documentation of the supported events at this time, you may be able to extract events based on their usage in other plugins and the functionality the offer.
 
 Note that while many event types are available but not yet exported, such as the `PanelEditEnteredEvent`, you can still subscribe to them by re-implementing the event type yourself:
 

--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
@@ -103,4 +103,4 @@ class MyPanelEditEnteredEvent extends BusEventWithPayload<number> {
 }
 ```
 
-We’ll be improving the event bus and adding more events in the future. Let me know how you’re using the event bus, and any events you think would be useful to your plugin!
+We’ll be improving the event bus and adding more events in the future. Let us know how you’re using the event bus, and any events you think would be useful to your plugin!

--- a/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
+++ b/docusaurus/docs/create-a-plugin/develop-a-plugin/panel-properties.md
@@ -1,0 +1,106 @@
+---
+id: subscribe-events
+title: Subscribe to Grafana events
+description: Work with the event bus to subscribe to Grafana application events
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - panel
+  - properties
+  - eventbus
+  - event bus
+  - subscribe
+  - events
+sidebar_position: 5
+---
+
+# Subscribe to Grafana events
+
+If you’re building a [panel plugin](../../introduction/plugin-types-usage.md#panel-visualization-plugins), Grafana already provides the data you need to configure and render your panel. If not, you can usually retrieve the information you need from any of the runtime services, like `BackendSrv` and `TemplateSrv`.
+
+However, in some cases you may want your plugin to react to changes that occur outside of your plugin. For example, you may want your plugin to react when the user hovers their cursor over data in another panel. In this guide, you’ll learn how to make your plugin react to events in Grafana.
+
+:::tip
+
+For a step-by-step guide to making your own panel plugin, refer to our [Tutorial for panel plugins](../../tutorials/build-a-panel-plugin.md).
+
+:::
+
+## Access the event bus
+
+The event bus for subscribing to Grafana events is located on the [`PanelProps`](https://github.com/grafana/grafana/blob/57960148e47e4d82e899dbfa3cb9b2d474ad56dc/packages/grafana-data/src/types/panel.ts#L74-L122) interface. This interface exposes runtime information about the panel, such as the panel's dimensions and timing measurements. Refer to the code comments for the property definitions.
+
+You can access the event bus and other panel properties through the `props` argument of your plugin. For example:
+
+```js title="src/components/SimplePanel.tsx"
+export const SimplePanel: React.FC<Props> = ({ options, data, width, height }) => {
+```
+
+## Subscribe to Grafana application events
+
+:::note
+
+If you’ve previously built plugins using Angular, note that you don’t need to subscribe to render events to update your visualization in React. React components automatically re-renders whenever any of its dependencies has changed.
+
+:::
+
+Grafana uses an event bus to publish application events to notify different parts of Grafana when the user performs an action. Your plugin can react to these actions by subscribing to one or more events.
+
+Events are identified by a unique string; also, they can have an optional payload. In the following example, the `ZoomOutEvent` is identified by the `zoom-out` string and carries a number as a payload.
+
+```tsx
+class ZoomOutEvent extends BusEventWithPayload<number> {
+  static type = 'zoom-out';
+}
+```
+
+Here are a few other events you can subscribe to:
+
+- `RefreshEvent` from `@grafana/runtime`
+- `DataHoverEvent` from `@grafana/data`
+
+You can access the event bus available from the panel props, and subscribe to events of a certain type using the `getStream()` method. The callback passed to the subscribe method will be called for every new event, as in this example:
+
+```tsx
+import React, { useEffect } from 'react';
+import { RefreshEvent } from '@grafana/runtime';
+
+// ...
+
+interface Props extends PanelProps<MyOptions> {}
+
+export const MyPanel: React.FC<Props> = ({ eventBus }) => {
+  useEffect(() => {
+    const subscriber = eventBus.getStream(RefreshEvent).subscribe((event) => {
+      console.log(`Received event: ${event.type}`);
+    });
+
+    return () => {
+      subscriber.unsubscribe();
+    };
+  }, [eventBus]);
+
+  return <div>Event bus example</div>;
+};
+```
+
+:::important
+
+Remember to call `unsubscribe()` on your subscriber to avoid memory leaks.
+
+:::
+
+## What events are supported?
+
+While there’s no official documentation of the supported events, you can figure out which events are available for subscription. To do so, search for `static type = '.*';` in the Grafana GitHub repository.
+
+Note that while many event types are available but not yet exported, such as the `PanelEditEnteredEvent`, you can still subscribe to them by re-implementing the event type yourself:
+
+```tsx
+class MyPanelEditEnteredEvent extends BusEventWithPayload<number> {
+  static type = 'panel-edit-started';
+}
+```
+
+We’ll be improving the event bus and adding more events in the future. Let me know how you’re using the event bus, and any events you think would be useful to your plugin!


### PR DESCRIPTION
Add documentation for event bus for working with properties of panel plugins. Fixes https://github.com/grafana/grafana/issues/79431

Open issue: This doc includes content from https://community.grafana.com/t/how-to-subscribe-to-grafana-application-events/59147

However, I could not verify the accuracy of this step:

> While there’s no official documentation of the supported events, you can figure out the available events by searching for static type = '.*'; in the Grafana repository.

What should this step be? Can we provide this as a link to a search page?