### PR TITLE
Plugin E2E: Add new version for selector

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
@@ -117,6 +117,7 @@ export const versionedPages = {
               [MIN_GRAFANA_VERSION]: 'Variable editor Preview of Values option',
             },
             submitButton: {
+              '10.4.0': 'data-testid Variable editor Run Query button',
               [MIN_GRAFANA_VERSION]: 'Variable editor Submit button',
             },
           },


### PR DESCRIPTION

**What this PR does / why we need it**:

The value of the `submitButton` selector was changed in https://github.com/grafana/grafana/pull/80193, so doing the corresponding change also in this repo. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.10.2-canary.692.bc4695f.0
  # or 
  yarn add @grafana/plugin-e2e@0.10.2-canary.692.bc4695f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
