### PR TITLE
docs: specify frontend and backend can be included

### DIFF
--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/nested-plugins.mdx
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/nested-plugins.mdx
@@ -16,7 +16,7 @@ import ScaffoldNPM from '@snippets/createplugin-scaffold.npm.md';
 import ScaffoldPNPM from '@snippets/createplugin-scaffold.pnpm.md';
 import ScaffoldYarn from '@snippets/createplugin-scaffold.yarn.md';
 
-Grafana app plugins can nest frontend data sources together with panel plugins so that you can provide a complete user experience.
+Grafana app plugins can nest data sources, both frontend and backend, together with panel plugins so that you can provide a complete user experience.
 
 ## Before you begin
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Minor text update to indicate that both frontend and backend datasources can be bundled within an app.

