### PR TITLE
Plugin E2E: Fix isFeatureEnabled fixture

### DIFF
--- a/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
+++ b/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
@@ -7,7 +7,7 @@ type FeatureToggleFixture = TestFixture<
   PluginFixture & PluginOptions & PlaywrightCombinedArgs
 >;
 
-const isFeatureToggleEnabled: FeatureToggleFixture = async ({ page }, use) => {
+const isFeatureToggleEnabled: FeatureToggleFixture = async ({ page, grafanaVersion }, use) => {
   await use(async <T = object>(featureToggle: keyof T) => {
     const featureToggles: T = await page.evaluate('window.grafanaBootData.settings.featureToggles');
     return Boolean(featureToggles[featureToggle]);

--- a/packages/plugin-e2e/src/fixtures/page.ts
+++ b/packages/plugin-e2e/src/fixtures/page.ts
@@ -24,6 +24,7 @@ const page: PageFixture = async ({ page, featureToggles }, use) => {
       console.error('Failed to set feature toggles', error);
     }
   }
+  await page.goto('/');
   await use(page);
 };
 

--- a/packages/plugin-e2e/src/fixtures/scripts/overrideFeatureToggles.js
+++ b/packages/plugin-e2e/src/fixtures/scripts/overrideFeatureToggles.js
@@ -1,7 +1,6 @@
 // this script is evaluated in the browser context, so we cannot use typescript
 export const overrideFeatureToggles = (featureToggles) => {
   const timeout = 5;
-  const localStorageKey = 'grafana.featureToggles';
 
   const waitForGrafanaBootData = (cb) => {
     if (window.grafanaBootData) {

--- a/packages/plugin-e2e/src/fixtures/scripts/overrideFeatureToggles.js
+++ b/packages/plugin-e2e/src/fixtures/scripts/overrideFeatureToggles.js
@@ -11,28 +11,14 @@ export const overrideFeatureToggles = (featureToggles) => {
     }
   };
 
-  const versionGte = (version, major, minor) => {
-    const [majorVersion, minorVersion] = version.split('.');
-    return Number(majorVersion) >= major && Number(minorVersion) >= minor;
-  };
-
   // wait for Grafana boot data to be added to the window object
   waitForGrafanaBootData(() => {
     const version = window?.grafanaBootData?.settings?.buildInfo?.version;
 
-    // since Grafana 10.1.0, Grafana reads feature toggles from localStorage
-    // since this script runs in the browser context, we don't have access to semver.gte function that is used in other places of this package
-    if (versionGte(version, 10, 1)) {
-      const value = Object.entries(featureToggles)
-        .map(([key, value]) => `${key}=${value}`)
-        .join(',');
-      localStorage.setItem(localStorageKey, value);
-    } else {
-      // override feature toggles with the ones provided by the test
-      window.grafanaBootData.settings.featureToggles = {
-        ...window.grafanaBootData.settings.featureToggles,
-        ...featureToggles,
-      };
-    }
+    // override feature toggles with the ones provided by the test
+    window.grafanaBootData.settings.featureToggles = {
+      ...window.grafanaBootData.settings.featureToggles,
+      ...featureToggles,
+    };
   });
 };

--- a/packages/plugin-e2e/tests/datasource/feature-toggles/queryEditor.async.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/feature-toggles/queryEditor.async.spec.ts
@@ -1,11 +1,20 @@
 import { expect, test } from '../../../src';
 import { ProvisionFile } from '../../../src/types';
 
+const TRUTHY_CUSTOM_TOGGLE = 'custom_toggle1';
+const FALSY_CUSTOM_TOGGLE = 'custom_toggle2';
 // override the feature toggles defined in playwright.config.ts only for tests in this file
 test.use({
   featureToggles: {
     redshiftAsyncQueryDataSupport: true,
+    [TRUTHY_CUSTOM_TOGGLE]: true,
+    [FALSY_CUSTOM_TOGGLE]: false,
   },
+});
+
+test('should set feature toggles correctly', async ({ isFeatureToggleEnabled }) => {
+  expect(await isFeatureToggleEnabled(TRUTHY_CUSTOM_TOGGLE)).toBeTruthy();
+  expect(await isFeatureToggleEnabled(FALSY_CUSTOM_TOGGLE)).toBeFalsy();
 });
 
 test('async query data handler should return a `finished` status', async ({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

While adding support for [substituting feature toggles](https://github.com/grafana/plugin-tools/pull/651) during a test session, overrides were set in local storage (when Grafana version is => 10.1.0). I did not think about the fact that we have a fixture called `isFeatureEnabled`. If overrides aren't propagated to `window.grafanaBootData.settings.featureToggles`, there's no way for this fixture to know weather a FE feature is enabled or not. This PR ensures overrides are added directly to `window.grafanaBootData.settings.featureToggles`, which will fix the broken `isFeatureEnabled` fixture. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.10.1-canary.691.5a4661c.0
  # or 
  yarn add @grafana/plugin-e2e@0.10.1-canary.691.5a4661c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
