### PR TITLE
Fix broken livereload injection when using Grafana 10.2.3

### DIFF
--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -43,7 +43,7 @@ export enum PLUGIN_TYPES {
 // and will be available to use in the templates.
 // Example: "@grafana/ui": "{{ grafanaVersion }}"
 export const EXTRA_TEMPLATE_VARIABLES = {
-  grafanaVersion: '10.0.3',
+  grafanaVersion: '10.2.3',
   grafanaImage: 'grafana-enterprise',
 };
 

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -43,7 +43,7 @@ export enum PLUGIN_TYPES {
 // and will be available to use in the templates.
 // Example: "@grafana/ui": "{{ grafanaVersion }}"
 export const EXTRA_TEMPLATE_VARIABLES = {
-  grafanaVersion: '10.2.3',
+  grafanaVersion: '10.0.3',
   grafanaImage: 'grafana-enterprise',
 };
 

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -13,4 +13,4 @@ ENV GF_DEFAULT_APP_MODE "development"
 
 # Inject livereload script into grafana index.html
 USER root
-RUN sed -i 's/<\/body><\/html>/<script src=\"http:\/\/localhost:35729\/livereload.js\"><\/script><\/body><\/html>/g' /usr/share/grafana/public/views/index.html
+RUN sed -i 's/<\/body>/<script src=\"http:\/\/localhost:35729\/livereload.js\"><\/script><\/body>/g' /usr/share/grafana/public/views/index.html

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -13,4 +13,4 @@ ENV GF_DEFAULT_APP_MODE "development"
 
 # Inject livereload script into grafana index.html
 USER root
-RUN sed -i 's/<\/body>/<script src=\"http:\/\/localhost:35729\/livereload.js\"><\/script><\/body>/g' /usr/share/grafana/public/views/index.html
+RUN sed -i 's|</body>|<script src="http://localhost:35729/livereload.js"></script></body>|g' /usr/share/grafana/public/views/index.html


### PR DESCRIPTION
I needed this version of Grafana to use the latest features in my
scenesapp plugin. But bumping to this version of Grafana broke the
livereload injection.
I haven't tracked down exactly when/how/why the old injection command
no longer works, but I have found this fix. If you're happy with it,
maybe we can just merge this change, without bothering to find the
cause of the issue? Or maybe you can help by tracking down the cause
(or help me to do so)?

Thanks

~~Also bumping the Grafana version here, so you can see this in action. But happy to revert the Grafana version and just keep the livereload change, if we need a smaller scope to get this merged.~~
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@3.1.2-canary.696.20ca811.0
  # or 
  yarn add @grafana/create-plugin@3.1.2-canary.696.20ca811.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
