### PR TITLE
Create-plugin: Use react-router v6 by default

### DIFF
--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -69,6 +69,7 @@ function getTemplateData(answers: CliArgs) {
     isNPM: packageManagerName === 'npm',
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
+    reactRouterV6: features.reactRouterV6,
   };
 
   return templateData;

--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -69,9 +69,8 @@ function getTemplateData(answers: CliArgs) {
     isNPM: packageManagerName === 'npm',
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
-    useReactRouterV6: features.useReactRouterV6,
-    useReactRouterTypes: !features.useReactRouterV6 && isAppType, // v6 is written in typescript, so it's only needed for <v6
-    reactRouterVersion: features.useReactRouterV6 ? '6.10.0' : '5.2.0',
+    useReactRouterV6: features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app,
+    reactRouterVersion: features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app ? '6.10.0' : '5.2.0',
   };
 
   return templateData;

--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -69,7 +69,9 @@ function getTemplateData(answers: CliArgs) {
     isNPM: packageManagerName === 'npm',
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
-    reactRouterV6: features.reactRouterV6,
+    useReactRouterV6: features.useReactRouterV6,
+    useReactRouterTypes: !features.useReactRouterV6 && isAppType, // v6 is written in typescript, so it's only needed for <v6
+    reactRouterVersion: features.useReactRouterV6 ? '6.10.0' : '5.2.0',
   };
 
   return templateData;

--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -59,6 +59,7 @@ function getTemplateData(answers: CliArgs) {
   const { packageManagerName, packageManagerVersion } = getPackageManagerFromUserAgent();
   const packageManagerInstallCmd = getPackageManagerInstallCmd(packageManagerName);
   const isAppType = pluginType === PLUGIN_TYPES.app || pluginType === PLUGIN_TYPES.scenes;
+  const useReactRouterV6 = features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app;
   const templateData: TemplateData = {
     ...answers,
     pluginId,
@@ -69,8 +70,8 @@ function getTemplateData(answers: CliArgs) {
     isNPM: packageManagerName === 'npm',
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
-    useReactRouterV6: features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app,
-    reactRouterVersion: features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app ? '6.22.0' : '5.2.0',
+    useReactRouterV6,
+    reactRouterVersion: useReactRouterV6 ? '6.22.0' : '5.2.0',
   };
 
   return templateData;

--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -70,7 +70,7 @@ function getTemplateData(answers: CliArgs) {
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
     useReactRouterV6: features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app,
-    reactRouterVersion: features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app ? '6.10.0' : '5.2.0',
+    reactRouterVersion: features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app ? '6.22.0' : '5.2.0',
   };
 
   return templateData;

--- a/packages/create-plugin/src/commands/types.ts
+++ b/packages/create-plugin/src/commands/types.ts
@@ -19,5 +19,7 @@ export type TemplateData = {
   isNPM: boolean;
   version: string;
   bundleGrafanaUI: boolean;
-  reactRouterV6: boolean;
+  useReactRouterV6: boolean;
+  useReactRouterTypes: boolean;
+  reactRouterVersion: string;
 };

--- a/packages/create-plugin/src/commands/types.ts
+++ b/packages/create-plugin/src/commands/types.ts
@@ -19,4 +19,5 @@ export type TemplateData = {
   isNPM: boolean;
   version: string;
   bundleGrafanaUI: boolean;
+  reactRouterV6: boolean;
 };

--- a/packages/create-plugin/src/commands/types.ts
+++ b/packages/create-plugin/src/commands/types.ts
@@ -20,6 +20,5 @@ export type TemplateData = {
   version: string;
   bundleGrafanaUI: boolean;
   useReactRouterV6: boolean;
-  useReactRouterTypes: boolean;
   reactRouterVersion: string;
 };

--- a/packages/create-plugin/src/utils/utils.config.ts
+++ b/packages/create-plugin/src/utils/utils.config.ts
@@ -7,7 +7,7 @@ type FeatureFlags = {
 
   // If set to true, the plugin will be scaffolded with React Router v6. Defaults to true.
   // (Attention! We always scaffold new projects with React Router v6, so if you are changing this to `false` manually you will need to make changes to the React code as well.)
-  reactRouterV6: boolean;
+  useReactRouterV6: boolean;
 };
 
 type CreatePluginConfig = UserConfig & {
@@ -70,7 +70,7 @@ function readRCFileSync(path: string): CreatePluginConfig | undefined {
 
 function createFeatureFlags(flags?: FeatureFlags): FeatureFlags {
   return {
-    reactRouterV6: true,
+    useReactRouterV6: true,
     bundleGrafanaUI: false,
     ...flags,
   };

--- a/packages/create-plugin/src/utils/utils.config.ts
+++ b/packages/create-plugin/src/utils/utils.config.ts
@@ -4,6 +4,10 @@ import { getVersion } from './utils.version.js';
 
 type FeatureFlags = {
   bundleGrafanaUI: boolean;
+
+  // If set to true, the plugin will be scaffolded with React Router v6. Defaults to true.
+  // (Attention! We always scaffold new projects with React Router v6, so if you are changing this to `false` manually you will need to make changes to the React code as well.)
+  reactRouterV6: boolean;
 };
 
 type CreatePluginConfig = UserConfig & {
@@ -66,6 +70,7 @@ function readRCFileSync(path: string): CreatePluginConfig | undefined {
 
 function createFeatureFlags(flags?: FeatureFlags): FeatureFlags {
   return {
+    reactRouterV6: true,
     bundleGrafanaUI: false,
     ...flags,
   };

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -97,5 +97,7 @@ export function getTemplateData() {
     packageManagerVersion,
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
+    reactRouterV6: features.reactRouterV6,
+    reactRouterVersion: features.reactRouterV6 ? '6.10.0' : '5.2.0',
   };
 }

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -97,8 +97,7 @@ export function getTemplateData() {
     packageManagerVersion,
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
-    useReactRouterV6: features.useReactRouterV6,
-    useReactRouterTypes: !features.useReactRouterV6 && pluginJson.type === PLUGIN_TYPES.app, // v6 is written in typescript, so it's only needed for <v6
+    useReactRouterV6: features.useReactRouterV6 && pluginJson.type === PLUGIN_TYPES.app,
     reactRouterVersion: features.useReactRouterV6 ? '6.10.0' : '5.2.0',
   };
 }

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -98,6 +98,6 @@ export function getTemplateData() {
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
     useReactRouterV6: features.useReactRouterV6 && pluginJson.type === PLUGIN_TYPES.app,
-    reactRouterVersion: features.useReactRouterV6 ? '6.10.0' : '5.2.0',
+    reactRouterVersion: features.useReactRouterV6 ? '6.22.0' : '5.2.0',
   };
 }

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -5,7 +5,7 @@ import mkdirp from 'mkdirp';
 import { filterOutCommonFiles, isFile, isFileStartingWith } from './utils.files.js';
 import { renderHandlebarsTemplate } from './utils.handlebars.js';
 import { getPluginJson } from './utils.plugin.js';
-import { TEMPLATE_PATHS, EXPORT_PATH_PREFIX, EXTRA_TEMPLATE_VARIABLES } from '../constants.js';
+import { TEMPLATE_PATHS, EXPORT_PATH_PREFIX, EXTRA_TEMPLATE_VARIABLES, PLUGIN_TYPES } from '../constants.js';
 import { getPackageManagerWithFallback } from './utils.packageManager.js';
 import { getExportFileName } from '../utils/utils.files.js';
 import { getVersion } from './utils.version.js';
@@ -97,7 +97,8 @@ export function getTemplateData() {
     packageManagerVersion,
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
-    reactRouterV6: features.reactRouterV6,
-    reactRouterVersion: features.reactRouterV6 ? '6.10.0' : '5.2.0',
+    useReactRouterV6: features.useReactRouterV6,
+    useReactRouterTypes: !features.useReactRouterV6 && pluginJson.type === PLUGIN_TYPES.app, // v6 is written in typescript, so it's only needed for <v6
+    reactRouterVersion: features.useReactRouterV6 ? '6.10.0' : '5.2.0',
   };
 }

--- a/packages/create-plugin/templates/app/src/components/App/App.tsx
+++ b/packages/create-plugin/templates/app/src/components/App/App.tsx
@@ -1,21 +1,20 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import { AppRootProps } from '@grafana/data';
 import { ROUTES } from '../../constants';
 import { PageFour, PageOne, PageThree, PageTwo } from '../../pages';
-import { prefixRoute } from '../../utils/utils.routing';
 
 export function App(props: AppRootProps) {
   return (
-      <Switch>
-        <Route exact path={prefixRoute(ROUTES.Two)} component={PageTwo} />
-        <Route exact path={prefixRoute(`${ROUTES.Three}/:id?`)} component={PageThree} />
+      <Routes>
+        <Route path={ROUTES.Two} element={<PageTwo />} />
+        <Route path={`${ROUTES.Three}/:id?`} element={<PageThree />} />
 
         {/* Full-width page (this page will have no side navigation) */}
-        <Route exact path={prefixRoute(ROUTES.Four)} component={PageFour} />
+        <Route path={ROUTES.Four} element={<PageFour />} />
 
         {/* Default page */}
-        <Route component={PageOne} />
-      </Switch>
+        <Route path="*" element={<PageOne />} />
+      </Routes>
   );
 }

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -49,8 +49,8 @@ const config = async (env): Promise<Configuration> => {
       'react-redux',
       'redux',
       'rxjs',
-      'react-router',
-      'react-router-dom',
+      'react-router',{{#unless reactRouterV6}}
+      'react-router-dom',{{/unless}}
       'd3',
       'angular',{{#unless bundleGrafanaUI}}
       '@grafana/ui',{{/unless}}

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -49,7 +49,7 @@ const config = async (env): Promise<Configuration> => {
       'react-redux',
       'redux',
       'rxjs',
-      'react-router',{{#unless reactRouterV6}}
+      'react-router',{{#unless useReactRouterV6}}
       'react-router-dom',{{/unless}}
       'd3',
       'angular',{{#unless bundleGrafanaUI}}

--- a/packages/create-plugin/templates/common/.cprc.json
+++ b/packages/create-plugin/templates/common/.cprc.json
@@ -2,7 +2,7 @@
   "features": {
     {{#if bundleGrafanaUI}}
     "bundleGrafanaUI": true{{/if}}
-    {{#if reactRouterV6}}
-    "reactRouterV6": true{{/if}}
+    {{#if useReactRouterV6}}
+    "useReactRouterV6": true{{/if}}
   }
 }

--- a/packages/create-plugin/templates/common/.cprc.json
+++ b/packages/create-plugin/templates/common/.cprc.json
@@ -2,5 +2,7 @@
   "features": {
     {{#if bundleGrafanaUI}}
     "bundleGrafanaUI": true{{/if}}
+    {{#if reactRouterV6}}
+    "reactRouterV6": true{{/if}}
   }
 }

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -30,7 +30,7 @@
     "@testing-library/react": "14.0.0",
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.194",
-    "@types/node": "^20.8.7",{{#if isAppType}}
+    "@types/node": "^20.8.7",{{#if useReactRouterTypes}}
     "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/if}}
     "@types/testing-library__jest-dom": "5.14.8",
     "copy-webpack-plugin": "^11.0.0",
@@ -67,7 +67,7 @@
     "@grafana/scenes": "^1.28.0",{{/if_eq}}
     "react": "18.2.0",
     "react-dom": "18.2.0",{{#if isAppType}}
-    "react-router-dom": "5.3.3",
+    "react-router-dom": "^{{ reactRouterVersion }}",
     "rxjs": "7.8.0",{{/if}}
     "tslib": "2.5.3"
   },

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -30,8 +30,8 @@
     "@testing-library/react": "14.0.0",
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.194",
-    "@types/node": "^20.8.7",{{#if useReactRouterTypes}}
-    "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/if}}
+    "@types/node": "^20.8.7",{{#unless useReactRouterV6}}
+    "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/unless}}
     "@types/testing-library__jest-dom": "5.14.8",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.3",

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.194",
     "@types/node": "^20.8.7",{{#if isAppType}}
-    "@types/react-router-dom": "^5.3.3",{{/if}}
+    "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/if}}
     "@types/testing-library__jest-dom": "5.14.8",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.3",

--- a/packages/create-plugin/templates/scenes-app/src/components/Routes/Routes.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/components/Routes/Routes.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Route, Routes as ReactRoutes } from 'react-router-dom';
 import { HomePage } from '../../pages/Home';
 import { PageWithTabs } from '../../pages/WithTabs';
 import { WithDrilldown } from '../../pages/WithDrilldown';
-import { prefixRoute } from '../../utils/utils.routing';
 import { ROUTES } from '../../constants';
 import { HelloWorldPluginPage } from '../../pages/HelloWorld';
-
+ 
 export const Routes = () => {
   return (
-    <Switch>
-      <Route path={prefixRoute(`${ROUTES.WithTabs}`)} component={PageWithTabs} />
-      <Route path={prefixRoute(`${ROUTES.WithDrilldown}`)} component={WithDrilldown} />
-      <Route path={prefixRoute(`${ROUTES.Home}`)} component={HomePage} />
-      <Route path={prefixRoute(`${ROUTES.HelloWorld}`)} component={HelloWorldPluginPage} />
-      <Redirect to={prefixRoute(ROUTES.Home)} />
-    </Switch>
+    // HEADS UP! We don't need a <BrowserRouter> here, as the core Grafana app already has a router.
+    <ReactRoutes>
+      {/* HEADS UP! We can use relative paths here now. */}
+      <Route path={ROUTES.WithTabs} element={<PageWithTabs />} />
+      <Route path={ROUTES.WithDrilldown} element={<WithDrilldown />} />
+      <Route path={ROUTES.Home} element={<HomePage />} />
+      <Route path={ROUTES.HelloWorld} element={<HelloWorldPluginPage />} />
+
+      <Route path="*" element={<HomePage />} />
+    </ReactRoutes>
   );
 };

--- a/packages/create-plugin/templates/scenes-app/src/components/Routes/Routes.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/components/Routes/Routes.tsx
@@ -1,22 +1,20 @@
 import React from 'react';
-import { Route, Routes as ReactRoutes } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { HomePage } from '../../pages/Home';
 import { PageWithTabs } from '../../pages/WithTabs';
 import { WithDrilldown } from '../../pages/WithDrilldown';
+import { prefixRoute } from '../../utils/utils.routing';
 import { ROUTES } from '../../constants';
 import { HelloWorldPluginPage } from '../../pages/HelloWorld';
- 
+
 export const Routes = () => {
   return (
-    // HEADS UP! We don't need a <BrowserRouter> here, as the core Grafana app already has a router.
-    <ReactRoutes>
-      {/* HEADS UP! We can use relative paths here now. */}
-      <Route path={ROUTES.WithTabs} element={<PageWithTabs />} />
-      <Route path={ROUTES.WithDrilldown} element={<WithDrilldown />} />
-      <Route path={ROUTES.Home} element={<HomePage />} />
-      <Route path={ROUTES.HelloWorld} element={<HelloWorldPluginPage />} />
-
-      <Route path="*" element={<HomePage />} />
-    </ReactRoutes>
+    <Switch>
+      <Route path={prefixRoute(`${ROUTES.WithTabs}`)} component={PageWithTabs} />
+      <Route path={prefixRoute(`${ROUTES.WithDrilldown}`)} component={WithDrilldown} />
+      <Route path={prefixRoute(`${ROUTES.Home}`)} component={HomePage} />
+      <Route path={prefixRoute(`${ROUTES.HelloWorld}`)} component={HelloWorldPluginPage} />
+      <Redirect to={prefixRoute(ROUTES.Home)} />
+    </Switch>
   );
 };


### PR DESCRIPTION
### What changed?
The goal of this PR is to by default scaffold app plugins with the v6 version of react-router. The scenes apps are still scaffolded with react-router@v5, as bumping this will require changes in the `@grafana/scenes` package, as soon as this is done we are going to scaffold those with v6 as well.

**Updating plugins**
This PR introduces a new feature flag called `useReactRouterV6`. This can later be used during plugin updates to migrate to the v6 version of react-router. (Currently not possible to do this with the create-plugin tool, as it is not touching dependencies).

- [x] Add a feature-toggle to use react-router v6 (used for updates, so we don't introduce a breaking change)
- [x] Move the scaffolded _app_ to by default use react-router v6
- [x] Make sure the scaffolded scenes app is still on react-router v5
- [x] Check if any tests need to be updated

@sympatheticmoose for visibility.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@3.3.0-canary.710.17aff14.0
  # or 
  yarn add @grafana/create-plugin@3.3.0-canary.710.17aff14.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
