### PR TITLE
create-plugin: Adds support for remote docker development of backend plugins and frontend react dev tools

### DIFF
--- a/packages/create-plugin/docker/Dockerfile
+++ b/packages/create-plugin/docker/Dockerfile
@@ -1,0 +1,38 @@
+ARG ARCH=amd64
+ARG BASE_IMAGE=grafana/grafana-oss-${ARCH}:development-ubuntu
+
+FROM ${BASE_IMAGE} as plugindev
+
+ARG GO_VERSION=1.21.6
+ARG GO_ARCH=amd64
+
+
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+
+ENV GF_PATHS_HOME="/usr/share/grafana"
+WORKDIR $GF_PATHS_HOME
+
+USER root
+RUN apt-get update && \
+    apt-get install -y supervisor && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Installing Go
+RUN curl -O -L https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+    echo "export PATH=$PATH:/usr/local/go/bin:~/go/bin" >> ~/.bashrc && \
+    rm -f go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+
+# Installing delve for debugging
+RUN /usr/local/go/bin/go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Installing mage for plugin (re)building
+RUN git clone https://github.com/magefile/mage; \
+    cd mage; \
+    export PATH=$PATH:/usr/local/go/bin; \
+    go run bootstrap.go
+
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/packages/create-plugin/docker/README.md
+++ b/packages/create-plugin/docker/README.md
@@ -3,3 +3,38 @@
 This is a first-pass at creating a dev image of grafana that spins up `delve` along with grafana to allow remote debugging.
 
 The image it is based on also supports the full dev build of react to enable profiling (chrome react dev tools)
+
+## Connecting from VSCode
+
+Example launch config for vscode:
+
+```JSON
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Standalone debug mode",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/pkg",
+      "env": {},
+      "args": [
+        "-standalone"
+      ]
+    },
+    {
+      "name": "Attach to plugin backend in docker",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "remotePath": "",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "showLog": true,
+      "trace": "log",
+      "logOutput": "rpc"
+    }
+  ]
+}
+```

--- a/packages/create-plugin/docker/README.md
+++ b/packages/create-plugin/docker/README.md
@@ -1,0 +1,5 @@
+# Building remote docker developer image
+
+This is a first-pass at creating a dev image of grafana that spins up `delve` along with grafana to allow remote debugging.
+
+The image it is based on also supports the full dev build of react to enable profiling (chrome react dev tools)

--- a/packages/create-plugin/docker/build.sh
+++ b/packages/create-plugin/docker/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+docker buildx build \
+  --platform linux/arm64 \
+  --build-arg ARCH=arm64 \
+  -f Dockerfile \
+  -t grafana/grafana-plugindev-linux-arm64:v1 .
+
+docker buildx build \
+  --platform linux/amd64 \
+  --build-arg ARCH=amd64 \
+  -f Dockerfile \
+  -t grafana/grafana-plugindev-linux-amd64:v1 .
+

--- a/packages/create-plugin/docker/example/docker-compose.yaml
+++ b/packages/create-plugin/docker/example/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: '3.0'
+
+services:
+  grafana:
+    image: grafana-plugindev-linux-arm64:v1
+    platform: 'linux/arm64'
+    ports:
+      - 4000:3000/tcp
+      - 4345:2345/tcp # delve
+    security_opt:
+      - "apparmor:unconfined"
+      - "seccomp:unconfined"
+    cap_add:
+      - SYS_PTRACE
+    volumes:
+      - ./dist:/var/lib/grafana/plugins/grafana-examplebackend-app
+      - ./provisioning:/etc/grafana/provisioning
+    environment:
+      NODE_ENV: development
+      GF_APP_MODE: development
+      GF_LOG_FILTERS: plugin.grafana-examplebackend-app:debug
+      GF_LOG_LEVEL: debug
+      GF_DATAPROXY_LOGGING: 1
+      GF_AUTH_ANONYMOUS_ENABLED: 1
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-examplebackend-app
+      GF_PLUGINS_DELVE_ENABLED: true
+      GF_PLUGINS_DELVE_PLUGINID: gpx_examplebackend

--- a/packages/create-plugin/docker/supervisord/supervisord.conf
+++ b/packages/create-plugin/docker/supervisord/supervisord.conf
@@ -1,0 +1,25 @@
+[supervisord]
+nodaemon=true
+user=root
+
+[program:grafana]
+user=root
+directory=/var/lib/grafana
+command=/run.sh
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+killasgroup=true
+stopasgroup=true
+autostart=true
+
+[program:delve]
+user=root
+command=/bin/bash -c 'pgrep -f %(ENV_GF_PLUGINS_DELVE_PLUGINID)s | xargs /root/go/bin/dlv attach --api-version=2 --headless --continue --accept-multiclient --listen=:2345'
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+killasgroup=false
+stopasgroup=false
+autostart=true
+autorestart=true


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a first-pass at setting up a remote docker debug environment, we'll iterate on this some to iron out a couple of issues.

This takes a locally built dev image of grafana (until we get them auto-published in the pipeline), and adds golang+mage to the image, and runs supervisord to launch grafana and delve connected to the backend.

Pending Items:

- [ ] Move backend plugin build inside docker container and supervise a mage build:watch
  - [ ] docker-compose would need to map the git repo to a volume in order to build/rebuild with mage
- [ ] Modify delve to always kill process on disconnect
- [ ] Get the gpx_* binary name from src/plugin.json vs having to set env var
- [ ] Maybe detect from src/plugin.json if backend is supported (and do not try to spawn delve), this can still bem useful for frontend debug tools
- [ ] Another option - write a small watcher service to respawn dlv with the new PID when process is killed (mage build:watch might be sufficient)
- [ ] not tested on alpine (yet!)

**Which issue(s) this PR fixes**:

Fixes #735 

**Special notes for your reviewer**:
