### PR TITLE
Plugin E2E: Fix feature toggles race condition

### DIFF
--- a/packages/plugin-e2e/src/fixtures/scripts/overrideFeatureToggles.js
+++ b/packages/plugin-e2e/src/fixtures/scripts/overrideFeatureToggles.js
@@ -1,9 +1,8 @@
 // this script is evaluated in the browser context, so we cannot use typescript
 export const overrideFeatureToggles = (featureToggles) => {
-  const timeout = 5;
-
+  const timeout = 1;
   const waitForGrafanaBootData = (cb) => {
-    if (window.grafanaBootData) {
+    if (window?.grafanaBootData?.settings?.featureToggles) {
       cb();
     } else {
       setTimeout(() => waitForGrafanaBootData(cb), timeout);
@@ -12,7 +11,7 @@ export const overrideFeatureToggles = (featureToggles) => {
 
   // wait for Grafana boot data to be added to the window object
   waitForGrafanaBootData(() => {
-    const version = window?.grafanaBootData?.settings?.buildInfo?.version;
+    console.log('@grafana/plugin-e2e: setting the following feature toggles', featureToggles);
 
     // override feature toggles with the ones provided by the test
     window.grafanaBootData.settings.featureToggles = {


### PR DESCRIPTION
**What this PR does / why we need it**:

Plugin E2E allows users to [override feature toggles](https://github.com/grafana/plugin-tools/pull/651) during test sessions. The way it works is that it simply wait until `window.grafanaBootData` is rendered, and then sets the toggles that the user defined in the playwright config. While working with other things, I've noticed there's some intermittent flakiness to this. I turns out it's because even though the `window.grafanaBootData` is defined, it does not necessarily mean that `window.grafanaBootData.settings.featureToggles` is defined yet. That meant the toggles that were set by plugin-e2e (sometimes) became overwritten by the ones coming from Grafana. 

This PR simply checks that Grafana have added its feature toggles to the boot data before plugin-e2e adds its overrides. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
