### PR TITLE
Create-plugin: Change how the `update` command works

### DIFF
--- a/packages/create-plugin/src/utils/utils.plugin.ts
+++ b/packages/create-plugin/src/utils/utils.plugin.ts
@@ -1,5 +1,8 @@
 import path from 'node:path';
 import { readJsonFile } from './utils.files.js';
+import { compileTemplateFiles, getTemplateData } from './utils.templates.js';
+import { UDPATE_CONFIG } from '../constants.js';
+import { prettifyFiles } from './utils.prettifyFiles.js';
 
 export function getPluginJson(srcDir?: string) {
   const srcPath = srcDir || path.join(process.cwd(), 'src');
@@ -15,4 +18,10 @@ export function isPluginDirectory() {
   } catch (e) {
     return false;
   }
+}
+
+// Updates the .config/ directory with the latest templates
+export async function updateDotConfigFolder() {
+  compileTemplateFiles(UDPATE_CONFIG.filesToOverride, getTemplateData());
+  await prettifyFiles({ targetPath: '.config', projectRoot: '.' });
 }


### PR DESCRIPTION
**Split out from:** https://github.com/grafana/plugin-tools/pull/702
**Builds on:** https://github.com/grafana/plugin-tools/pull/706
([Related design doc](https://docs.google.com/document/d/15dm4WV9v7Ga9Z_Hp3CJMf2D3meuTyEWqBc3omqiOksQ/edit))

### What changed?
This PR changes how the `update` command works: it removes the user prompts to make the flow smoother, **and also makes sure that all NPM package dependencies are updated (`devDependencies` and `dependencies` including the Grafana package versions).** The main reasoning behind this is that certain devDependencies and dependencies need to be kept in sync, and updating only one of them can result in a broken setup. For more info please refer to the [design doc](https://docs.google.com/document/d/15dm4WV9v7Ga9Z_Hp3CJMf2D3meuTyEWqBc3omqiOksQ/edit).

In my opinion this shouldn't be a breaking change, however it certainly changes how updates using the tool work.

### Examples

<details>
  <summary>Successful update (expand for video)</summary>

https://github.com/grafana/plugin-tools/assets/9974811/226e26b0-30bc-4c19-9dee-86b809b52719
</details>


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.0.0-canary.707.de31b1e.0
  # or 
  yarn add @grafana/create-plugin@4.0.0-canary.707.de31b1e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
