### PR TITLE
Create plugin: Fix react-router dependencies

### DIFF
--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -59,6 +59,7 @@ function getTemplateData(answers: CliArgs) {
   const { packageManagerName, packageManagerVersion } = getPackageManagerFromUserAgent();
   const packageManagerInstallCmd = getPackageManagerInstallCmd(packageManagerName);
   const isAppType = pluginType === PLUGIN_TYPES.app || pluginType === PLUGIN_TYPES.scenes;
+  const useReactRouterV5 = !features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app;
   const useReactRouterV6 = features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app;
   const templateData: TemplateData = {
     ...answers,
@@ -70,6 +71,7 @@ function getTemplateData(answers: CliArgs) {
     isNPM: packageManagerName === 'npm',
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
+    useReactRouterV5,
     useReactRouterV6,
     reactRouterVersion: useReactRouterV6 ? '6.22.0' : '5.2.0',
   };

--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -59,8 +59,8 @@ function getTemplateData(answers: CliArgs) {
   const { packageManagerName, packageManagerVersion } = getPackageManagerFromUserAgent();
   const packageManagerInstallCmd = getPackageManagerInstallCmd(packageManagerName);
   const isAppType = pluginType === PLUGIN_TYPES.app || pluginType === PLUGIN_TYPES.scenes;
-  const useReactRouterV5 = !features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app;
-  const useReactRouterV6 = features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app;
+  const useReactRouterV5 = !features.useReactRouterV6 && isAppType;
+  const useReactRouterV6 = features.useReactRouterV6 && pluginType === PLUGIN_TYPES.app; // Not yet supported by @grafana/scenes
   const templateData: TemplateData = {
     ...answers,
     pluginId,

--- a/packages/create-plugin/src/commands/types.ts
+++ b/packages/create-plugin/src/commands/types.ts
@@ -19,6 +19,7 @@ export type TemplateData = {
   isNPM: boolean;
   version: string;
   bundleGrafanaUI: boolean;
+  useReactRouterV5: boolean;
   useReactRouterV6: boolean;
   reactRouterVersion: string;
 };

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -97,6 +97,7 @@ export function getTemplateData() {
     packageManagerVersion,
     version: currentVersion,
     bundleGrafanaUI: features.bundleGrafanaUI,
+    useReactRouterV5: !features.useReactRouterV6 && pluginJson.type === PLUGIN_TYPES.app,
     useReactRouterV6: features.useReactRouterV6 && pluginJson.type === PLUGIN_TYPES.app,
     reactRouterVersion: features.useReactRouterV6 ? '6.22.0' : '5.2.0',
   };

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -49,8 +49,8 @@ const config = async (env): Promise<Configuration> => {
       'react-redux',
       'redux',
       'rxjs',
-      'react-router',{{#unless useReactRouterV6}}
-      'react-router-dom',{{/unless}}
+      'react-router',{{#if useReactRouterV5}}
+      'react-router-dom',{{/if}}
       'd3',
       'angular',{{#unless bundleGrafanaUI}}
       '@grafana/ui',{{/unless}}

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -30,8 +30,8 @@
     "@testing-library/react": "14.0.0",
     "@types/jest": "^29.5.0",
     "@types/lodash": "^4.14.194",
-    "@types/node": "^20.8.7",{{#unless useReactRouterV6}}
-    "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/unless}}
+    "@types/node": "^20.8.7",{{#if useReactRouterV5}}
+    "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/if}}
     "@types/testing-library__jest-dom": "5.14.8",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.7.3",


### PR DESCRIPTION
### What changed?
Thanks to @jackw we realised that due to some of my previous changes now panel plugins and datasource plugins are also scaffolded with the `@types/react-router-dom` devDependency. This PR aims to fix that.

**More details:**
 The actual bug was on these lines (the condition `#unless useReactRouterV6` is also true if it is a panel plugin for example):
 ```
"@types/node": "^20.8.7",{{#unless useReactRouterV6}}
    "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/unless}}
```