### PR TITLE
Docs: Migrate to react-router v6

### DIFF
--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -50,7 +50,7 @@ Starting from Grafana 10, plugins should use the v6 of `react-router`. Overall, 
 
 Follow the steps below to start using React router v6 in your plugin:
 
-#### **1. Update the build related configuration:**
+#### 1. Update the build related configuration:
 
 Enable using `react-router@v6` by setting the following feature flag in `<project-root>/.cprc.json`:
 
@@ -70,7 +70,7 @@ npx @grafana/create-plugin@latest update
 
 After updating the build config you probably also need to update some things in your code. Please follow the steps below:
 
-#### **2. Use `<Routes>` instead of `<Switch>`**
+#### 2. Use `<Routes>` instead of `<Switch>`
 
 ```typescript
 // Using <Routes> instead of <Switch> in `react-router` v6
@@ -85,7 +85,7 @@ return (
 );
 ```
 
-#### **3. Remove the `exact` prop from `<Route>` components**
+#### 3. Remove the `exact` prop from `<Route>` components
 
 ```typescript
 return (

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -78,7 +78,7 @@ groupId="package-manager"
 queryString="current-package-manager"
 />
 
-After updating the build configuration, it is likely that you will need to make additional updates to your plugin. Please follow the steps below:
+After updating the build configuration, it is likely that you will need to make additional updates to your plugin. To do so, follow the steps below:
 
 #### 2. Use `<Routes>` instead of `<Switch>`
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -37,3 +37,65 @@ Most code targeting 9.x will continue to work without any issues. An exception i
 When writing plugins that should run on 9.x, continue to use the Vector interfaces. In this case, when targeting versions 10+, you can now use simple arrays rather than wrapper classes.
 
 To make this transition seamless, we employed the Original JavaScript Sin™. That is, we [extended the native Array prototype](https://github.com/grafana/grafana/blob/v10.0.x/packages/grafana-data/src/types/vector.ts) with several Vector methods. We will atone and undo this in v11, when Vector interfaces and classes are removed.
+
+## Update to React Router v6
+
+Starting from Grafana 10 plugins should start updating to use the v6 version of `react-router`. Overall, `react-router` v6 aims to simplify route configuration and provide a more flexible and intuitive API for developers.
+
+**We strongly encourage developers to update their plugins to use the v6 version `react-router` as soon as possible, as the v5 version is going to be deprecated in the future.**
+
+[Official React Router v5 to v6 migration guide](https://reactrouter.com/en/main/upgrading/v5)
+
+### Update using `@grafana/create-plugin`
+
+Follow the steps below to start using React router v6 in your plugin.
+
+#### **1. Update the build related configuration:**
+
+Enable using `react-router@v6` by setting the following feature flag in `<project-root>/.cprc.json`:
+
+```json
+{
+  "features": {
+    "useReactRouterV6": true
+  }
+}
+```
+
+Now update the build configuration using the create-plugin tool:
+
+```bash
+npx @grafana/create-plugin@latest update
+```
+
+After updating the build config you probably also need to update some things in your code. Please follow the steps below:
+
+#### **2. Use `<Routes>` instead of `<Switch>`**
+
+```typescript
+// Using <Routes> instead of <Switch> in `react-router` v6
+import { Routes } from 'react-router-dom';
+
+// ...
+
+return (
+  <Routes>
+    <Route path="/" element={<Home />} />
+  </Routes>
+);
+```
+
+#### **3. Remove the `exact` prop from `<Route>` components**
+
+```typescript
+return (
+  <Routes>
+    {/* BAD (Until v5) */}
+    <Route exact path="/" element={<Home />} />
+
+    {/* GOOD (From v6) */}
+    {/* (Routes are "exact" by default, you need to use the "*" to match sub-routes) */}
+    <Route path="/" element={<Home />} />
+  </Routes>
+);
+```

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -99,3 +99,7 @@ return (
   </Routes>
 );
 ```
+
+#### 4. Follow the original `react-router` migration guide for more in-depth changes
+
+Visit the [official react-router v5 to v6 migration guide](https://reactrouter.com/en/main/upgrading/v5) for more information.

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -48,7 +48,7 @@ Starting from Grafana 10, plugins should use the v6 of `react-router`. Overall, 
 
 ### Update using `@grafana/create-plugin`
 
-Follow the steps below to start using React router v6 in your plugin.
+Follow the steps below to start using React router v6 in your plugin:
 
 #### **1. Update the build related configuration:**
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -40,7 +40,7 @@ To make this transition seamless, we employed the Original JavaScript Sin™. Th
 
 ## Update to React Router v6
 
-Starting from Grafana 10 plugins should start updating to use the v6 version of `react-router`. Overall, `react-router` v6 aims to simplify route configuration and provide a more flexible and intuitive API for developers.
+Starting from Grafana 10, plugins should use the v6 of `react-router`. Overall, `react-router` v6 aims to simplify route configuration and provide a more flexible and intuitive API for developers.
 
 **We strongly encourage developers to update their plugins to use the v6 version `react-router` as soon as possible, as the v5 version is going to be deprecated in the future.**
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -68,7 +68,7 @@ Now update the build configuration using the create-plugin tool:
 npx @grafana/create-plugin@latest update
 ```
 
-After updating the build config you probably also need to update some things in your code. Please follow the steps below:
+After updating the build configuration, you probably also need to make some updates. Follow the steps below:
 
 #### 2. Use `<Routes>` instead of `<Switch>`
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -12,6 +12,10 @@ keywords:
   - migration
 ---
 
+import UpdateNPM from '@snippets/createplugin-update.npm.md';
+import UpdatePNPM from '@snippets/createplugin-update.pnpm.md';
+import UpdateYarn from '@snippets/createplugin-update.yarn.md';
+
 # Migrate plugins from Grafana version 9.x to 10.x
 
 Follow these instructions to migrate plugins from Grafana version 9.x to 10.x.
@@ -64,9 +68,15 @@ Enable using `react-router@v6` by setting the following feature flag in `<projec
 
 Now update the build configuration using the create-plugin tool:
 
-```bash
-npx @grafana/create-plugin@latest update
-```
+<CodeSnippets
+snippets={[
+{ component: UpdateNPM, label: 'npm' },
+{ component: UpdatePNPM, label: 'pnpm' },
+{ component: UpdateYarn, label: 'yarn' },
+]}
+groupId="package-manager"
+queryString="current-package-manager"
+/>
 
 After updating the build configuration, it is likely that you will need to make additional updates to your plugin. Please follow the steps below:
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -68,7 +68,7 @@ Now update the build configuration using the create-plugin tool:
 npx @grafana/create-plugin@latest update
 ```
 
-After updating the build configuration, you probably also need to make some updates. Follow the steps below:
+After updating the build configuration, it is likely that you will need to make additional updates to your plugin. Please follow the steps below:
 
 #### 2. Use `<Routes>` instead of `<Switch>`
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -48,7 +48,7 @@ Starting from Grafana 10, plugins can start using the v6 of `react-router`. Over
 
 If your current plugin version needs to maintain compatibility with Grafana v9, then you can continue to use `react-router@v5` in Grafana v10. Both versions are available for plugins. However, **we strongly encourage developers to update their plugins to use the v6 version `react-router` as soon as possible**, as the v5 version is going to be deprecated in Grafana v11 and subsequently removed.
 
-[Official React Router v5 to v6 migration guide](https://reactrouter.com/en/main/upgrading/v5)
+For more general information, refer to the [Official React Router v5 to v6 migration guide](https://reactrouter.com/en/main/upgrading/v5).
 
 ### Update using `@grafana/create-plugin`
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v9.x-v10.x.md
@@ -40,15 +40,15 @@ To make this transition seamless, we employed the Original JavaScript Sin™. Th
 
 ## Update to React Router v6
 
-Starting from Grafana 10, plugins should use the v6 of `react-router`. Overall, `react-router` v6 aims to simplify route configuration and provide a more flexible and intuitive API for developers.
+Starting from Grafana 10, plugins can start using the v6 of `react-router`. Overall, `react-router` v6 aims to simplify route configuration and provide a more flexible and intuitive API for developers.
 
-**We strongly encourage developers to update their plugins to use the v6 version `react-router` as soon as possible, as the v5 version is going to be deprecated in the future.**
+If your current plugin version needs to maintain compatibility with Grafana v9, then you can continue to use `react-router@v5` in Grafana v10. Both versions are available for plugins. However, **we strongly encourage developers to update their plugins to use the v6 version `react-router` as soon as possible**, as the v5 version is going to be deprecated in Grafana v11 and subsequently removed.
 
 [Official React Router v5 to v6 migration guide](https://reactrouter.com/en/main/upgrading/v5)
 
 ### Update using `@grafana/create-plugin`
 
-Follow the steps below to start using React router v6 in your plugin:
+Follow the steps below to start using `react-router` v6 in your plugin:
 
 #### 1. Update the build related configuration:
 


### PR DESCRIPTION
### What changed?

Added migration docs for changing to `react-router@6`. Most of the work was copied over from https://github.com/grafana/grafana/pull/69835 (which I will close now).

fixes https://github.com/grafana/grafana/issues/69059