### PR TITLE
Plugin E2E: Add fixture that reads provisioned data source files

### DIFF
--- a/packages/plugin-e2e/src/api.ts
+++ b/packages/plugin-e2e/src/api.ts
@@ -2,7 +2,13 @@ import { test as base, expect as baseExpect, selectors } from '@playwright/test'
 import { E2ESelectors } from './e2e-selectors/types';
 import fixtures from './fixtures';
 import matchers from './matchers';
-import { CreateDataSourceArgs, CreateDataSourcePageArgs, DataSource, ReadProvisionArgs } from './types';
+import {
+  CreateDataSourceArgs,
+  CreateDataSourcePageArgs,
+  Dashboard,
+  DataSourceSettings,
+  ReadProvisionedDataSourceArgs,
+} from './types';
 import {
   PanelEditPage,
   GrafanaPage,
@@ -136,7 +142,7 @@ export type PluginFixture = {
    * you may use this command in a setup project. Read more about setup projects
    * here: https://playwright.dev/docs/auth#basic-shared-account-in-all-tests
    */
-  createDataSource: (args: CreateDataSourceArgs) => Promise<DataSource>;
+  createDataSource: (args: CreateDataSourceArgs) => Promise<DataSourceSettings>;
 
   /**
    * Fixture command that login to Grafana using the Grafana API.
@@ -165,10 +171,13 @@ export type PluginFixture = {
   login: () => Promise<void>;
 
   /**
-   * Fixture command that reads a the yaml file for a provisioned dashboard
-   * or data source and returns it as json.
+   * Fixture command that reads a yaml file in the provisioning/datasources directory.
+   *
+   * The file name should be the name of the file with the .yaml|.yml extension.
+   * If a data source name is provided, the first data source that matches the name will be returned.
+   * If no name is provided, the first data source in the list of data sources will be returned.
    */
-  readProvision<T = any>(args: ReadProvisionArgs): Promise<T>;
+  readProvisionedDataSource<T = {}, S = {}>(args: ReadProvisionedDataSourceArgs): Promise<DataSourceSettings<T, S>>;
 
   /**
    * Function that checks if a feature toggle is enabled. Only works for frontend feature toggles.

--- a/packages/plugin-e2e/src/fixtures/commands/createDataSource.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createDataSource.ts
@@ -1,18 +1,18 @@
 import { v4 as uuidv4 } from 'uuid';
 import { APIRequestContext, expect, TestFixture } from '@playwright/test';
 import { PluginFixture, PluginOptions } from '../../api';
-import { CreateDataSourceArgs, DataSource } from '../../types';
+import { CreateDataSourceArgs, DataSourceSettings } from '../../types';
 import { PlaywrightCombinedArgs } from '../types';
 
 type CreateDataSourceViaAPIFixture = TestFixture<
-  (args: CreateDataSourceArgs) => Promise<DataSource>,
+  (args: CreateDataSourceArgs) => Promise<DataSourceSettings>,
   PluginFixture & PluginOptions & PlaywrightCombinedArgs
 >;
 
 export const createDataSourceViaAPI = async (
   request: APIRequestContext,
   datasource: CreateDataSourceArgs
-): Promise<DataSource> => {
+): Promise<DataSourceSettings> => {
   const { type, name } = datasource;
   const dsName = name ?? `${type}-${uuidv4()}`;
 

--- a/packages/plugin-e2e/src/fixtures/commands/readProvisionedDataSource.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/readProvisionedDataSource.ts
@@ -1,0 +1,26 @@
+import { TestFixture } from '@playwright/test';
+import { promises } from 'fs';
+import path from 'path';
+import { parse as parseYml } from 'yaml';
+import { PluginFixture, PluginOptions } from '../../api';
+import { DataSourceSettings, ReadProvisionedDataSourceArgs } from '../../types';
+import { PlaywrightCombinedArgs } from '../types';
+
+type ReadProvisionedDataSourceFixture = TestFixture<
+  <T = any>(args: ReadProvisionedDataSourceArgs) => Promise<T>,
+  PluginFixture & PluginOptions & PlaywrightCombinedArgs
+>;
+
+const readProvisionedDataSource: ReadProvisionedDataSourceFixture = async ({ provisioningRootDir }, use) => {
+  await use(async ({ fileName: filePath, name }) => {
+    const resolvedPath = path.resolve(path.join(provisioningRootDir, path.join('datasources', filePath)));
+    const contents = await promises.readFile(resolvedPath, 'utf8');
+    const yml = parseYml(contents);
+    if (!name) {
+      return yml.datasources[0];
+    }
+    return yml.datasources.find((ds: DataSourceSettings) => ds.name === name);
+  });
+};
+
+export default readProvisionedDataSource;

--- a/packages/plugin-e2e/src/fixtures/commands/readProvisionedDataSource.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/readProvisionedDataSource.ts
@@ -13,7 +13,7 @@ type ReadProvisionedDataSourceFixture = TestFixture<
 
 const readProvisionedDataSource: ReadProvisionedDataSourceFixture = async ({ provisioningRootDir }, use) => {
   await use(async ({ fileName: filePath, name }) => {
-    const resolvedPath = path.resolve(path.join(provisioningRootDir, path.join('datasources', filePath)));
+    const resolvedPath = path.resolve(path.join(provisioningRootDir, 'datasources', filePath));
     const contents = await promises.readFile(resolvedPath, 'utf8');
     const yml = parseYml(contents);
     if (!name) {

--- a/packages/plugin-e2e/src/fixtures/index.ts
+++ b/packages/plugin-e2e/src/fixtures/index.ts
@@ -6,6 +6,7 @@ import createDataSourceConfigPage from './commands/createDataSourceConfigPage';
 import panelEditPage from './panelEditPage';
 import createDataSource from './commands/createDataSource';
 import readProvision from './commands/readProvision';
+import readProvisionedDataSource from './commands/readProvisionedDataSource';
 import newDashboardPage from './newDashboardPage';
 import variableEditPage from './variableEditPage';
 import explorePage from './explorePage';
@@ -25,6 +26,7 @@ const fixtures = {
   explorePage,
   createDataSource,
   readProvision,
+  readProvisionedDataSource,
   isFeatureToggleEnabled,
 };
 

--- a/packages/plugin-e2e/src/models/DataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/models/DataSourceConfigPage.ts
@@ -1,9 +1,9 @@
 import { Response } from '@playwright/test';
-import { DataSource, NavigateOptions, PluginTestCtx, TriggerQueryOptions } from '../types';
+import { DataSourceSettings, NavigateOptions, PluginTestCtx, TriggerQueryOptions } from '../types';
 import { GrafanaPage } from './GrafanaPage';
 
 export class DataSourceConfigPage extends GrafanaPage {
-  constructor(ctx: PluginTestCtx, private datasource: DataSource) {
+  constructor(ctx: PluginTestCtx, private datasource: DataSourceSettings) {
     super(ctx);
   }
   async deleteDataSource() {

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -11,21 +11,21 @@ export type PluginTestCtx = { grafanaVersion: string; selectors: E2ESelectors } 
 >;
 
 /**
- * The data source object
+ * The data source settings
  */
-export interface DataSource<T = any> {
+export interface DataSourceSettings<T = {}, S = {}> {
   id: number;
   editable?: boolean;
   uid: string;
   orgId?: number;
-  name?: string;
+  name: string;
   type: string;
   access?: string;
   url?: string;
   database?: string;
   isDefault?: boolean;
-  jsonData?: T;
-  secureJsonData?: T;
+  jsonData: T;
+  secureJsonData?: S;
 }
 
 /**
@@ -35,13 +35,6 @@ export interface Dashboard {
   uid: string;
   title?: string;
 }
-
-/**
- * The YAML provision file parsed to a javascript object
- */
-export type ProvisionFile<T = DataSource> = {
-  datasources: Array<DataSource<T>>;
-};
 
 export type CreateDataSourceArgs<T = any> = {
   /**
@@ -142,6 +135,18 @@ export type ReadProvisionArgs = {
    * The path, relative to the provisioning folder, to the dashboard json file
    */
   filePath: string;
+};
+
+export type ReadProvisionedDataSourceArgs = {
+  /**
+   * The path, relative to the provisioning folder, to the dashboard json file
+   */
+  fileName: string;
+
+  /**
+   * The name of the data source in the datasources list
+   */
+  name?: string;
 };
 
 export type NavigateOptions = {

--- a/packages/plugin-e2e/tests/admin/datasource/annotations/annotationEditor.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/annotations/annotationEditor.spec.ts
@@ -1,15 +1,14 @@
 import { test, expect } from '../../../../src';
-import { ProvisionFile } from '../../../../src/types';
 import { REDSHIFT_SCHEMAS } from '../mocks/resource';
 
 test('should load resources and display them as options when clicking on an input', async ({
   annotationEditPage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
   await annotationEditPage.mockResourceResponse('schemas', REDSHIFT_SCHEMAS);
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/redshift.yaml' });
-  await annotationEditPage.datasource.set(provision.datasources?.[0]!.name!);
+  const ds = await readProvisionedDataSource({ fileName: 'redshift.yaml' });
+  await annotationEditPage.datasource.set(ds.name);
   await page.getByLabel('Schema').click();
   await expect(annotationEditPage.getByTestIdOrAriaLabel('Select option')).toContainText(REDSHIFT_SCHEMAS);
 });

--- a/packages/plugin-e2e/tests/admin/datasource/annotations/annotationQueryRunner.integration.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/annotations/annotationQueryRunner.integration.spec.ts
@@ -1,17 +1,16 @@
 import semverLt from 'semver/functions/lt';
 import { test, expect, AnnotationEditPage } from '../../../../src';
-import { Dashboard, ProvisionFile } from '../../../src/types';
 
 test('should run successfully if valid Redshift query was provided', async ({
   annotationEditPage,
   page,
   selectors,
-  readProvision,
+  readProvisionedDataSource,
   grafanaVersion,
 }, testInfo) => {
   testInfo.skip(semverLt(grafanaVersion, '9.2.0'), 'Code editor seems to trigger one query per character typed');
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/redshift.yaml' });
-  await annotationEditPage.datasource.set(provision.datasources?.[0]!.name!);
+  const ds = await readProvisionedDataSource({ fileName: 'redshift.yaml' });
+  await annotationEditPage.datasource.set(ds.name);
   await page.waitForFunction(() => (window as any).monaco);
   await annotationEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).click();
   await page.keyboard.insertText('SELECT starttime, eventname FROM event ORDER BY eventname ASC LIMIT 5 ');
@@ -22,10 +21,10 @@ test('should run successfully if valid Redshift query was provided', async ({
 test('should run successfully if valid Google Sheets query was provided', async ({
   annotationEditPage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
-  await annotationEditPage.datasource.set(provision.datasources?.[0]!.name!);
+  const ds = await readProvisionedDataSource({ fileName: 'google-sheets-datasource-jwt.yaml' });
+  await annotationEditPage.datasource.set(ds.name);
   await page.getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
   await page.keyboard.press('Enter');

--- a/packages/plugin-e2e/tests/admin/datasource/explore/queryEditor.integration.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/explore/queryEditor.integration.spec.ts
@@ -1,14 +1,13 @@
 const semver = require('semver');
 import { expect, test } from '../../../../src';
-import { ProvisionFile } from '../../../../src/types';
 
 test('should return data and not display panel error when a valid query is provided', async ({
   explorePage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
-  await explorePage.datasource.set(provision.datasources?.[0]!.name!);
+  const ds = await readProvisionedDataSource({ fileName: 'google-sheets-datasource-jwt.yaml' });
+  await explorePage.datasource.set(ds.name);
   await explorePage.timeRange.set({ from: '2019-01-11', to: '2019-12-15' });
   await explorePage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
@@ -21,10 +20,10 @@ test('should return data and not display panel error when a valid query is provi
 test('should return an error and display panel error when an invalid query is provided', async ({
   explorePage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
-  await explorePage.datasource.set(provision.datasources?.[0]!.name!);
+  const ds = await readProvisionedDataSource({ fileName: 'google-sheets-datasource-jwt.yaml' });
+  await explorePage.datasource.set(ds.name);
   await explorePage.timeRange.set({ from: '2019-01-11', to: '2019-12-15' });
   await page.getByPlaceholder('Class Data!A2:E').fill('invalid range');
   await page.keyboard.press('Tab');

--- a/packages/plugin-e2e/tests/admin/datasource/feature-toggles/queryEditor.async.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/feature-toggles/queryEditor.async.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '../../../../src';
-import { ProvisionFile } from '../../../../src/types';
 
 const TRUTHY_CUSTOM_TOGGLE = 'custom_toggle1';
 const FALSY_CUSTOM_TOGGLE = 'custom_toggle2';
+
 // override the feature toggles defined in playwright.config.ts only for tests in this file
 test.use({
   featureToggles: {
@@ -21,10 +21,10 @@ test('async query data handler should return a `finished` status', async ({
   selectors,
   panelEditPage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
-  const provisionFile = await readProvision<ProvisionFile>({ filePath: 'datasources/redshift.yaml' });
-  await panelEditPage.datasource.set(provisionFile.datasources[0].name!);
+  const ds = await readProvisionedDataSource({ fileName: 'redshift.yaml' });
+  await panelEditPage.datasource.set(ds.name);
   await panelEditPage.timeRange.set({ from: '2020-01-31', to: '2020-02-20' });
   await page.waitForFunction(() => (window as any).monaco);
   await panelEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).click();

--- a/packages/plugin-e2e/tests/admin/datasource/feature-toggles/queryEditor.sync.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/feature-toggles/queryEditor.sync.spec.ts
@@ -1,16 +1,15 @@
 import { expect, test } from '../../../../src';
-import { ProvisionFile } from '../../../../src/types';
 
 test('standard query data handler should only be called once', async ({
   panelEditPage,
   page,
   selectors,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
   const requestListener = (request) => request.url().includes(selectors.apis.DataSource.query) && calledTimes++;
 
-  const provisionFile = await readProvision<ProvisionFile>({ filePath: 'datasources/redshift.yaml' });
-  await panelEditPage.datasource.set(provisionFile.datasources[0].name!);
+  const ds = await readProvisionedDataSource({ fileName: 'redshift.yaml' });
+  await panelEditPage.datasource.set(ds.name);
   await panelEditPage.timeRange.set({ from: '2020-01-31', to: '2020-02-20' });
   await page.waitForFunction(() => (window as any).monaco);
   await panelEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).click();

--- a/packages/plugin-e2e/tests/admin/datasource/query-editor/queryEditor.integration.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/query-editor/queryEditor.integration.spec.ts
@@ -1,13 +1,14 @@
 import { expect, test } from '../../../../src';
-import { ProvisionFile } from '../../../../src/types';
 
 test('should return data and not display panel error when a valid query is provided', async ({
   panelEditPage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
-  await panelEditPage.datasource.set(provision.datasources?.[0]!.name!);
+  const ds = await readProvisionedDataSource({
+    fileName: 'google-sheets-datasource-jwt.yaml',
+  });
+  await panelEditPage.datasource.set(ds.name);
   await panelEditPage.timeRange.set({ from: '2019-01-11', to: '2019-12-15' });
   await panelEditPage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');
@@ -19,10 +20,12 @@ test('should return data and not display panel error when a valid query is provi
 test('should return an error and display panel error when an invalid query is provided', async ({
   panelEditPage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
-  await panelEditPage.datasource.set(provision.datasources?.[0]!.name!);
+  const ds = await readProvisionedDataSource({
+    fileName: 'google-sheets-datasource-jwt.yaml',
+  });
+  await panelEditPage.datasource.set(ds.name);
   await panelEditPage.timeRange.set({ from: '2019-01-11', to: '2019-12-15' });
   await panelEditPage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await page.keyboard.insertText('1TZlZX67Y0s4CvRro_3pCYqRCKuXer81oFp_xcsjPpe8');

--- a/packages/plugin-e2e/tests/admin/datasource/query-editor/queryEditor.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/query-editor/queryEditor.spec.ts
@@ -1,25 +1,40 @@
 import { expect, test } from '../../../../src';
-import { ProvisionFile } from '../../../../src/types';
 import { GOOGLE_SHEETS_SPREADSHEETS } from '../mocks/resource';
+
+export interface SheetsJsonData {
+  authenticationType: string;
+  tokenUri?: string;
+  clientEmail?: string;
+  defaultProject?: string;
+  privateKeyPath?: string;
+}
+
+export interface SheetsSecureJsonData {
+  privateKey?: string;
+}
 
 test('should list spreadsheets when clicking on spreadsheet segment', async ({
   panelEditPage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
-  const sheetsDataSource = await readProvision<ProvisionFile>({
-    filePath: 'datasources/google-sheets-datasource-jwt.yaml',
-  }).then((provision) => provision.datasources?.[0]!);
-  await panelEditPage.datasource.set(sheetsDataSource.name!);
+  const ds = await readProvisionedDataSource<SheetsJsonData, SheetsSecureJsonData>({
+    fileName: 'google-sheets-datasource-jwt.yaml',
+  });
+  await panelEditPage.datasource.set(ds.name);
   await panelEditPage.mockResourceResponse('spreadsheets', GOOGLE_SHEETS_SPREADSHEETS);
   await panelEditPage.getQueryEditorRow('A').getByText('Enter SpreadsheetID').click();
   await expect(page.getByText(GOOGLE_SHEETS_SPREADSHEETS.spreadsheets.sheet1, { exact: true })).toHaveCount(1);
   await expect(page.getByText(GOOGLE_SHEETS_SPREADSHEETS.spreadsheets.sheet2, { exact: true })).toHaveCount(1);
 });
 
-test('should set correct cache time on query passed to the backend', async ({ panelEditPage, page, readProvision }) => {
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/google-sheets-datasource-jwt.yaml' });
-  await panelEditPage.datasource.set(provision.datasources?.[0]!.name!);
+test('should set correct cache time on query passed to the backend', async ({
+  panelEditPage,
+  page,
+  readProvisionedDataSource,
+}) => {
+  const ds = await readProvisionedDataSource({ fileName: 'google-sheets-datasource-jwt.yaml' });
+  await panelEditPage.datasource.set(ds.name);
   await panelEditPage.mockResourceResponse('spreadsheets', GOOGLE_SHEETS_SPREADSHEETS);
   await panelEditPage.getQueryEditorRow('A').getByText('5m', { exact: true }).click();
   await page.keyboard.insertText('1h');

--- a/packages/plugin-e2e/tests/admin/datasource/variables/customVariableEditor.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/variables/customVariableEditor.spec.ts
@@ -1,17 +1,16 @@
 import { expect, test } from '../../../../src';
-import { ProvisionFile } from '../../../src/types';
 import { REDSHIFT_SCHEMAS, REDSHIFT_TABLES } from '../mocks/resource';
 
 test('should load resources and display them as options when clicking on an input', async ({
   variableEditPage,
   page,
-  readProvision,
+  readProvisionedDataSource,
 }) => {
   await variableEditPage.mockResourceResponse('schemas', REDSHIFT_SCHEMAS);
   await variableEditPage.mockResourceResponse('tables', REDSHIFT_TABLES);
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/redshift.yaml' });
+  const ds = await readProvisionedDataSource({ fileName: 'redshift.yaml' });
   await variableEditPage.setVariableType('Query');
-  await variableEditPage.datasource.set(provision.datasources?.[0]!.name!);
+  await variableEditPage.datasource.set(ds.name);
   await page.getByLabel('Schema').click();
   await expect(variableEditPage.getByTestIdOrAriaLabel('Select option')).toContainText(REDSHIFT_SCHEMAS);
   await page.keyboard.press('Enter');

--- a/packages/plugin-e2e/tests/admin/datasource/variables/customVariableQueryRunner.integration.spec.ts
+++ b/packages/plugin-e2e/tests/admin/datasource/variables/customVariableQueryRunner.integration.spec.ts
@@ -1,15 +1,14 @@
 import { VariableEditPage, expect, test } from '../../../../src';
-import { Dashboard, ProvisionFile } from '../../../../src/types';
 
 test('custom variable editor query runner should return data when query is valid', async ({
   variableEditPage,
   page,
-  readProvision,
+  readProvisionedDataSource,
   selectors,
 }) => {
-  const provision = await readProvision<ProvisionFile>({ filePath: 'datasources/redshift.yaml' });
+  const ds = await readProvisionedDataSource({ fileName: 'redshift.yaml' });
   await variableEditPage.setVariableType('Query');
-  await variableEditPage.datasource.set(provision.datasources?.[0]!.name!);
+  await variableEditPage.datasource.set(ds.name);
   await page.waitForFunction(() => (window as any).monaco);
   await variableEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).click();
   await page.keyboard.insertText('select distinct(environment) from long_format_example');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

`grafana/e2e` has a utility function called `readProvisions`. This allows you to read a yaml file from the provisioning repo. This is useful when you for example want to test the config editor with valid configurations, and you don't want to re-type all the settings. See [example](https://github.com/grafana/redshift-datasource/blob/main/cypress/integration/smoke.spec.ts#L50-L70) in Cypress tests for the redshift plugin. 

At an early stage of this project, I copied this utility function to plugin-e2e and provided it as a fixture. However, it's hard to provide a consistent way to use this fixture as it can read any type of provisioned file - data source, dashboard, permissions etc. It's better to create one fixture per type of provisioned file so we can offer correct typings etc. 

This PR adds a new fixture called `readProvisionedDataSource`. There will be a separate PR that adds a fixture for `readProvisionedDashboard`. 

Also making some type improvements to the DataSourceSettings. 


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.14.0-canary.740.aade71f.0
  # or 
  yarn add @grafana/plugin-e2e@0.14.0-canary.740.aade71f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
