### PR TITLE
Create-plugin: Check if inside a plugin directory

### DIFF
--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -12,6 +12,7 @@ import {
 } from '../utils/utils.npm.js';
 import { getPackageManagerWithFallback } from '../utils/utils.packageManager.js';
 import { isGitDirectory, isGitDirectoryClean } from '../utils/utils.git.js';
+import { isPluginDirectory } from '../utils/utils.plugin.js';
 
 export const update = async (argv: minimist.ParsedArgs) => {
   try {
@@ -32,6 +33,18 @@ In case you want to proceed as is please use the ${chalk.bold('--force')} flag.)
         subtitle: '(Commit your changes or stash them.)',
         content: `(This check is necessary to make sure that the updates are easy to revert and don't mess with any changes you currently have.
 In case you want to proceed as is please use the ${chalk.bold('--force')} flag.)`,
+      });
+
+      process.exit(1);
+    }
+
+    if (!isPluginDirectory() && !argv.force) {
+      printRedBox({
+        title: 'Are you inside a plugin directory?',
+        subtitle: 'We couldn\'t find a "src/plugin.json" file under your current directory.',
+        content: `(Please make sure to run this command from the root of your plugin folder. In case you want to proceed as is please use the ${chalk.bold(
+          '--force'
+        )} flag.)`,
       });
 
       process.exit(1);

--- a/packages/create-plugin/src/utils/utils.plugin.ts
+++ b/packages/create-plugin/src/utils/utils.plugin.ts
@@ -6,3 +6,13 @@ export function getPluginJson(srcDir?: string) {
   const pluginJsonPath = path.join(srcPath, 'plugin.json');
   return readJsonFile(pluginJsonPath);
 }
+
+// Checks if CWD is a valid root directory of a plugin
+export function isPluginDirectory() {
+  try {
+    getPluginJson();
+    return true;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
**Split out from:** https://github.com/grafana/plugin-tools/pull/702
**Builds on:** https://github.com/grafana/plugin-tools/pull/705

### What changed?
This PR adds a check to see if the `update` command is running inside a valid plugin directory, and shows an error message if not.


### Examples


<details>
  <summary>Not a plugin directory (expand for video)</summary>

https://github.com/grafana/plugin-tools/assets/9974811/f9f1fd0d-021c-4a56-b0c1-462fe3edf277
</details>

@sympatheticmoose for visibility.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@3.2.0-canary.706.8d661c1.0
  # or 
  yarn add @grafana/create-plugin@3.2.0-canary.706.8d661c1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
