### PR TITLE
PluginE2E: Added (app) plugin config fixture

### DIFF
--- a/packages/plugin-e2e/docker-compose.yaml
+++ b/packages/plugin-e2e/docker-compose.yaml
@@ -1,10 +1,10 @@
-version: "3.7"
+version: '3.7'
 
 services:
   grafana:
     image: grafana/${GRAFANA_IMAGE:-grafana-enterprise}:${GRAFANA_VERSION:-main}
     environment:
-      - GF_INSTALL_PLUGINS=grafana-clock-panel 2.1.3,grafana-googlesheets-datasource 1.2.4,grafana-redshift-datasource 1.13.0,marcusolsson-json-datasource 1.3.12
+      - GF_INSTALL_PLUGINS=grafana-clock-panel 2.1.3,grafana-googlesheets-datasource 1.2.4,grafana-redshift-datasource 1.13.0,marcusolsson-json-datasource 1.3.12,redis-app 2.2.1
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ORG_NAME=Main Org.

--- a/packages/plugin-e2e/provisioning/plugins/redis-app.yaml
+++ b/packages/plugin-e2e/provisioning/plugins/redis-app.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+apps:
+  - type: redis-app
+    org_id: 1
+    org_name: Main Org.
+    disabled: false

--- a/packages/plugin-e2e/src/api.ts
+++ b/packages/plugin-e2e/src/api.ts
@@ -148,10 +148,7 @@ export type PluginFixture = {
   createDataSourceConfigPage: (args: CreateDataSourcePageArgs) => Promise<DataSourceConfigPage>;
 
   /**
-   * Fixture command that will create an isolated AppConfigPage instance for a given plugin.
-   *
-   * By default, when createing the page, the browser will navigate to it. If you want to turn off this
-   * behaviour you can pass an optional second parameter with the property { goto: false }.
+   * Fixture command that will navigate to the AppConfigPage for a given plugin.
    */
   gotoAppConfigPage: (args: GotoAppConfigPageArgs) => Promise<AppConfigPage>;
 

--- a/packages/plugin-e2e/src/api.ts
+++ b/packages/plugin-e2e/src/api.ts
@@ -10,7 +10,7 @@ import {
   ReadProvisionedDataSourceArgs,
   CreateUserArgs,
   Dashboard,
-  PluginConfigPageArgs,
+  GotoAppConfigPageArgs,
 } from './types';
 import {
   PanelEditPage,
@@ -153,7 +153,7 @@ export type PluginFixture = {
    * By default, when createing the page, the browser will navigate to it. If you want to turn off this
    * behaviour you can pass an optional second parameter with the property { goto: false }.
    */
-  createAppConfigPage: (args: PluginConfigPageArgs) => Promise<AppConfigPage>;
+  gotoAppConfigPage: (args: GotoAppConfigPageArgs) => Promise<AppConfigPage>;
 
   /**
    * Fixture command that creates a data source via the Grafana API.

--- a/packages/plugin-e2e/src/api.ts
+++ b/packages/plugin-e2e/src/api.ts
@@ -10,6 +10,7 @@ import {
   ReadProvisionedDataSourceArgs,
   CreateUserArgs,
   Dashboard,
+  PluginConfigPageArgs,
 } from './types';
 import {
   PanelEditPage,
@@ -18,6 +19,7 @@ import {
   DashboardPage,
   VariableEditPage,
   AnnotationEditPage,
+  AppConfigPage,
 } from './models';
 import { grafanaE2ESelectorEngine } from './selectorEngine';
 import { ExplorePage } from './models/pages/ExplorePage';
@@ -144,6 +146,14 @@ export type PluginFixture = {
    * data source using the Grafana API, create a new DataSourceConfigPage instance and navigate to the page.
    */
   createDataSourceConfigPage: (args: CreateDataSourcePageArgs) => Promise<DataSourceConfigPage>;
+
+  /**
+   * Fixture command that will create an isolated AppConfigPage instance for a given plugin.
+   *
+   * By default, when createing the page, the browser will navigate to it. If you want to turn off this
+   * behaviour you can pass an optional second parameter with the property { goto: false }.
+   */
+  createAppConfigPage: (args: PluginConfigPageArgs, options?: { goto?: boolean }) => Promise<AppConfigPage>;
 
   /**
    * Fixture command that creates a data source via the Grafana API.

--- a/packages/plugin-e2e/src/api.ts
+++ b/packages/plugin-e2e/src/api.ts
@@ -153,7 +153,7 @@ export type PluginFixture = {
    * By default, when createing the page, the browser will navigate to it. If you want to turn off this
    * behaviour you can pass an optional second parameter with the property { goto: false }.
    */
-  createAppConfigPage: (args: PluginConfigPageArgs, options?: { goto?: boolean }) => Promise<AppConfigPage>;
+  createAppConfigPage: (args: PluginConfigPageArgs) => Promise<AppConfigPage>;
 
   /**
    * Fixture command that creates a data source via the Grafana API.

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -17,6 +17,9 @@ export type APIs = {
   Dashboard: {
     delete: (uid: string) => string;
   };
+  Plugins: {
+    settings: (pluginId: string) => string;
+  };
 };
 
 export type Components = {
@@ -178,5 +181,8 @@ export type Pages = {
   };
   Explore: {
     url: string;
+  };
+  Plugin: {
+    url: (pluginId: string) => string;
   };
 };

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -17,7 +17,7 @@ export type APIs = {
   Dashboard: {
     delete: (uid: string) => string;
   };
-  Plugins: {
+  Plugin: {
     settings: (pluginId: string) => string;
   };
 };

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/apis.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/apis.ts
@@ -31,4 +31,9 @@ export const versionedAPIs = {
       [MIN_GRAFANA_VERSION]: (uid: string) => `/api/datasources/uid/${uid}`,
     },
   },
+  Plugin: {
+    settings: {
+      [MIN_GRAFANA_VERSION]: (pluginId: string) => `/api/plugins/${pluginId}/settings`,
+    },
+  },
 };

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
@@ -130,4 +130,9 @@ export const versionedPages = {
       [MIN_GRAFANA_VERSION]: '/explore',
     },
   },
+  Plugin: {
+    url: {
+      [MIN_GRAFANA_VERSION]: (pluginId: string) => `/plugins/${pluginId}`,
+    },
+  },
 };

--- a/packages/plugin-e2e/src/fixtures/commands/createAppConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createAppConfigPage.ts
@@ -5,14 +5,19 @@ import { PlaywrightCombinedArgs } from '../types';
 import { AppConfigPage } from '../../models/pages/AppConfigPage';
 
 type CreateAPPConfigPageFixture = TestFixture<
-  (args: PluginConfigPageArgs) => Promise<AppConfigPage>,
+  (args: PluginConfigPageArgs, options?: { goto?: boolean }) => Promise<AppConfigPage>,
   PluginFixture & PluginOptions & PlaywrightCombinedArgs
 >;
 
-export const createAppConfigPage: CreateAPPConfigPageFixture = async (ctx, use) => {
-  await use(async (args) => {
-    const page = new AppConfigPage(ctx, args);
-    await page.goto();
-    return page;
+export const createAppConfigPage: CreateAPPConfigPageFixture = async (
+  { page, selectors, grafanaVersion, request },
+  use
+) => {
+  await use(async (args, options = { goto: true }) => {
+    const appConfigPage = new AppConfigPage({ page, selectors, grafanaVersion, request }, args);
+    if (options.goto) {
+      await appConfigPage.goto();
+    }
+    return appConfigPage;
   });
 };

--- a/packages/plugin-e2e/src/fixtures/commands/createAppConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createAppConfigPage.ts
@@ -5,7 +5,7 @@ import { PlaywrightCombinedArgs } from '../types';
 import { AppConfigPage } from '../../models/pages/AppConfigPage';
 
 type CreateAPPConfigPageFixture = TestFixture<
-  (args: PluginConfigPageArgs, options?: { goto?: boolean }) => Promise<AppConfigPage>,
+  (args: PluginConfigPageArgs) => Promise<AppConfigPage>,
   PluginFixture & PluginOptions & PlaywrightCombinedArgs
 >;
 
@@ -13,11 +13,9 @@ export const createAppConfigPage: CreateAPPConfigPageFixture = async (
   { page, selectors, grafanaVersion, request },
   use
 ) => {
-  await use(async (args, options = { goto: true }) => {
+  await use(async (args) => {
     const appConfigPage = new AppConfigPage({ page, selectors, grafanaVersion, request }, args);
-    if (options.goto) {
-      await appConfigPage.goto();
-    }
+    await appConfigPage.goto();
     return appConfigPage;
   });
 };

--- a/packages/plugin-e2e/src/fixtures/commands/createAppConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createAppConfigPage.ts
@@ -1,0 +1,18 @@
+import { TestFixture } from '@playwright/test';
+import { PluginFixture, PluginOptions } from '../../api';
+import { PluginConfigPageArgs } from '../../types';
+import { PlaywrightCombinedArgs } from '../types';
+import { AppConfigPage } from '../../models/pages/AppConfigPage';
+
+type CreateAPPConfigPageFixture = TestFixture<
+  (args: PluginConfigPageArgs) => Promise<AppConfigPage>,
+  PluginFixture & PluginOptions & PlaywrightCombinedArgs
+>;
+
+export const createAppConfigPage: CreateAPPConfigPageFixture = async (ctx, use) => {
+  await use(async (args) => {
+    const page = new AppConfigPage(ctx, args);
+    await page.goto();
+    return page;
+  });
+};

--- a/packages/plugin-e2e/src/fixtures/commands/gotoAppConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/gotoAppConfigPage.ts
@@ -1,15 +1,15 @@
 import { TestFixture } from '@playwright/test';
 import { PluginFixture, PluginOptions } from '../../api';
-import { PluginConfigPageArgs } from '../../types';
+import { GotoAppConfigPageArgs } from '../../types';
 import { PlaywrightCombinedArgs } from '../types';
 import { AppConfigPage } from '../../models/pages/AppConfigPage';
 
-type CreateAPPConfigPageFixture = TestFixture<
-  (args: PluginConfigPageArgs) => Promise<AppConfigPage>,
+type GotoAppConfigPageFixture = TestFixture<
+  (args: GotoAppConfigPageArgs) => Promise<AppConfigPage>,
   PluginFixture & PluginOptions & PlaywrightCombinedArgs
 >;
 
-export const createAppConfigPage: CreateAPPConfigPageFixture = async (
+export const gotoAppConfigPage: GotoAppConfigPageFixture = async (
   { page, selectors, grafanaVersion, request },
   use
 ) => {

--- a/packages/plugin-e2e/src/fixtures/index.ts
+++ b/packages/plugin-e2e/src/fixtures/index.ts
@@ -13,7 +13,7 @@ import explorePage from './explorePage';
 import isFeatureToggleEnabled from './isFeatureToggleEnabled';
 import page from './page';
 import createUser from './commands/createUser';
-import { createAppConfigPage } from './commands/createAppConfigPage';
+import { gotoAppConfigPage } from './commands/gotoAppConfigPage';
 
 const fixtures = {
   selectors,
@@ -31,7 +31,7 @@ const fixtures = {
   readProvisionedDashboard,
   isFeatureToggleEnabled,
   createUser,
-  createAppConfigPage,
+  gotoAppConfigPage,
 };
 
 export default fixtures;

--- a/packages/plugin-e2e/src/fixtures/index.ts
+++ b/packages/plugin-e2e/src/fixtures/index.ts
@@ -13,6 +13,7 @@ import explorePage from './explorePage';
 import isFeatureToggleEnabled from './isFeatureToggleEnabled';
 import page from './page';
 import createUser from './commands/createUser';
+import { createAppConfigPage } from './commands/createAppConfigPage';
 
 const fixtures = {
   selectors,
@@ -30,6 +31,7 @@ const fixtures = {
   readProvisionedDashboard,
   isFeatureToggleEnabled,
   createUser,
+  createAppConfigPage,
 };
 
 export default fixtures;

--- a/packages/plugin-e2e/src/models/index.ts
+++ b/packages/plugin-e2e/src/models/index.ts
@@ -10,3 +10,5 @@ export { VariablePage } from './pages/VariablePage';
 export { DataSourcePicker } from './components/DataSourcePicker';
 export { Panel } from './components/Panel';
 export { TimeRange } from './components/TimeRange';
+export { AppConfigPage } from './pages/AppConfigPage';
+export { PluginConfigPage } from './pages/PluginConfigPage';

--- a/packages/plugin-e2e/src/models/pages/AppConfigPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AppConfigPage.ts
@@ -1,0 +1,17 @@
+import { Response as PlaywrightResponse } from '@playwright/test';
+import { PluginConfigPageArgs, PluginTestCtx } from '../../types';
+import { PluginConfigPage } from './PluginConfigPage';
+
+export class AppConfigPage extends PluginConfigPage {
+  constructor(readonly ctx: PluginTestCtx, readonly args: PluginConfigPageArgs) {
+    super(ctx, args);
+  }
+
+  /**
+   * Will wait for the settings endpoint to be called e.g. when saving settings
+   */
+  waitForSettingsResponse(options?: { timeout?: number }): Promise<PlaywrightResponse> {
+    const url = this.ctx.selectors.apis.Plugins.settings(this.args.pluginId);
+    return this.ctx.page.waitForResponse(url, options);
+  }
+}

--- a/packages/plugin-e2e/src/models/pages/AppConfigPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AppConfigPage.ts
@@ -11,7 +11,7 @@ export class AppConfigPage extends PluginConfigPage {
    * Will wait for the settings endpoint to be called e.g. when saving settings
    */
   waitForSettingsResponse(options?: { timeout?: number }): Promise<PlaywrightResponse> {
-    const url = this.ctx.selectors.apis.Plugins.settings(this.args.pluginId);
+    const url = this.ctx.selectors.apis.Plugin.settings(this.args.pluginId);
     return this.ctx.page.waitForResponse(url, options);
   }
 }

--- a/packages/plugin-e2e/src/models/pages/PluginConfigPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PluginConfigPage.ts
@@ -1,0 +1,17 @@
+import { Response as PlaywrightResponse } from '@playwright/test';
+import { PluginConfigPageArgs, NavigateOptions, PluginTestCtx } from '../../types';
+import { GrafanaPage } from './GrafanaPage';
+
+export class PluginConfigPage extends GrafanaPage {
+  constructor(readonly ctx: PluginTestCtx, readonly args: PluginConfigPageArgs) {
+    super(ctx);
+  }
+
+  /**
+   * Navigates to the app plugin config page.
+   */
+  goto(options?: NavigateOptions): Promise<void> {
+    const url = this.ctx.selectors.pages.Plugin.url(this.args.pluginId);
+    return super.navigate(url, options);
+  }
+}

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -304,6 +304,6 @@ export interface ContainTextOptions {
   useInnerText?: boolean;
 }
 
-export type AppConfigPageArgs = {
+export type PluginConfigPageArgs = {
   pluginId: string;
 };

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -303,3 +303,7 @@ export interface ContainTextOptions {
    */
   useInnerText?: boolean;
 }
+
+export type AppConfigPageArgs = {
+  pluginId: string;
+};

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -307,3 +307,5 @@ export interface ContainTextOptions {
 export type PluginConfigPageArgs = {
   pluginId: string;
 };
+
+export type GotoAppConfigPageArgs = PluginConfigPageArgs;

--- a/packages/plugin-e2e/tests/as-admin-user/app/app-config/appConfig.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/app/app-config/appConfig.spec.ts
@@ -1,25 +1,14 @@
-import { Page } from '@playwright/test';
 import { expect, test } from '../../../../src';
 
-test('should navigate, by default, to app config page for provided plugin id when created', async ({
+test('should navigate to app config page for provided plugin id when created', async ({
   createAppConfigPage,
   page,
 }) => {
   await createAppConfigPage({ pluginId: 'redis-app' });
-  expect(pathFromUrl(page)).toBe('/plugins/redis-app');
+  await expect(page).toHaveURL(/.*\/plugins\/redis-app$/);
 });
 
-test('should not navigate to app config page for provided plugin id when created', async ({
-  createAppConfigPage,
-  page,
-}) => {
-  const configPage = await createAppConfigPage({ pluginId: 'redis-app' }, { goto: false });
-  expect(pathFromUrl(page)).toBe('/');
-  await configPage.goto();
-  expect(pathFromUrl(page)).toBe('/plugins/redis-app');
-});
-
-test.only('should wait for plugin config settings API to respond', async ({ createAppConfigPage, page }) => {
+test('should wait for plugin config settings API to respond', async ({ createAppConfigPage, page }) => {
   const configPage = await createAppConfigPage({ pluginId: 'redis-app' });
   await page.route(
     '/api/plugins/redis-app/settings',
@@ -33,8 +22,3 @@ test.only('should wait for plugin config settings API to respond', async ({ crea
   page.getByRole('button', { name: 'Disable' }).first().click();
   await expect(response).toBeOK();
 });
-
-function pathFromUrl(page: Page): string {
-  const url = new URL(page.url());
-  return url.pathname;
-}

--- a/packages/plugin-e2e/tests/as-admin-user/app/app-config/appConfig.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/app/app-config/appConfig.spec.ts
@@ -1,0 +1,40 @@
+import { Page } from '@playwright/test';
+import { expect, test } from '../../../../src';
+
+test('should navigate, by default, to app config page for provided plugin id when created', async ({
+  createAppConfigPage,
+  page,
+}) => {
+  await createAppConfigPage({ pluginId: 'redis-app' });
+  expect(pathFromUrl(page)).toBe('/plugins/redis-app');
+});
+
+test('should not navigate to app config page for provided plugin id when created', async ({
+  createAppConfigPage,
+  page,
+}) => {
+  const configPage = await createAppConfigPage({ pluginId: 'redis-app' }, { goto: false });
+  expect(pathFromUrl(page)).toBe('/');
+  await configPage.goto();
+  expect(pathFromUrl(page)).toBe('/plugins/redis-app');
+});
+
+test.only('should wait for plugin config settings API to respond', async ({ createAppConfigPage, page }) => {
+  const configPage = await createAppConfigPage({ pluginId: 'redis-app' });
+  await page.route(
+    '/api/plugins/redis-app/settings',
+    async (route) => {
+      await route.fulfill({ status: 200 });
+    },
+    { times: 1 }
+  );
+
+  const response = configPage.waitForSettingsResponse();
+  page.getByRole('button', { name: 'Disable' }).first().click();
+  await expect(response).toBeOK();
+});
+
+function pathFromUrl(page: Page): string {
+  const url = new URL(page.url());
+  return url.pathname;
+}

--- a/packages/plugin-e2e/tests/as-admin-user/app/app-config/appConfig.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/app/app-config/appConfig.spec.ts
@@ -1,15 +1,12 @@
 import { expect, test } from '../../../../src';
 
-test('should navigate to app config page for provided plugin id when created', async ({
-  createAppConfigPage,
-  page,
-}) => {
-  await createAppConfigPage({ pluginId: 'redis-app' });
+test('should navigate to app config page for provided plugin id when created', async ({ gotoAppConfigPage, page }) => {
+  await gotoAppConfigPage({ pluginId: 'redis-app' });
   await expect(page).toHaveURL(/.*\/plugins\/redis-app$/);
 });
 
-test('should wait for plugin config settings API to respond', async ({ createAppConfigPage, page }) => {
-  const configPage = await createAppConfigPage({ pluginId: 'redis-app' });
+test('should wait for plugin config settings API to respond', async ({ gotoAppConfigPage, page }) => {
+  const configPage = await gotoAppConfigPage({ pluginId: 'redis-app' });
   await page.route(
     '/api/plugins/redis-app/settings',
     async (route) => {


### PR DESCRIPTION
### Description
Adding fixture to make it easier to test app configs pages. This is a thin abstraction and I need to verify this against older versions of Grafana prior to merging it.

### Todo:
- [x] Adding missing test fixture
- [x] Figure out if we can get the plugin id in another way than to pass it in the test.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.20.0-canary.795.f5d5401.0
  # or 
  yarn add @grafana/plugin-e2e@0.20.0-canary.795.f5d5401.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
