### PR TITLE
CI: Test scaffolds against built NPM packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          # cache: 'npm'
 
       - name: Download packed artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
         run: npm exec nx affected -- --target test
       - name: Build all packages
         run: npm run build
+      - name: Pack packages for testing
+        run: |
+          mkdir ./packed-artifacts
+          npm pack --workspace="@grafana/create-plugin" --workspace="@grafana/sign-plugin" --pack-destination="./packed-artifacts"
+      - name: Upload artifacts for testing
+        uses: actions/upload-artifact@v4
+        with:
+          name: packed-artifacts
+          path: ./packed-artifacts
+          retention-days: 3
 
   generate-plugins:
     name: Test plugin scaffolding
@@ -42,28 +52,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - cmd: generate-app
+          - cmd: create-plugin --pluginName='Sample app' --orgName='sample-org' --pluginDescription='This is a sample app.' --pluginType='app' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+            workingDir: './sampleorg-sample-app'
             hasBackend: false
-          - cmd: generate-app-backend
+          - cmd: create-plugin --pluginName='Sample app' --orgName='sample-org' --pluginDescription='This is a sample backend app.' --pluginType='app' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+            workingDir: './sampleorg-sample-app'
             hasBackend: true
-          - cmd: generate-panel
+          - cmd: create-plugin --pluginName='Sample panel' --orgName='sample-org' --pluginDescription='This is a sample panel.' --pluginType='panel' --hasGithubWorkflows --hasGithubLevitateWorkflow
+            workingDir: './sampleorg-sample-panel'
             hasBackend: false
-          - cmd: generate-datasource
+          - cmd: create-plugin --pluginName='Sample datasource' --orgName='sample-org' --pluginDescription='This is a sample datasource.' --pluginType='datasource' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+            workingDir: './sampleorg-sample-datasource'
             hasBackend: false
-          - cmd: generate-datasource-backend
+          - cmd: create-plugin --pluginName='Sample datasource' --orgName='sample-org' --pluginDescription='This is a sample backend datasource.' --pluginType='datasource' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+            workingDir: './sampleorg-sample-datasource'
             hasBackend: true
-          - cmd: generate-scenes-app
+          - cmd: create-plugin --pluginName='Sample scenesapp' --orgName='sample-org' --pluginDescription='This is a sample scenes app.' --pluginType='scenesapp' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+            workingDir: './sampleorg-sample-scenesapp'
             hasBackend: false
-    env:
-      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
-      NX_BRANCH: ${{ github.event.number || github.ref_name }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
-          fetch-depth: 0
-      - uses: nrwl/nx-set-shas@v4
       - name: Setup .npmrc file for NPM registry
         uses: actions/setup-node@v4
         with:
@@ -71,49 +78,50 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
-      - name: Install package dependencies
-        run: npm ci --no-audit
+      - name: Download packed artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: packed-artifacts
+          path: ./packed-artifacts
+
+      - name: Install npm packages globally
+        run: for file in *.tgz; do npm install -g "$file"; done
+        working-directory: ./packed-artifacts
 
       - name: Generate plugin
-        run: npm exec nx run @grafana/create-plugin:${{ matrix.cmd }}
+        run: ${{ matrix.cmd }}
 
       - name: Install generated plugin dependencies
         run: npm install --no-audit
-        working-directory: ./packages/create-plugin/generated
+        working-directory: ${{ matrix.workingDir }}
 
       - name: Lint plugin frontend
         run: npm run lint
-        working-directory: ./packages/create-plugin/generated
+        working-directory: ${{ matrix.workingDir }}
 
       - name: Build plugin frontend
         run: npm run build
-        working-directory: ./packages/create-plugin/generated
-
-      - name: '@grafana/sign-plugin - build'
-        if: ${{ matrix.cmd == 'generate-panel' && github.actor != 'dependabot[bot]' }}
-        env:
-          GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-        run: npm exec nx run @grafana/sign-plugin:build
+        working-directory: ${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
         if: ${{ matrix.cmd == 'generate-panel' && github.actor != 'dependabot[bot]' }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-        run: node ../../sign-plugin/dist/bin/run.js --rootUrls http://www.example.com --signatureType private
-        working-directory: ./packages/create-plugin/generated
+        run: sign-plugin --rootUrls http://www.example.com --signatureType private
+        working-directory: ${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_API_KEY to sign generate-panel plugin'
         if: ${{ matrix.cmd == 'generate-panel' && github.actor != 'dependabot[bot]' }}
         env:
           GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
-        run: node ../../sign-plugin/dist/bin/run.js --rootUrls http://www.example.com --signatureType private
-        working-directory: ./packages/create-plugin/generated
+        run: sign-plugin --rootUrls http://www.example.com --signatureType private
+        working-directory: ${{ matrix.workingDir }}
 
       - uses: actions/setup-go@v5
         with:
           go-version: '~1.20'
           check-latest: true
-          cache-dependency-path: ./packages/create-plugin/generated/go.sum
+          cache-dependency-path: ${{ matrix.workingDir }}/go.sum
         if: ${{ matrix.hasBackend == true }}
 
       - name: Build plugin backend
@@ -121,7 +129,7 @@ jobs:
         with:
           version: latest
           args: -v build:linux
-          workdir: ./packages/create-plugin/generated
+          workdir: ${{ matrix.workingDir }}
         if: ${{ matrix.hasBackend == true }}
 
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           name: packed-artifacts
           path: ./packed-artifacts
-          retention-days: 3
+          retention-days: 1
 
   generate-plugins:
     name: Test plugin scaffolding
@@ -104,14 +104,14 @@ jobs:
         working-directory: ${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
-        if: ${{ matrix.cmd == 'generate-panel' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.workingDir == 'sampleorg-sample-panel' && github.actor != 'dependabot[bot]' }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
         working-directory: ${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_API_KEY to sign generate-panel plugin'
-        if: ${{ matrix.cmd == 'generate-panel' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.workingDir == 'sampleorg-sample-panel' && github.actor != 'dependabot[bot]' }}
         env:
           GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,10 @@ jobs:
         run: npm run lint
         working-directory: ${{ matrix.workingDir }}
 
+      - name: Lint plugin frontend
+        run: npm run typecheck
+        working-directory: ${{ matrix.workingDir }}
+
       - name: Build plugin frontend
         run: npm run build
         working-directory: ${{ matrix.workingDir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          # cache: 'npm'
 
       - name: Download packed artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,23 +52,23 @@ jobs:
     strategy:
       matrix:
         include:
-          - cmd: create-plugin --pluginName='Sample app' --orgName='sample-org' --pluginDescription='This is a sample app.' --pluginType='app' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
-            workingDir: './sampleorg-sample-app'
+          - workingDir: './sampleorg-sample-app'
+            cmd: create-plugin --pluginName='Sample app' --orgName='sample-org' --pluginDescription='This is a sample app.' --pluginType='app' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: false
-          - cmd: create-plugin --pluginName='Sample app' --orgName='sample-org' --pluginDescription='This is a sample backend app.' --pluginType='app' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
-            workingDir: './sampleorg-sample-app'
+          - workingDir: './sampleorg-sample-app'
+            cmd: create-plugin --pluginName='Sample app' --orgName='sample-org' --pluginDescription='This is a sample backend app.' --pluginType='app' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: true
-          - cmd: create-plugin --pluginName='Sample panel' --orgName='sample-org' --pluginDescription='This is a sample panel.' --pluginType='panel' --hasGithubWorkflows --hasGithubLevitateWorkflow
-            workingDir: './sampleorg-sample-panel'
+          - workingDir: './sampleorg-sample-panel'
+            cmd: create-plugin --pluginName='Sample panel' --orgName='sample-org' --pluginDescription='This is a sample panel.' --pluginType='panel' --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: false
-          - cmd: create-plugin --pluginName='Sample datasource' --orgName='sample-org' --pluginDescription='This is a sample datasource.' --pluginType='datasource' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
-            workingDir: './sampleorg-sample-datasource'
+          - workingDir: './sampleorg-sample-datasource'
+            cmd: create-plugin --pluginName='Sample datasource' --orgName='sample-org' --pluginDescription='This is a sample datasource.' --pluginType='datasource' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: false
-          - cmd: create-plugin --pluginName='Sample datasource' --orgName='sample-org' --pluginDescription='This is a sample backend datasource.' --pluginType='datasource' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
-            workingDir: './sampleorg-sample-datasource'
+          - workingDir: './sampleorg-sample-datasource'
+            cmd: create-plugin --pluginName='Sample datasource' --orgName='sample-org' --pluginDescription='This is a sample backend datasource.' --pluginType='datasource' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: true
-          - cmd: create-plugin --pluginName='Sample scenesapp' --orgName='sample-org' --pluginDescription='This is a sample scenes app.' --pluginType='scenesapp' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
-            workingDir: './sampleorg-sample-scenesapp'
+          - workingDir: './sampleorg-sample-scenesapp'
+            cmd: create-plugin --pluginName='Sample scenesapp' --orgName='sample-org' --pluginDescription='This is a sample scenes app.' --pluginType='scenesapp' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: false
     steps:
       - name: Setup .npmrc file for NPM registry
@@ -107,14 +107,14 @@ jobs:
         working-directory: ${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
-        if: ${{ matrix.workingDir == 'sampleorg-sample-panel' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.workingDir == './sampleorg-sample-panel' && github.actor != 'dependabot[bot]' }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
         working-directory: ${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_API_KEY to sign generate-panel plugin'
-        if: ${{ matrix.workingDir == 'sampleorg-sample-panel' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.workingDir == './sampleorg-sample-panel' && github.actor != 'dependabot[bot]' }}
         env:
           GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,23 +52,23 @@ jobs:
     strategy:
       matrix:
         include:
-          - workingDir: './sampleorg-sample-app'
-            cmd: create-plugin --pluginName='Sample app' --orgName='sample-org' --pluginDescription='This is a sample app.' --pluginType='app' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+          - workingDir: 'myorg-nobackend-app'
+            cmd: create-plugin --pluginName='no-backend' --orgName='myorg' --pluginDescription='This is a sample app.' --pluginType='app' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: false
-          - workingDir: './sampleorg-sample-app'
-            cmd: create-plugin --pluginName='Sample app' --orgName='sample-org' --pluginDescription='This is a sample backend app.' --pluginType='app' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+          - workingDir: 'myorg-backend-app'
+            cmd: create-plugin --pluginName='backend' --orgName='myorg' --pluginDescription='This is a sample backend app.' --pluginType='app' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: true
-          - workingDir: './sampleorg-sample-panel'
-            cmd: create-plugin --pluginName='Sample panel' --orgName='sample-org' --pluginDescription='This is a sample panel.' --pluginType='panel' --hasGithubWorkflows --hasGithubLevitateWorkflow
+          - workingDir: 'myorg-nobackend-panel'
+            cmd: create-plugin --pluginName='no-backend' --orgName='myorg' --pluginDescription='This is a sample panel.' --pluginType='panel' --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: false
-          - workingDir: './sampleorg-sample-datasource'
-            cmd: create-plugin --pluginName='Sample datasource' --orgName='sample-org' --pluginDescription='This is a sample datasource.' --pluginType='datasource' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+          - workingDir: 'myorg-nobackend-datasource'
+            cmd: create-plugin --pluginName='no-backend' --orgName='myorg' --pluginDescription='This is a sample datasource.' --pluginType='datasource' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: false
-          - workingDir: './sampleorg-sample-datasource'
-            cmd: create-plugin --pluginName='Sample datasource' --orgName='sample-org' --pluginDescription='This is a sample backend datasource.' --pluginType='datasource' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+          - workingDir: 'myorg-backend-datasource'
+            cmd: create-plugin --pluginName='backend' --orgName='myorg' --pluginDescription='This is a sample backend datasource.' --pluginType='datasource' --hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: true
-          - workingDir: './sampleorg-sample-scenesapp'
-            cmd: create-plugin --pluginName='Sample scenesapp' --orgName='sample-org' --pluginDescription='This is a sample scenes app.' --pluginType='scenesapp' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
+          - workingDir: 'myorg-nobackend-scenesapp'
+            cmd: create-plugin --pluginName='no-backend' --orgName='myorg' --pluginDescription='This is a sample scenes app.' --pluginType='scenesapp' --no-hasBackend --hasGithubWorkflows --hasGithubLevitateWorkflow
             hasBackend: false
     steps:
       - name: Setup .npmrc file for NPM registry
@@ -92,39 +92,39 @@ jobs:
 
       - name: Install generated plugin dependencies
         run: npm install --no-audit
-        working-directory: ${{ matrix.workingDir }}
+        working-directory: ./${{ matrix.workingDir }}
 
       - name: Lint plugin frontend
         run: npm run lint
-        working-directory: ${{ matrix.workingDir }}
+        working-directory: ./${{ matrix.workingDir }}
 
-      - name: Lint plugin frontend
+      - name: Typecheck plugin frontend
         run: npm run typecheck
-        working-directory: ${{ matrix.workingDir }}
+        working-directory: ./${{ matrix.workingDir }}
 
       - name: Build plugin frontend
         run: npm run build
-        working-directory: ${{ matrix.workingDir }}
+        working-directory: ./${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
-        if: ${{ matrix.workingDir == './sampleorg-sample-panel' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'dependabot[bot]' }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
-        working-directory: ${{ matrix.workingDir }}
+        working-directory: ./${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_API_KEY to sign generate-panel plugin'
-        if: ${{ matrix.workingDir == './sampleorg-sample-panel' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'dependabot[bot]' }}
         env:
           GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
-        working-directory: ${{ matrix.workingDir }}
+        working-directory: ./${{ matrix.workingDir }}
 
       - uses: actions/setup-go@v5
         with:
           go-version: '~1.20'
           check-latest: true
-          cache-dependency-path: ${{ matrix.workingDir }}/go.sum
+          cache-dependency-path: ./${{ matrix.workingDir }}/go.sum
         if: ${{ matrix.hasBackend == true }}
 
       - name: Build plugin backend
@@ -132,7 +132,7 @@ jobs:
         with:
           version: latest
           args: -v build:linux
-          workdir: ${{ matrix.workingDir }}
+          workdir: ./${{ matrix.workingDir }}
         if: ${{ matrix.hasBackend == true }}
 
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ playwright-report/
 packages/plugin-e2e/playwright/.cache/
 packages/plugin-e2e/playwright/.auth
 .nx/cache
+
+# Used in CI to pass built packages to the next job
+packed-artifacts/


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Since removing plop we've been able to scaffold plugins via the cli by passing args however we're still testing them in CI via the "generate-<pluginType>" scripts. These scripts were originally created for development and don't mimic a user journey all that well. This PR aims to address this by doing the following:

- `jobs.test` now npm packs and uploads the npm packages as tarballs
- `jobs.generate-plugins` no longer clones the repo. Instead it downloads the previously built tarballs and installs them globally using `npm -g install <name_of_package>.tgz`.
- `jobs.generate-plugins` matrix has been updated to run each command using the globally installed package (`create-plugin` or `sign-plugin`) and passes args to answer any prompts.
- `jobs.generate-plugins` now additionally runs `typecheck` on the scaffolded plugins

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

Artifacts are only retained for a maximum of 1 day. I'm happy to change this but given how often this workflow is run I see no need to clutter the storage

From the current builds in this PR it appears these changes speed up the job by ~1.5mins.