### PR TITLE
Plugin E2E: Generate dts files

### DIFF
--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -1,5 +1,4 @@
 import { GrafanaPage, VariableEditPage } from './models';
-import { Panel } from './models/Panel';
 import { AlertPageOptions, AlertVariant, ContainTextOptions } from './types';
 
 export { expect, test, type PluginFixture, type PluginOptions } from './api';

--- a/packages/plugin-e2e/tsconfig.json
+++ b/packages/plugin-e2e/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist",
     "stripInternal": true,
     "removeComments": false,
+    "declaration": true,
     "allowJs": true
   },
   "exclude": ["node_modules"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Seems that since https://github.com/grafana/plugin-tools/pull/694 plugin-e2e no longer spits out dts files. This PR adds back the `declaration: true` setting to the tsconfig.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
