### PR TITLE
New Doc: Adding a suggestion supplier to a plugin

### DIFF
--- a/docusaurus/docs/migration-guides/angular-react/suggestion-supplier.md
+++ b/docusaurus/docs/migration-guides/angular-react/suggestion-supplier.md
@@ -18,7 +18,7 @@ keywords:
 
 You can add a suggestion supplier to examine query data coming from a panel and suggest usage of the plugin for the type of data detected. This guide provides instructions for doing so along with links to relevant examples.
 
-A single stat panel would be ranked "high" for a single series, and "low" for multiple series (or even none).
+A good example is the `stat` panel, which inspects the query resukts and ranks itself "high" for a single series, and "low" for multiple series (or even none).
 
 ## Add the suggestion supplier
 
@@ -65,6 +65,10 @@ export class MyDataSuggestionsSupplier {
 
 When creating a suggestion supplier be certain the plugin can actually render something for the data being provided.
 
+If the suggestion supplier ranks the plugin high incorrectly, the end result will often display a blank panel and/or an error message.
+
+It's best to offer the plugin only to query data that matches well-known criteria that the plugin can process and visualize.
+
 :::
 
 ## Additional resources
@@ -73,6 +77,12 @@ Reference these suggestion suppliers to get ideas for further customization:
 
 - [Piechart panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/piechart/suggestions.ts#L7)
 
+The piechart panel checks the query for more than 30 rows return and does not offer itself as a visualization, even though it could display the data it will be nearly unreadable.
+
 - [Stat panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/stat/suggestions.ts#L7)
 
+Similar to the piechart panel, this plugin offers itself for data row results less than 10. It also sets default options based on the types of fields inside the query results.
+
 - [Heatmap panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/heatmap/suggestions.ts#L8)
+
+This panel does some processing on the data, and if there are any warnings generated, it omits itself from being offered.

--- a/docusaurus/docs/migration-guides/angular-react/suggestion-supplier.md
+++ b/docusaurus/docs/migration-guides/angular-react/suggestion-supplier.md
@@ -1,6 +1,6 @@
 ---
-id: adding-suggestion-supplier
-title: Adding a suggestion supplier to a plugin
+id: add-suggestion-supplier
+title: Add a suggestion supplier
 sidebar_position: 9
 description: How to add a suggestion supplier to a plugin.
 keywords:
@@ -13,15 +13,16 @@ keywords:
   - migration
   - suggestion
 ---
-# Angular to React: Adding a Suggestion Supplier
 
-The suggestion supplier examines query data coming from a panel and suggests usage of the plugin for the type of data detected.
+# Angular to React: Add a suggestion supplier
 
-A single stat panel would be rank "high" for a single series, and "low" for multiple series (or even none).
+You can add a suggestion supplier to examine query data coming from a panel and suggest usage of the plugin for the type of data detected. This guide provides instructions for doing so along with links to relevant examples.
 
-## Adding the suggestion supplier
+A single stat panel would be ranked "high" for a single series, and "low" for multiple series (or even none).
 
-Part of the `module.ts`
+## Add the suggestion supplier
+
+Here is an example suggestion suppler seen as part of `module.ts`:
 
 ```ts
 import { MyDataSuggestionsSupplier } from './suggestions';
@@ -30,7 +31,7 @@ import { MyDataSuggestionsSupplier } from './suggestions';
 .setSuggestionsSupplier(new MyDataSuggestionsSupplier());
 ```
 
-An example suggestion supplier (derived from polystat):
+Here is an example suggestion supplier derived from polystat:
 
 ```ts
 import { VisualizationSuggestionsBuilder } from '@grafana/data';
@@ -58,17 +59,20 @@ export class MyDataSuggestionsSupplier {
     });
   }
 }
+```
 
-## Special Notes
+:::note
 
 When creating a suggestion supplier be certain the plugin can actually render something for the data being provided.
 
-## Additional Resources
+:::
 
-These panels implemement suggestion suppliers, and can be referenced for further customization.
+## Additional resources
 
-[Piechart Panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/piechart/suggestions.ts#L7)
+Reference these suggestion suppliers to get ideas for further customization:
 
-[Stat Panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/stat/suggestions.ts#L7)
+- [Piechart panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/piechart/suggestions.ts#L7)
 
-[Heatmap Panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/heatmap/suggestions.ts#L8)
+- [Stat panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/stat/suggestions.ts#L7)
+
+- [Heatmap panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/heatmap/suggestions.ts#L8)

--- a/docusaurus/docs/migration-guides/angular-react/suggestion-supplier.md
+++ b/docusaurus/docs/migration-guides/angular-react/suggestion-supplier.md
@@ -1,0 +1,74 @@
+---
+id: adding-suggestion-supplier
+title: Adding a suggestion supplier to a plugin
+sidebar_position: 9
+description: How to add a suggestion supplier to a plugin.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - React
+  - ReactJS
+  - Angular
+  - migration
+  - suggestion
+---
+# Angular to React: Adding a Suggestion Supplier
+
+The suggestion supplier examines query data coming from a panel and suggests usage of the plugin for the type of data detected.
+
+A single stat panel would be rank "high" for a single series, and "low" for multiple series (or even none).
+
+## Adding the suggestion supplier
+
+Part of the `module.ts`
+
+```ts
+import { MyDataSuggestionsSupplier } from './suggestions';
+...
+
+.setSuggestionsSupplier(new MyDataSuggestionsSupplier());
+```
+
+An example suggestion supplier (derived from polystat):
+
+```ts
+import { VisualizationSuggestionsBuilder } from '@grafana/data';
+import { MyOptions } from './types';
+
+export class MyDataSuggestionsSupplier {
+  getSuggestionsForData(builder: VisualizationSuggestionsBuilder) {
+    const { dataSummary: ds } = builder;
+
+    if (!ds.hasData) {
+      return;
+    }
+    if (!ds.hasNumberField) {
+      return;
+    }
+
+    const list = builder.getListAppender<MyOptions, {}>({
+      name: 'MyPanel',
+      pluginId: 'myorg-description-panel',
+      options: {},
+    });
+
+    list.append({
+      name: 'MyPanel',
+    });
+  }
+}
+
+## Special Notes
+
+When creating a suggestion supplier be certain the plugin can actually render something for the data being provided.
+
+## Additional Resources
+
+These panels implemement suggestion suppliers, and can be referenced for further customization.
+
+[Piechart Panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/piechart/suggestions.ts#L7)
+
+[Stat Panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/stat/suggestions.ts#L7)
+
+[Heatmap Panel](https://github.com/grafana/grafana/blob/main/public/app/plugins/panel/heatmap/suggestions.ts#L8)


### PR DESCRIPTION

**What this PR does / why we need it**:

Adds docs for creating a suggestion supplier for a plugin

**Which issue(s) this PR fixes**:

Fixes # https://github.com/grafana/grafana/issues/84419