### PR TITLE
Create Plugin: add support for remote debugging in docker dev env

### DIFF
--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -19,7 +19,7 @@ The [`create-plugin` tool](./get-started.mdx#use-plugin-tools-to-develop-your-pl
 
 :::info
 
-It's not necessary to [sign a plugin](/publish-a-plugin/sign-a-plugin.md)  during development. The Docker development environment that is scaffolded with `@grafana/create-plugin` will load the plugin without a signature. This is because it is configured by default to run in [development mode](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#configure-grafana-for-development).
+It's not necessary to [sign a plugin](/publish-a-plugin/sign-a-plugin.md) during development. The Docker development environment that is scaffolded with `@grafana/create-plugin` will load the plugin without a signature. This is because it is configured by default to run in [development mode](https://github.com/grafana/grafana/blob/main/contribute/developer-guide.md#configure-grafana-for-development).
 
 :::
 
@@ -71,6 +71,8 @@ services:
       args:
         grafana_version: ${GRAFANA_VERSION:-9.1.2}
         grafana_image: ${GRAFANA_IMAGE:-grafana}
+        GO_VERSION: ${GO_VERSION:-1.22}
+        GO_ARCH: ${GO_ARCH:-amd64}
 ```
 
 This example assigns the environment variable `GRAFANA_IMAGE` to the build arg `grafana_image` with a default value of `grafana`. This gives you the option to set the value when running `docker-compose` commands.

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -27,7 +27,9 @@ It's not necessary to [sign a plugin](/publish-a-plugin/sign-a-plugin.md)  durin
 
 We have chosen to use Docker because it simplifies the process of creating, deploying, and running applications. It allows you to create consistent and isolated environments for your plugin. This makes it easy to manage dependencies and ensure that the plugin runs the same way across different machines.
 
-With the `create-plugin` tool, the Docker container is configured with the necessary variables to allow easy access to Grafana and to load plugins without the need for them to be signed. The plugin tool also adds a live reload feature that allows you to make your frontend code changes to trigger refreshes in the browser.
+With the `create-plugin` tool, the Docker container is configured with the necessary variables to allow easy access to Grafana and to load plugins without the need for them to be signed. The plugin tool also adds a live reload feature that allows you to make your frontend code changes to trigger refreshes in the browser, and changing the backend code will make the plugin binary to automatically reload.
+
+The docker environment also allows you to attach a debugger to the plugin backend code, making the development process easier.
 
 ## Get started with Docker
 
@@ -72,3 +74,34 @@ services:
 ```
 
 This example assigns the environment variable `GRAFANA_IMAGE` to the build arg `grafana_image` with a default value of `grafana`. This gives you the option to set the value when running `docker-compose` commands.
+
+### Debugging Backend plugin
+
+If you're developing a plugin with a backend part, the docker compose file will also expose the port `2345` for debugging, from a headless delve instance running inside the docker environment.
+You can attach a debugger client to this port to debug your backend code.
+For example, in VSCode, you can add a `launch.json` configuration like this:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to plugin backend in docker",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "showLog": true,
+      "trace": "log",
+      "logOutput": "rpc",
+      "substitutePath": [
+        {
+          "from": "${workspaceFolder}",
+          "to": "/root/<your-plugin-id>"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -26,11 +26,18 @@ USER root
 
 
 # Installing supervisor and inotify-tools
-RUN apt-get update && \
-    apt-get install -y supervisor && \
-    apt-get install -y  inotify-tools && \
-    rm -rf /var/lib/apt/lists/*
+RUN if grep -i -q alpine /etc/issue; then \
+      apk add supervisor inotify-tools git; \
+    elif grep -i -q ubuntu /etc/issue; then \
+      DEBIAN_FRONTEND=noninteractive && \
+      apt-get update && \
+      apt-get install -y supervisor inotify-tools git && \
+      rm -rf /var/lib/apt/lists/*; \
+    else \
+      echo 'ERROR: Unsupported base image' && /bin/false; \
+    fi
 
+COPY supervisord/supervisord.conf /etc/supervisor.d/supervisord.ini
 COPY supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 
@@ -56,4 +63,6 @@ RUN git clone https://github.com/magefile/mage; \
 RUN sed -i 's|</body>|<script src="http://localhost:35729/livereload.js"></script></body>|g' /usr/share/grafana/public/views/index.html
 
 
-ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -1,7 +1,12 @@
-ARG grafana_version=latest
-ARG grafana_image=grafana-enterprise
+ARG ARCH=amd64
+ARG BASE_IMAGE=grafana/grafana-oss-${ARCH}:development-ubuntu
 
-FROM grafana/${grafana_image}:${grafana_version}
+FROM ${BASE_IMAGE} as plugindev
+
+{{#if hasBackend}}
+ARG GO_VERSION=1.21.6
+ARG GO_ARCH=amd64
+{{/if}}
 
 # Make it as simple as possible to access the grafana instance for development purposes
 # Do NOT enable these settings in a public facing / production grafana instance
@@ -11,6 +16,44 @@ ENV GF_AUTH_BASIC_ENABLED "false"
 # Set development mode so plugins can be loaded without the need to sign
 ENV GF_DEFAULT_APP_MODE "development"
 
-# Inject livereload script into grafana index.html
+
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+
+ENV GF_PATHS_HOME="/usr/share/grafana"
+WORKDIR $GF_PATHS_HOME
+
 USER root
+
+
+# Installing supervisor and inotify-tools
+RUN apt-get update && \
+    apt-get install -y supervisor && \
+    apt-get install -y  inotify-tools && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+
+{{#if hasBackend}}
+# Installing Go
+RUN curl -O -L https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+    rm -rf /usr/local/go && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+    echo "export PATH=$PATH:/usr/local/go/bin:~/go/bin" >> ~/.bashrc && \
+    rm -f go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
+
+# Installing delve for debugging
+RUN /usr/local/go/bin/go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Installing mage for plugin (re)building
+RUN git clone https://github.com/magefile/mage; \
+    cd mage; \
+    export PATH=$PATH:/usr/local/go/bin; \
+    go run bootstrap.go
+{{/if}}
+
+# Inject livereload script into grafana index.html
 RUN sed -i 's|</body>|<script src="http://localhost:35729/livereload.js"></script></body>|g' /usr/share/grafana/public/views/index.html
+
+
+ENTRYPOINT ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -1,7 +1,7 @@
-ARG ARCH=amd64
-ARG BASE_IMAGE=grafana/grafana-oss-${ARCH}:development-ubuntu
+ARG grafana_version=latest
+ARG grafana_image=grafana-enterprise
 
-FROM ${BASE_IMAGE} as plugindev
+FROM grafana/${grafana_image}:${grafana_version}
 
 {{#if hasBackend}}
 ARG GO_VERSION=1.21.6

--- a/packages/create-plugin/templates/common/.config/entrypoint.sh
+++ b/packages/create-plugin/templates/common/.config/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if grep -i -q alpine /etc/issue; then
+    exec /usr/bin/supervisord -c /etc/supervisord.conf
+elif grep -i -q ubuntu /etc/issue; then
+    exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf
+else
+    echo 'ERROR: Unsupported base image'
+    exit 1
+fi

--- a/packages/create-plugin/templates/common/.config/supervisord/supervisord.conf
+++ b/packages/create-plugin/templates/common/.config/supervisord/supervisord.conf
@@ -1,0 +1,49 @@
+[supervisord]
+nodaemon=true
+user=root
+
+[program:grafana]
+user=root
+directory=/var/lib/grafana
+command=/run.sh
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+killasgroup=true
+stopasgroup=true
+autostart=true
+
+{{#if hasBackend}}
+[program:delve]
+user=root
+command=/bin/bash -c 'pid=""; while [ -z "$pid" ]; do pid=$(pgrep -f gpx_{{ snakeCase pluginName }}); done; /root/go/bin/dlv attach --api-version=2 --headless --continue --accept-multiclient --listen=:2345 $pid'
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+killasgroup=false
+stopasgroup=false
+autostart=true
+autorestart=true
+
+[program:build-watcher]
+user=root
+command=/bin/bash -c 'while inotifywait -e modify,create,delete -r /var/lib/grafana/plugins/{{ pluginId }}; do echo "Change detected, restarting delve...";supervisorctl restart delve; done'
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+killasgroup=true
+stopasgroup=true
+autostart=true
+
+[program:mage-watcher]
+user=root
+environment=PATH="/usr/local/go/bin:/root/go/bin:%(ENV_PATH)s"
+directory=/root/{{ pluginId }}
+command=/bin/bash -c 'git config --global --add safe.directory /root/{{ pluginId }} && mage -v watch'
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+killasgroup=true
+stopasgroup=true
+autostart=true
+{{/if}}

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -9,7 +9,8 @@ services:
     build:
       context: ./.config
       args:
-        - ARCH=amd64
+        grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}} }
+        grafana_version: ${GRAFANA_VERSION:-{{~grafanaVersion~}} }
     ports:
       - 3000:3000/tcp
 {{#if hasBackend}}

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -2,15 +2,33 @@ version: '3.0'
 
 services:
   grafana:
+    user: root
     container_name: '{{ pluginId }}'
+
     platform: 'linux/amd64'
     build:
       context: ./.config
       args:
-        grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}} }
-        grafana_version: ${GRAFANA_VERSION:-{{~grafanaVersion~}} }
+        - ARCH=amd64
     ports:
       - 3000:3000/tcp
+{{#if hasBackend}}
+      - 2345:2345/tcp # delve
+{{/if}}
+    security_opt:
+      - "apparmor:unconfined"
+      - "seccomp:unconfined"
+    cap_add:
+      - SYS_PTRACE
     volumes:
       - ./dist:/var/lib/grafana/plugins/{{ pluginId }}
       - ./provisioning:/etc/grafana/provisioning
+      - .:/root/{{ pluginId }}
+
+    environment:
+      NODE_ENV: development
+      GF_LOG_FILTERS: plugin.{{ pluginId }}:debug
+      GF_LOG_LEVEL: debug
+      GF_DATAPROXY_LOGGING: 1
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: {{ pluginId }}
+      GF_PLUGINS_DELVE_ENABLED: true

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -15,12 +15,12 @@ services:
       - 3000:3000/tcp
 {{#if hasBackend}}
       - 2345:2345/tcp # delve
-{{/if}}
     security_opt:
       - "apparmor:unconfined"
       - "seccomp:unconfined"
     cap_add:
       - SYS_PTRACE
+{{/if}}
     volumes:
       - ./dist:/var/lib/grafana/plugins/{{ pluginId }}
       - ./provisioning:/etc/grafana/provisioning


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.
-->

**What this PR does / why we need it**:

This PRs changes our development docker environment to allow remote debugging for the backend.
The work was based on the draft PR https://github.com/grafana/plugin-tools/pull/773 and aims to fulfill it's pending items:

- [x] Move backend plugin build inside docker container and supervise a mage build:watch
  - [x] docker-compose would need to map the git repo to a volume in order to build/rebuild with mage
- [x] Modify delve to always kill process on disconnect
- [x] Get the gpx_* binary name from src/plugin.json vs having to set env var
- [x] Maybe detect from src/plugin.json if backend is supported (and do not try to spawn delve), this can still be useful for frontend debug tools
- [x] Another option - write a small watcher service to respawn dlv with the new PID when process is killed (mage build:watch might be sufficient)
- [x] tested on alpine

The `mage watch` target is changed in this PR: https://github.com/grafana/grafana-plugin-sdk-go/pull/926

And the necessary base Docker image will be added by the PR: https://github.com/grafana/grafana/pull/83321

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

This PRs is part of:
https://github.com/grafana/plugin-tools/issues/735

**Special notes for your reviewer**:

This PR covers only backend debugging.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.3.0-canary.809.5b2f9cc.0
  npm install @grafana/plugin-e2e@0.20.0-canary.809.5b2f9cc.0
  # or 
  yarn add @grafana/create-plugin@4.3.0-canary.809.5b2f9cc.0
  yarn add @grafana/plugin-e2e@0.20.0-canary.809.5b2f9cc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
