### PR TITLE
Update headings in build-a-logs-data-source-plugin.md

### DIFF
--- a/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
@@ -97,7 +97,7 @@ const result = createDataFrame({
 
 ## Enhance your logs data source plugin with optional features
 
-You can use the following optional features to enhance your logs data source plugin in Explore and Logs panel.
+You can use the following optional features to enhance your logs data source plugin in the Explore and Logs panel.
 
 [Explore](https://grafana.com/docs/grafana/latest/explore/) provides a useful interface for investigating incidents and troubleshooting logs. If the data source produces log results, we highly recommend implementing the following APIs to allow your users to get the most out of the logs UI and its features within Explore.
 

--- a/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
@@ -97,15 +97,13 @@ const result = createDataFrame({
 
 ## Enhance your logs data source plugin with optional features
 
-You can use the following optional features to enhance your logs data source plugin.
-
-### Implement features that enhance log querying experience in Explore
+You can use the following optional features to enhance your logs data source plugin in Explore and Logs panel.
 
 [Explore](https://grafana.com/docs/grafana/latest/explore/) provides a useful interface for investigating incidents and troubleshooting logs. If the data source produces log results, we highly recommend implementing the following APIs to allow your users to get the most out of the logs UI and its features within Explore.
 
 The following steps show the process for adding support for Explore features in a data source plugin through a seamless integration. Implement these APIs to enhance the user experience and take advantage of Explore's powerful log investigation capabilities.
 
-#### Show log results in Explore's Logs view
+### Show log results in Explore's Logs view
 
 To ensure that your log results are displayed in an interactive Logs view, you must add a `meta` attribute to `preferredVisualisationType` in your log result data frame.
 
@@ -130,7 +128,7 @@ const result = createDataFrame({
 });
 ```
 
-#### Highlight searched words
+### Highlight searched words
 
 :::note
 
@@ -165,7 +163,7 @@ const result = createDataFrame({
 });
 ```
 
-#### Log result `meta` information
+### Log result `meta` information
 
 :::note
 
@@ -236,7 +234,7 @@ const result = createDataFrame({
 });
 ```
 
-#### Color-coded log levels
+### Color-coded log levels
 
 :::note
 
@@ -248,7 +246,7 @@ Color-coded [log levels](https://grafana.com/docs/grafana/latest/explore/logs-in
 
 Refer to [Logs data frame format](#logs-data-frame-format) for more information.
 
-#### Copy link to log line
+### Copy link to log line
 
 :::note
 
@@ -262,7 +260,7 @@ If the underlying database doesn't return an `id` field, you can implement one w
 
 Refer to [Logs data frame format](#logs-data-frame-format) for more information.
 
-#### Filter fields using Log details
+### Filter fields using Log details
 
 :::note
 
@@ -300,7 +298,7 @@ export class ExampleDatasource extends DataSourceApi<ExampleQuery, ExampleOption
 }
 ```
 
-#### Live tailing
+### Live tailing
 
 :::note
 
@@ -336,7 +334,7 @@ export class ExampleDatasource extends DataSourceApi<ExampleQuery, ExampleOption
 }
 ```
 
-#### Log context
+### Log context
 
 :::note
 


### PR DESCRIPTION
Fixes headings in this section so features/APIs are correctly displayed in content outline on side.

<img width="1905" alt="image" src="https://github.com/grafana/plugin-tools/assets/30407135/64f7efcb-ccb2-499b-b31f-9a5973b14636">
