### PR TITLE
Plugin E2E: Make getQueryEditorRow method sync

### DIFF
--- a/packages/plugin-e2e/src/models/ExplorePage.ts
+++ b/packages/plugin-e2e/src/models/ExplorePage.ts
@@ -23,12 +23,10 @@ export class ExplorePage extends GrafanaPage {
   /**
    * Returns the locator for the query editor row with the given refId
    */
-  async getQueryEditorRow(refId: string): Promise<Locator> {
-    const locator = this.getByTestIdOrAriaLabel(this.ctx.selectors.components.QueryEditorRows.rows).filter({
+  getQueryEditorRow(refId: string): Locator {
+    return this.getByTestIdOrAriaLabel(this.ctx.selectors.components.QueryEditorRows.rows).filter({
       has: this.getByTestIdOrAriaLabel(this.ctx.selectors.components.QueryEditorRow.title(refId)),
     });
-    await expect(locator).toBeVisible();
-    return locator;
   }
 
   /**

--- a/packages/plugin-e2e/src/models/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/PanelEditPage.ts
@@ -86,7 +86,7 @@ export class PanelEditPage extends GrafanaPage implements PanelError {
   /**
    * Returns the name of the visualization currently selected in the panel editor
    */
-  getVisualizationName() {
+  getVisualizationName(): Locator {
     return this.getByTestIdOrAriaLabel(this.ctx.selectors.components.PanelEditor.toggleVizPicker);
   }
 
@@ -100,12 +100,10 @@ export class PanelEditPage extends GrafanaPage implements PanelError {
   /**
    * Returns the locator for the query editor row with the given refId
    */
-  async getQueryEditorRow(refId: string): Promise<Locator> {
-    const locator = this.getByTestIdOrAriaLabel(this.ctx.selectors.components.QueryEditorRows.rows).filter({
+  getQueryEditorRow(refId: string): Locator {
+    return this.getByTestIdOrAriaLabel(this.ctx.selectors.components.QueryEditorRows.rows).filter({
       has: this.getByTestIdOrAriaLabel(this.ctx.selectors.components.QueryEditorRow.title(refId)),
     });
-    await expect(locator).toBeVisible();
-    return locator;
   }
 
   /**

--- a/packages/plugin-e2e/tests/datasource/explore/queryEditor.integration.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/explore/queryEditor.integration.spec.ts
@@ -9,8 +9,7 @@ test('should return data and not display panel error when a valid query is provi
   const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
   await explorePage.datasource.set(provision.datasources?.[0]!.name!);
   await explorePage.timeRange.set({ from: '2019-01-11', to: '2019-12-15' });
-  const queryEditorRow = await explorePage.getQueryEditorRow('A');
-  await queryEditorRow.getByText('Enter SpreadsheetID').click();
+  await explorePage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   const responsePromise = page.waitForResponse((resp) => resp.url().includes('/api/ds/query'));
   await page.keyboard.press('Tab');
@@ -26,10 +25,9 @@ test('should return an error and display panel error when an invalid query is pr
   const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
   await explorePage.datasource.set(provision.datasources?.[0]!.name!);
   await explorePage.timeRange.set({ from: '2019-01-11', to: '2019-12-15' });
-  const queryEditorRow = await explorePage.getQueryEditorRow('A');
   await page.getByPlaceholder('Class Data!A2:E').fill('invalid range');
   await page.keyboard.press('Tab');
-  await queryEditorRow.getByText('Enter SpreadsheetID').click();
+  await explorePage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   const responsePromise = page.waitForResponse((resp) => resp.url().includes('/api/ds/query'));
   await page.keyboard.press('Tab');

--- a/packages/plugin-e2e/tests/datasource/explore/queryEditor.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/explore/queryEditor.spec.ts
@@ -8,7 +8,7 @@ test('editor populates query from url', async ({ explorePage, readProvision }) =
       `panes=%7B%22xlX%22:%7B%22datasource%22:%22undefined%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22grafana-redshift-datasource%22,%22uid%22:%22P7DC3E4760CFAC4AH%22%7D,%22rawSQL%22:%22SELECT%20%2A%20FROM%20public.average_temperature%22,%22format%22:0%7D%5D,%22range%22:%7B%22from%22:%221579046400000%22,%22to%22:%221607990400000%22%7D%7D%7D&schemaVersion=1&orgId=1&left=%7B%22datasource%22:%22P7DC3E4760CFAC4AH%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22grafana-redshift-datasource%22,%22uid%22:%22P7DC3E4760CFAC4AH%22%7D,%22rawSQL%22:%22SELECT%20%2A%20FROM%20public.average_temperature%22,%22format%22:0%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D`
     ),
   });
-  const queryEditorRowLocator = await explorePage.getQueryEditorRow('A');
+  const queryEditorRowLocator = explorePage.getQueryEditorRow('A');
   await expect(queryEditorRowLocator).toContainText('SELECT * FROM public.average_temperature');
   await expect(queryEditorRowLocator).toContainText('Time Series');
 });

--- a/packages/plugin-e2e/tests/datasource/query-editor/queryEditor.integration.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/query-editor/queryEditor.integration.spec.ts
@@ -9,8 +9,7 @@ test('should return data and not display panel error when a valid query is provi
   const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
   await panelEditPage.datasource.set(provision.datasources?.[0]!.name!);
   await panelEditPage.timeRange.set({ from: '2019-01-11', to: '2019-12-15' });
-  const queryEditorRow = await panelEditPage.getQueryEditorRow('A');
-  await queryEditorRow.getByText('Enter SpreadsheetID').click();
+  await panelEditPage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   await page.keyboard.press('Enter');
   await expect(panelEditPage.refreshPanel()).toBeOK();
@@ -25,8 +24,7 @@ test('should return an error and display panel error when an invalid query is pr
   const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
   await panelEditPage.datasource.set(provision.datasources?.[0]!.name!);
   await panelEditPage.timeRange.set({ from: '2019-01-11', to: '2019-12-15' });
-  const queryEditorRow = await panelEditPage.getQueryEditorRow('A');
-  await queryEditorRow.getByText('Enter SpreadsheetID').click();
+  await panelEditPage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   await page.keyboard.press('Enter');
   await page.getByPlaceholder('Class Data!A2:E').fill('invalid range');

--- a/packages/plugin-e2e/tests/datasource/query-editor/queryEditor.spec.ts
+++ b/packages/plugin-e2e/tests/datasource/query-editor/queryEditor.spec.ts
@@ -11,9 +11,8 @@ test('should list spreadsheets when clicking on spreadsheet segment', async ({
     filePath: 'datasources/google-sheets-datasource-jwt.yaml',
   }).then((provision) => provision.datasources?.[0]!);
   await panelEditPage.datasource.set(sheetsDataSource.name!);
-  const queryEditorRow = await panelEditPage.getQueryEditorRow('A');
   await panelEditPage.mockResourceResponse('spreadsheets', GOOGLE_SHEETS_SPREADSHEETS);
-  await queryEditorRow.getByText('Enter SpreadsheetID').click();
+  await panelEditPage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await expect(page.getByText(GOOGLE_SHEETS_SPREADSHEETS.spreadsheets.sheet1, { exact: true })).toHaveCount(1);
   await expect(page.getByText(GOOGLE_SHEETS_SPREADSHEETS.spreadsheets.sheet2, { exact: true })).toHaveCount(1);
 });
@@ -21,9 +20,8 @@ test('should list spreadsheets when clicking on spreadsheet segment', async ({
 test('should set correct cache time on query passed to the backend', async ({ panelEditPage, page, readProvision }) => {
   const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
   await panelEditPage.datasource.set(provision.datasources?.[0]!.name!);
-  const queryEditorRow = await panelEditPage.getQueryEditorRow('A');
   await panelEditPage.mockResourceResponse('spreadsheets', GOOGLE_SHEETS_SPREADSHEETS);
-  await queryEditorRow.getByText('5m', { exact: true }).click();
+  await panelEditPage.getQueryEditorRow('A').getByText('5m', { exact: true }).click();
   await page.keyboard.insertText('1h');
   await page.keyboard.press('Enter');
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

There's absolutely no point in letting the `getQueryEditorRow` method be async. This PR changes that, and simply resolves the locator synchronously. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
