### PR TITLE
Docs: Clarify exception for signing plugin

### DIFF
--- a/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
+++ b/docusaurus/docs/publish-a-plugin/publish-or-update-a-plugin.md
@@ -114,6 +114,10 @@ For more information on plugin deprecation and how to request your plugin to be 
 
 - The @grafana/toolkit tool is deprecated. Please [migrate to `create-plugin`](../migration-guides/migrate-from-toolkit.mdx). In the future, we will reject submissions based on @grafana/toolkit as it becomes increasingly out-of-date.
 
+### Do all plugins require signatures?
+
+- All plugins require signatures unless they are in development or being submitted to review for the first time.
+
 ### Do plugin signatures expire?
 
 - Plugin signatures do not currently expire.

--- a/docusaurus/docs/publish-a-plugin/sign-a-plugin.md
+++ b/docusaurus/docs/publish-a-plugin/sign-a-plugin.md
@@ -17,7 +17,7 @@ All Grafana Labs-authored backend plugins, including Enterprise plugins, are sig
 
 :::info
 
-It's not necessary to sign a plugin during development. The [Docker development environment](../get-started/set-up-development-environment.mdx) that is scaffolded with `@grafana/create-plugin` will load the plugin without a signature. This is because it is configured by default to run in [development mode](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#configure-grafana-for-development).
+It's not necessary to sign a plugin during development or when submitting a plugin for review for the first time. The [Docker development environment](../get-started/set-up-development-environment.mdx) that is scaffolded with `@grafana/create-plugin` will load the plugin without a signature. This is because it is configured by default to run in [development mode](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#configure-grafana-for-development).
 
 :::
 


### PR DESCRIPTION
Clarifies that first-time plugin submissions don't require sigs. 

Fixes https://github.com/grafana/plugin-tools/issues/802.
