### PR TITLE
Docs: 2nd editorial pass on several E2E testing topics

### DIFF
--- a/docusaurus/docs/e2e-test-a-plugin/ci.md
+++ b/docusaurus/docs/e2e-test-a-plugin/ci.md
@@ -70,7 +70,7 @@ The `plugin-grafana-dependency` mode is the default, so if you don't specify a v
 
 This mode returns the most recent grafana-dev image. Additionally, it returns all the latest patch releases of Grafana Enterprise since the version that was specified as `grafanaDependency` in the [plugin.json](../metadata.md). To avoid starting too many jobs, the output is capped at 6 versions.
 
-![Plugin dependencies](/img/e2e-version-plugin-dependency.png)
+![[plugin-grafana-dependency mode](/img/e2e-version-plugin-dependency.png)
 
 ### Use the version-support-policy mode
 
@@ -90,6 +90,6 @@ To use the `version-support-policy` mode, you need to specify the `version-resol
 
 ## Playwright report
 
-The end-to-end tooling generates a Playwright HTML test report for every Grafana version that is being tested. In case any of the tests fail, a Playwright trace viewer is also generated along with the report. The `Upload artifacts` step in the example workflows uploads the report as an artifact.
+The end-to-end tooling generates a Playwright HTML test report for every Grafana version that is being tested. In case any of the tests fail, a Playwright trace viewer is also generated along with the report. The `Upload artifacts` step in the example workflows uploads the report to GitHub as an artifact.
 
 To find information on how to download and view the report, refer to the [Playwright documentation](https://playwright.dev/docs/ci-intro#html-report).

--- a/docusaurus/docs/e2e-test-a-plugin/ci.md
+++ b/docusaurus/docs/e2e-test-a-plugin/ci.md
@@ -1,6 +1,6 @@
 ---
 id: ci
-title: CI Workflow
+title: CI workflow
 description: How to run end-to-end tests in CI.
 keywords:
   - grafana
@@ -19,11 +19,14 @@ import FEPluginNPM from '@snippets/plugin-e2e-fe-plugin-workflow.npm.md';
 import FEPluginYarn from '@snippets/plugin-e2e-fe-plugin-workflow.yarn.md';
 import FEPluginPNPM from '@snippets/plugin-e2e-fe-plugin-workflow.pnpm.md';
 
-## Introduction
+# CI workflow
 
-Using a CI workflow to run end-to-end tests allows you to continuously checking for breakages. We recommend using the following Github workflows for every PR in your Github repository to run end-to-end tests against a range of Grafana versions.
+You can use a CI workflow to run end-to-end tests that allow you to continuously check for breakages. We recommend using the following GitHub workflows for every PR in your GitHub repository to run end-to-end tests against a range of Grafana versions.
 
-:::note These are generic examples based on frontend and backend plugins. You may need to alter or remove some of the steps in the `playwright-tests` job before using it in your plugin.
+:::note
+
+These are generic examples based on frontend and backend plugins. You may need to alter or remove some of the steps in the `playwright-tests` job before using it in your plugin.
+
 :::
 
 <details>
@@ -52,25 +55,28 @@ queryString="current-package-manager"
 />
 </details>
 
-### The e2e-versions Action
+## The e2e-versions Action
 
-These example workflows have a job called `Resolve Grafana images` that uses the [e2e-version](https://github.com/grafana/plugin-actions/tree/main/e2e-version) Action to resolve a list of Grafana images. For every image returned, a new job will be fired up that builds the plugin, starts Grafana, and runs the end-to-end tests.
+These example workflows have a job called `Resolve Grafana images` that uses the [e2e-version](https://github.com/grafana/plugin-actions/tree/main/e2e-version) Action to resolve a list of Grafana images. For every image returned, a new job is started that builds the plugin, starts Grafana, and runs the end-to-end tests.
 
-The Action supports two modes - `plugin-grafana-dependency` and `version-support-policy`.
+The Action supports two modes:
 
-#### Use the plugin-grafana-dependency mode
+- `plugin-grafana-dependency`
+- `version-support-policy`.
 
-`plugin-grafana-dependency` is the default mode, so if you don't specify a value for the `version-resolver-type` input paramater, this is the resolver that will be used.
+### Use the plugin-grafana-dependency mode
+
+The `plugin-grafana-dependency` mode is the default, so if you don't specify a value for the `version-resolver-type` input parameter, this is the resolver that will be used.
 
 This mode returns the most recent grafana-dev image. Additionally, it returns all the latest patch releases of Grafana Enterprise since the version that was specified as `grafanaDependency` in the [plugin.json](../metadata.md). To avoid starting too many jobs, the output is capped at 6 versions.
 
-![](/img/e2e-version-plugin-dependency.png)
+![Plugin dependencies](/img/e2e-version-plugin-dependency.png)
 
-#### Use the version-support-policy mode
+### Use the version-support-policy mode
 
 Except for resolving the most recent `grafana-dev` image, the `version-support-policy` mode resolves versions according to Grafana's plugin compatibility support policy. Specifically, it retrieves the latest patch release for each minor version within the current major version of Grafana. Additionally, it includes the most recent release for the latest minor version of the previous major Grafana version.
 
-![](/img/e2e-version-version-support-policy.png)
+![Grafana version support policy](/img/e2e-version-version-support-policy.png)
 
 To use the `version-support-policy` mode, you need to specify the `version-resolver-type` input argument like in this example:
 
@@ -82,6 +88,8 @@ To use the `version-support-policy` mode, you need to specify the `version-resol
           version-resolver-type: version-support-policy
 ```
 
-### Playwright report
+## Playwright report
 
-A Playwright HTML test report is generated for every Grafana version that is being tested. In case any of the tests fail, a Playwright trace viewer is also generated along with the report. The `Upload artifacts` step in the example workflows uploads the report as an artifact. To find information on how to download and view the report, refer to the [Playwright documentatation](https://playwright.dev/docs/ci-intro#html-report).
+The end-to-end tooling generates a Playwright HTML test report for every Grafana version that is being tested. In case any of the tests fail, a Playwright trace viewer is also generated along with the report. The `Upload artifacts` step in the example workflows uploads the report as an artifact.
+
+To find information on how to download and view the report, refer to the [Playwright documentation](https://playwright.dev/docs/ci-intro#html-report).

--- a/docusaurus/docs/e2e-test-a-plugin/get-started.md
+++ b/docusaurus/docs/e2e-test-a-plugin/get-started.md
@@ -29,28 +29,24 @@ import ScaffoldPluginE2EDSWorkflowNPM from '@snippets/plugin-e2e-ds-workflow.npm
 import ScaffoldPluginE2EDSWorkflowYarn from '@snippets/plugin-e2e-ds-workflow.yarn.md';
 import ScaffoldPluginE2EDSWorkflowPNPM from '@snippets/plugin-e2e-ds-workflow.pnpm.md';
 
-This guide walks you through how to get started with end-to-end testing in your plugin.
+This guide walks you through how to get started with end-to-end testing in your plugin with the `@grafana/plugin-e2e` tool. You will learn:
 
-**Topics include:**
-
-- how to install `@grafana/plugin-e2e`
-- how to configure authentication
-- how to write tests
-- how to setup a basic Github workflow that runs tests against multiple versions of Grafana
+- How to install `@grafana/plugin-e2e`
+- How to configure authentication
+- How to write tests
+- How to setup a basic Github workflow that runs tests against multiple versions of Grafana
 
 :::warning
-`@grafana/plugin-e2e` is still in beta and subject to breaking changes.
+The `@grafana/plugin-e2e` tool is still in beta and subject to breaking changes.
 :::
 
-## Prerequisites
+## Before you begin
 
-- You need to have a Grafana plugin [development environment](https://grafana.com/developers/plugin-tools/get-started/set-up-development-environment)
-- Node.js 18+
-- Basic Knowledge of Playwright. If you have not worked with Playwright before, we recommend following the [Getting started](https://playwright.dev/docs/intro) section in their documentation
+You need to have the following:
 
-### Installing Playwright
-
-`@grafana/plugin-e2e` extends Playwright APIs, so you need to have `@playwright/test` with a minimum version of 1.41.2 installed as a dev dependency in the package.json file of your plugin. Please refer to the [Playwright documentation](https://playwright.dev/docs/intro#installing-playwright) for instruction on how to install. Make sure you can run the example tests that were generated when you installed Playwright before you proceed to the next step in this guide.
+- Grafana [plugin development environment](https://grafana.com/developers/plugin-tools/get-started/set-up-development-environment).
+- Node.js version 18 or later.
+- Basic knowledge of Playwright. If you have not worked with Playwright before, we recommend following the [Getting started](https://playwright.dev/docs/intro) section in their documentation.
 
 ## Set up @grafana/plugin-e2e
 
@@ -66,9 +62,13 @@ groupId="package-manager"
 queryString="current-package-manager"
 />
 
+### Step 0: Installing Playwright
+
+The `@grafana/plugin-e2e` tool extends Playwright APIs, so you need to have `@playwright/test` with a minimum version of 1.41.2 installed as a dev dependency in the `package.json` file of your plugin. Refer to the [Playwright documentation](https://playwright.dev/docs/intro#installing-playwright) for instruction on how to install. Make sure you can run the example tests that were generated when you installed Playwright before you proceed to the next step in this guide.
+
 ### Step 1: Installing `@grafana/plugin-e2e`
 
-Now open the terminal and run the following command in your plugin's project directory:
+Open the terminal and run the following command in your plugin's project directory:
 
 <CodeSnippets
 snippets={[
@@ -92,8 +92,8 @@ Open the Playwright config file that was generated when Playwright was installed
 
 2. Playwright uses [projects](https://playwright.dev/docs/test-projects) to logically group tests that have the same configuration. We're going to add two projects:
 
-   1. `auth` is a setup project will login to Grafana and store the authenticated state on disk.
-   2. `run-tests` runs all the tests in a browser of choice. By adding a dependency to the `auth` project we ensure login only happens once, and all tests in the `run-tests` project will start already authenticated.
+   1. `auth` is a setup project that will log in to Grafana and store the authenticated state on disk.
+   2. `run-tests` runs all the tests in your browser of choice. By adding a dependency to the `auth` project we ensure that login only happens once, and all tests in the `run-tests` project will start as already authenticated.
 
    Your Playwright config should have the following project configuration:
 
@@ -123,7 +123,9 @@ export default defineConfig({
 });
 ```
 
-The authenticated state is stored on disk and the file name pattern is as follows: `<plugin-root>/playwright/.auth/<username>.json`. To prevent these files from being version controlled, you can add the following line to your `.gitignore` file:
+The authenticated state is stored on disk with the following file name pattern: `<plugin-root>/playwright/.auth/<username>.json`.
+
+To prevent these files from being version controlled, you can add the following line to your `.gitignore` file:
 
 ```shell title=".gitignore"
 /playwright/.auth/
@@ -131,7 +133,7 @@ The authenticated state is stored on disk and the file name pattern is as follow
 
 ### Step 3: Start Grafana
 
-Next, start up the latest version of Grafana on your local machine.
+Start up the latest version of Grafana on your local machine like this:
 
 <CodeSnippets
 snippets={[
@@ -143,7 +145,7 @@ groupId="package-manager"
 queryString="current-package-manager"
 />
 
-If you want to start a specific version of Grafana, you can do that by specifying the `GRAFANA_VERSION` environment variable.
+If you want to start a specific version of Grafana, you can do that by specifying the `GRAFANA_VERSION` environment variable. For example:
 
 ```bash
 GRAFANA_VERSION=10.1.6 npm run server
@@ -151,7 +153,7 @@ GRAFANA_VERSION=10.1.6 npm run server
 
 ### Step 4: Write tests
 
-While installing Playwright in your project, a few example test files were generatated. We won't need those, so you can go ahead and delete these files.
+While installing Playwright in your project, a few example test files were generated. We won't need those, so you can go ahead and delete these files.
 
 You are now ready to write your tests. In this example, we're using the panel edit page to test the query editor for a backend data source plugin. The plugin was scaffolded with the [create-plugin](../get-started/get-started.mdx) tool, and for this data source the query endpoint returns hard coded data points. This test asserts that the values `1` and `3` are being displayed in the `Table` panel.
 
@@ -186,6 +188,7 @@ queryString="current-package-manager"
 We recommend using a CI workflow to run end-to-end tests to continuously check for breakages. The following Github workflow runs end-to-end tests against a range of Grafana versions for every PR in your Github repository.
 
 :::note
+
 This is a generic example based on a backend plugin. You may need to alter or remove some of the steps in the `playwright-tests` job before using it in your plugin.
 
 :::
@@ -200,4 +203,4 @@ groupId="package-manager"
 queryString="current-package-manager"
 />
 
-![](/img/e2e-version-plugin-dependency.png)
+![e2e testing of multiple Grafana versions](/img/e2e-version-plugin-dependency.png)

--- a/docusaurus/docs/e2e-test-a-plugin/get-started.md
+++ b/docusaurus/docs/e2e-test-a-plugin/get-started.md
@@ -62,11 +62,11 @@ groupId="package-manager"
 queryString="current-package-manager"
 />
 
-### Step 0: Installing Playwright
+### Step 1: Installing Playwright
 
 The `@grafana/plugin-e2e` tool extends Playwright APIs, so you need to have `@playwright/test` with a minimum version of 1.41.2 installed as a dev dependency in the `package.json` file of your plugin. Refer to the [Playwright documentation](https://playwright.dev/docs/intro#installing-playwright) for instruction on how to install. Make sure you can run the example tests that were generated when you installed Playwright before you proceed to the next step in this guide.
 
-### Step 1: Installing `@grafana/plugin-e2e`
+### Step 2: Installing `@grafana/plugin-e2e`
 
 Open the terminal and run the following command in your plugin's project directory:
 
@@ -80,7 +80,7 @@ groupId="package-manager"
 queryString="current-package-manager"
 />
 
-### Step 2: Configure Playwright
+### Step 3: Configure Playwright
 
 Open the Playwright config file that was generated when Playwright was installed.
 
@@ -131,7 +131,7 @@ To prevent these files from being version controlled, you can add the following 
 /playwright/.auth/
 ```
 
-### Step 3: Start Grafana
+### Step 4: Start Grafana
 
 Start up the latest version of Grafana on your local machine like this:
 
@@ -151,7 +151,7 @@ If you want to start a specific version of Grafana, you can do that by specifyin
 GRAFANA_VERSION=10.1.6 npm run server
 ```
 
-### Step 4: Write tests
+### Step 5: Write tests
 
 While installing Playwright in your project, a few example test files were generated. We won't need those, so you can go ahead and delete these files.
 
@@ -169,7 +169,7 @@ test('data query should return values 1 and 3', async ({ panelEditPage, readProv
 });
 ```
 
-### Step 5: Run tests
+### Step 6: Run tests
 
 Open a new terminal and run the test script from within your local plugin development directory.
 
@@ -183,7 +183,7 @@ groupId="package-manager"
 queryString="current-package-manager"
 />
 
-### Step 6: Run tests in CI
+### Step 7: Run tests in CI
 
 We recommend using a CI workflow to run end-to-end tests to continuously check for breakages. The following Github workflow runs end-to-end tests against a range of Grafana versions for every PR in your Github repository.
 

--- a/docusaurus/docs/e2e-test-a-plugin/introduction.md
+++ b/docusaurus/docs/e2e-test-a-plugin/introduction.md
@@ -12,23 +12,23 @@ keywords:
 sidebar_position: 1
 ---
 
-# Introduction
+# Introduction to plugin E2E testing
 
-[`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) is designed specifically for Grafana plugin developers. It extends [`Playwright test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers; enabling comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. This package simplifies the testing process, ensuring your plugin is robust and compatible with various Grafana environments.
+The [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) tool enables comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. It extends [`Playwright test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers. This package simplifies the testing process, ensuring your plugin is robust and compatible with various Grafana environments.
 
 :::warning
-`@grafana/plugin-e2e` is still in beta and subject to breaking changes.
+The `@grafana/plugin-e2e` tool is still in beta and subject to breaking changes.
 :::
 
 ## The problem
 
-Plugin authors typically want their plugins to be compatible with a range of Grafana versions. This can be challenging as things such as environment, APIs and UI components may differ from one Grafana version to another. Manually testing a plugin across multiple versions of Grafana is a tedious process, so in most cases end-to-end testing offers a better solution.
+Plugin authors typically want their plugins to be compatible with a range of Grafana versions. This can be challenging because things such as environment, APIs and UI components may differ from one Grafana version to another. Therefore, manually testing a plugin across multiple versions of Grafana is a tedious process, so in most cases end-to-end testing offers a better solution.
 
 ## The solution
 
-`@grafana/plugin-e2e` offers a consistent way to interact with the Grafana UI without having to handle UI deviations in the plugin test code. The API's of `@grafana/plugin-e2e` are guaranteed to work with all the latest minor versions of Grafana since 8.5.0. In addition to cross version compatibility, it provides a set of features that simplifies the end-to-end testing experience:
+The `@grafana/plugin-e2e` tool offers a consistent way to interact with the Grafana UI without having to handle UI deviations in the plugin test code. The APIs of `@grafana/plugin-e2e` are guaranteed to work with all the latest minor versions of Grafana since 8.5.0. In addition to cross-version compatibility, the tool provides a set of features that simplify the end-to-end testing experience:
 
-- **Predefined Fixtures:** Offers a set of predefined fixtures that are tailored for Grafana plugin testing.
-- **Custom Models:** Provides custom models that represent pages and components in Grafana, simplifying maintenance and creating reusable code to avoid repetition.
-- **Expect Matchers:** Includes a range of expect matchers that are specialized for Grafana plugin assertions, helping you validate plugin behavior more effectively.
+- **Predefined fixtures:** Offers a set of predefined fixtures that are tailored for Grafana plugin testing.
+- **Custom models:** Provides custom models that represent pages and components in Grafana, simplifying maintenance and creating reusable code to avoid repetition.
+- **Expect matchers:** Includes a range of expect matchers that are specialized for Grafana plugin assertions, helping you validate plugin behavior more effectively.
 - **Integration with Playwright:** Seamlessly integrates with the Playwright testing framework, leveraging its powerful browser automation capabilities.

--- a/docusaurus/docs/e2e-test-a-plugin/introduction.md
+++ b/docusaurus/docs/e2e-test-a-plugin/introduction.md
@@ -14,7 +14,7 @@ sidebar_position: 1
 
 # Introduction to plugin E2E testing
 
-The [`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) tool enables comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. It extends [`Playwright test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers. This package simplifies the testing process, ensuring your plugin is robust and compatible with various Grafana environments.
+[`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) is a testing tool designed specifically for Grafana plugin developers. It extends [`Playwright test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers; enabling comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. This package simplifies the testing process, ensuring your plugin is robust and compatible with various Grafana environments.
 
 :::warning
 The `@grafana/plugin-e2e` tool is still in beta and subject to breaking changes.

--- a/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
+++ b/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
@@ -14,7 +14,7 @@ sidebar_position: 20
 
 # Select UI elements
 
-This guide explains the role of selectors in Grafana end-to-end testing and how to use them with multiple versions of Grafana.
+This guide explains the role of selectors in Grafana end-to-end testing and how to use them to safely interact with UI elements across multiple versions of Grafana.
 
 ## Grafana end-to-end selectors
 
@@ -24,7 +24,7 @@ Selecting Grafana UI elements can be challenging because the selector may be def
 
 ## Playwright locator for Grafana UI elements
 
-All [pages](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e/src/models/pages) defined by `@grafana/plugin-e2e` expose a `getByTestIdOrAriaLabel` method that returns a Playwright [locator](https://playwright.dev/docs/locators) that resolves to one or more elements selected. The pages do so by using the appropriate HTML attribute as defined on the element. Whenever you want to resolve a Playwright locator based on a Grafana UI selector, you should always use this method.
+All [pages](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e/src/models/pages) defined by `@grafana/plugin-e2e` expose a `getByTestIdOrAriaLabel` method. This method returns a Playwright [locator](https://playwright.dev/docs/locators) that resolves to one or more elements, using the appropriate HTML attribute as defined on the element. Whenever you want to resolve a Playwright locator based on a [grafana/e2e-selectors](https://github.com/grafana/grafana/tree/main/packages/grafana-e2e-selectors), you should always use this method.
 
 ```ts
 panelEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).click();
@@ -32,7 +32,9 @@ panelEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).
 
 ## The selectors fixture
 
-Selectors defined in the `@grafana/e2e-selectors` package, provided through the `selectors` fixture, are tied to a specific Grafana version. As a result, the selectors can change from one version to another. When you start a new end-to-end test session, `@grafana/plugin-e2e` checks what version of Grafana is under test and resolves the selectors that are associated with the running version.
+Selectors defined in the `@grafana/e2e-selectors` package are tied to a specific Grafana version. This means that the selectors can change from one version to another, making it hard to use the selectors defined in `@grafana/e2e-selectors` when writing tests that target multiple versions of Grafana.
+
+To overcome this issue, `@grafana/plugin-e2e` has its own copy of end-to-end selectors. These selectors are a subset of the selectors defined in `@grafana/e2e-selectors`, and each selector value has defined a minimum Grafana version. When you start a new end-to-end test session, `@grafana/plugin-e2e` checks what version of Grafana is under test and resolves the selectors that are associated with the running version. The selectors are provided through the `selectors` fixture.
 
 ```ts
 import { test, expect } from '@grafana/plugin-e2e';

--- a/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
+++ b/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
@@ -1,7 +1,7 @@
 ---
 id: selecting-elements
-title: Selecting UI elements
-description: How to select UI elements on the page
+title: Select UI elements
+description: How to select UI elements on the page in end-to-end testing.
 keywords:
   - grafana
   - plugins
@@ -12,6 +12,10 @@ keywords:
 sidebar_position: 20
 ---
 
+# Select UI elements
+
+This guide explains the role of selectors in Grafana end-to-end testing and how to use them with multiple versions of Grafana.
+
 ## Grafana end-to-end selectors
 
 Since Grafana 7.0.0, end-to-end tests in Grafana have relied on selectors defined in the [`@grafana/e2e-selectors`](https://github.com/grafana/grafana/tree/main/packages/grafana-e2e-selectors) package to select elements in the Grafana UI.
@@ -20,7 +24,7 @@ Selecting Grafana UI elements can be challenging because the selector may be def
 
 ## Playwright locator for Grafana UI elements
 
-All [pages](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e/src/models/pages) defined by `@grafana/plugin-e2e` expose a `getByTestIdOrAriaLabel` method that returns a Playwright [locator](https://playwright.dev/docs/locators) that resolves to element(s) selected, using the appropriate HTML attribute as defined on the element. Whenever you want to resolve a Playwright locator based on a Grafana UI selector, you should always use this method.
+All [pages](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e/src/models/pages) defined by `@grafana/plugin-e2e` expose a `getByTestIdOrAriaLabel` method that returns a Playwright [locator](https://playwright.dev/docs/locators) that resolves to one or more elements selected. The pages do so by using the appropriate HTML attribute as defined on the element. Whenever you want to resolve a Playwright locator based on a Grafana UI selector, you should always use this method.
 
 ```ts
 panelEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).click();
@@ -28,7 +32,7 @@ panelEditPage.getByTestIdOrAriaLabel(selectors.components.CodeEditor.container).
 
 ## The selectors fixture
 
-Selectors defined in the `@grafana/e2e-selectors` package are tied to a specific Grafana version. This means that the selectors can change from one version to another. When a new end-to-end test session is started, `@grafana/plugin-e2e` checks what version of Grafana is under test and resolves selectors that are associated with the running version. The selectors are provided through the `selectors` fixture.
+Selectors defined in the `@grafana/e2e-selectors` package, provided through the `selectors` fixture, are tied to a specific Grafana version. As a result, the selectors can change from one version to another. When you start a new end-to-end test session, `@grafana/plugin-e2e` checks what version of Grafana is under test and resolves the selectors that are associated with the running version.
 
 ```ts
 import { test, expect } from '@grafana/plugin-e2e';


### PR DESCRIPTION
Fix minor style and other errors in the E2E test topics. Will be followed by additional PR(s) until the entire E2E docs have been covered.