### PR TITLE
Plugin E2E: Improve ds config Save & test for FE plugins

### DIFF
--- a/packages/plugin-e2e/docker-compose.yaml
+++ b/packages/plugin-e2e/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   grafana:
     image: grafana/${GRAFANA_IMAGE:-grafana-enterprise}:${GRAFANA_VERSION:-main}
     environment:
-      - GF_INSTALL_PLUGINS=grafana-clock-panel 2.1.3,grafana-googlesheets-datasource 1.2.4,grafana-redshift-datasource 1.13.0
+      - GF_INSTALL_PLUGINS=grafana-clock-panel 2.1.3,grafana-googlesheets-datasource 1.2.4,grafana-redshift-datasource 1.13.0,marcusolsson-json-datasource 1.3.12
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ORG_NAME=Main Org.

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -12,6 +12,7 @@ export type APIs = {
     query: string;
     health: (uid: string, id: string) => string;
     datasourceByUID: (uid: string) => string;
+    proxy: (uid: string) => string;
   };
   Dashboard: {
     delete: (uid: string) => string;

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/apis.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/apis.ts
@@ -22,6 +22,9 @@ export const versionedAPIs = {
     datasourceByUID: {
       [MIN_GRAFANA_VERSION]: (uid: string) => `/api/datasources/uid/${uid}`,
     },
+    proxy: {
+      [MIN_GRAFANA_VERSION]: (uid: string) => `api/datasources/proxy/uid/${uid}`,
+    },
   },
   Dashboard: {
     delete: {

--- a/packages/plugin-e2e/src/models/pages/DataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DataSourceConfigPage.ts
@@ -1,5 +1,5 @@
 import { Response } from '@playwright/test';
-import { DataSourceSettings, NavigateOptions, PluginTestCtx, TriggerQueryOptions } from '../../types';
+import { DataSourceSettings, NavigateOptions, PluginTestCtx, TriggerRequestOptions } from '../../types';
 import { GrafanaPage } from './GrafanaPage';
 
 export class DataSourceConfigPage extends GrafanaPage {
@@ -35,15 +35,15 @@ export class DataSourceConfigPage extends GrafanaPage {
    * Clicks the save and test button and waits for the response
    *
    * By default, this will return the response of the health check call to /api/datasources/uid/<pluginUid>/health.
-   * Optionally, if your plugin uses a custom health check endpoint, you can provide the {@link TriggerQueryOptions.healthCheckPath } of this url.
+   * Optionally, if your plugin uses a custom health check endpoint, you can provide the {@link TriggerRequestOptions.path } of this url.
    * May be useful for data source plugins that don't have a backend.
    */
-  async saveAndTest(options?: TriggerQueryOptions): Promise<Response> {
+  async saveAndTest(options?: TriggerRequestOptions): Promise<Response> {
     const { datasourceByUID, health } = this.ctx.selectors.apis.DataSource;
     const saveResponsePromise = this.ctx.page.waitForResponse((resp) =>
       resp.url().includes(datasourceByUID(this.datasource.uid))
     );
-    const healthPath = options?.healthCheckPath ?? health(this.datasource.uid, this.datasource.id.toString());
+    const healthPath = options?.path ?? health(this.datasource.uid, this.datasource.id.toString());
     const healthResponsePromise = this.ctx.page.waitForResponse((resp) => resp.url().includes(healthPath));
     await this.getByTestIdOrAriaLabel(this.ctx.selectors.pages.DataSource.saveAndTest).click();
     return saveResponsePromise.then(() => healthResponsePromise);

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -209,9 +209,9 @@ export type GetByTestIdOrAriaLabelOptions = {
 
 export type TriggerQueryOptions = {
   /**
-   * Set this to true to skip waiting for the response. Defaults to false.
+   * The path to the health check endpoint. Defaults to `/api/datasources/uid/<pluginUid>/health`
    */
-  skipWaitForResponse: boolean;
+  healthCheckPath?: string;
 };
 
 /**

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -207,11 +207,11 @@ export type GetByTestIdOrAriaLabelOptions = {
   startsWith?: boolean;
 };
 
-export type TriggerQueryOptions = {
+export type TriggerRequestOptions = {
   /**
-   * The path to the health check endpoint. Defaults to `/api/datasources/uid/<pluginUid>/health`
+   * The path to the endpoint to trigger
    */
-  healthCheckPath?: string;
+  path?: string;
 };
 
 /**

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/config-editor/configEditor.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/config-editor/configEditor.spec.ts
@@ -27,6 +27,6 @@ test('should call a custom health endpoint when healthCheckPath is provided', as
     await route.fulfill({ status: 200, body: 'OK' });
   });
   await page.getByPlaceholder('http://localhost:8080').fill('http://localhost:8080');
-  await expect(configPage.saveAndTest({ healthCheckPath })).toBeOK();
+  await expect(configPage.saveAndTest({ path: healthCheckPath })).toBeOK();
   await expect(configPage).toHaveAlert('success', { hasNotText: 'Datasource updated' });
 });

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/config-editor/configEditor.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/config-editor/configEditor.spec.ts
@@ -16,8 +16,17 @@ test('valid credentials should return a 200 status code', async ({ createDataSou
   await expect(configPage.saveAndTest()).toBeOK();
 });
 
-test('valid credentials should display a success alert on the page', async ({ createDataSourceConfigPage, page }) => {
-  const configPage = await createDataSourceConfigPage({ type: 'testdata' });
-  await configPage.saveAndTest({ skipWaitForResponse: true });
+test('should call a custom health endpoint when healthCheckPath is provided', async ({
+  createDataSourceConfigPage,
+  page,
+  selectors,
+}) => {
+  const configPage = await createDataSourceConfigPage({ type: 'marcusolsson-json-datasource' });
+  const healthCheckPath = selectors.apis.DataSource.proxy(configPage.datasource.uid);
+  await page.route(healthCheckPath, async (route) => {
+    await route.fulfill({ status: 200, body: 'OK' });
+  });
+  await page.getByPlaceholder('http://localhost:8080').fill('http://localhost:8080');
+  await expect(configPage.saveAndTest({ healthCheckPath })).toBeOK();
   await expect(configPage).toHaveAlert('success', { hasNotText: 'Datasource updated' });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves the story for testing the ds config in a frontend ds plugin. 

Unlike backend data source plugins, frontend data source plugins may call any third party api to test whether the config is valid or not. This PR makes it possible to optionally override the health check url path in the `DataSourceConfigPage.saveAndTest` method. That makes testing frontend data sources much more straight forward, and also the API less weird. :) 


### Breaking change notice
Before this change:

```ts
test('frontend data source - "Save & test" should be successful when configuration is valid', async ({
  createDataSourceConfigPage,
  readProvisionedDataSource,
  page,
}) => {
  const ds = await readProvisionedDataSource<MyDataSourceOptions, MySecureJsonData>({ fileName: 'datasources.yml' });
  const configPage = await createDataSourceConfigPage({ type: ds.type });
  await page.getByLabel('Path').fill(ds.jsonData.path);
  await page.getByLabel('API Key').fill(ds.secureJsonData.apiKey);
  const testDataSourceResponsePromise = page.waitForResponse('/api/health');
  await configPage.saveAndTest({ skipWaitForResponse: true });
  await expect(testDataSourceResponsePromise).toBeOK();
});
```

After: 

```ts
test('frontend data source - "Save & test" should be successful when configuration is valid', async ({
  createDataSourceConfigPage,
  readProvisionedDataSource,
  page,
}) => {
  const ds = await readProvisionedDataSource<MyDataSourceOptions, MySecureJsonData>({ fileName: 'datasources.yml' });
  const configPage = await createDataSourceConfigPage({ type: ds.type });
  await page.getByLabel('Path').fill(ds.jsonData.path);
  await page.getByLabel('API Key').fill(ds.secureJsonData.apiKey);
  await expect(configPage.saveAndTest({ path: '/api/health' })).toBeOK();
});
```


Before this PR, the process for testing the ds config in a frontend data source was weird: 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.3.0-canary.785.931f1cb.0
  npm install @grafana/plugin-e2e@0.19.0-canary.785.931f1cb.0
  # or 
  yarn add @grafana/create-plugin@4.3.0-canary.785.931f1cb.0
  yarn add @grafana/plugin-e2e@0.19.0-canary.785.931f1cb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
