### PR TITLE
Docs: Add a router or multiplexer

### DIFF
--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/add-router.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/add-router.md
@@ -10,7 +10,7 @@ keywords:
   - multiplexer
 ---
 
-# Add a router or multiplexer to your plugin
+# Add a query router or multiplexer to your data source backend
 
 Normally you implement the `QueryData` method in your backend plugin for data queries. But what if you need to support different kinds of queries: metrics, logs, and traces, for instance? That’s where the usage of a query _router_ (also known as a _multiplexer_) comes handy.
 

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/add-router.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/add-router.md
@@ -20,7 +20,7 @@ With `queryType` populated in queries and sent to your backend plugin below is a
 
 Implemented in this way, each query handler can then `json.Unmarshal` each query JSON field in [`DataQuery`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend#DataQuery) to a certain Go struct as shown in this example:
 
-```
+```go
 package mydatasource
 
 import (

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/add-router.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/add-router.md
@@ -78,7 +78,7 @@ func (d *MyDatasource) handleQueryFallback(ctx context.Context, req *backend.Que
 
 ## Advanced usage
 
-An example of using [`QueryTypeMux`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend/datasource#QueryTypeMux) can be found for Grafana's built-in Grafana Azure Monitor data source. Refer to this code for examples of implementation:
+An example of using [`QueryTypeMux`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend/datasource#QueryTypeMux) can be found for Grafana's built-in TestData data source. Refer to this code for examples of implementation:
 
 - [grafana/azuremonitor.go](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L49) at 164ce63e280565cc960fb0e0d9f074ec003d5a2a - See the code at the [grafana/grafana](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L49) repo.
 - [grafana/azuremonitor.go](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L182-L201) at 164ce63e280565cc960fb0e0d9f074ec003d5a2a - See the code at the [grafana/grafana](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L182-L201) repo.

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/add-router.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/add-router.md
@@ -1,0 +1,85 @@
+---
+id: add-router
+title: Add a router or multiplexer to your plugin
+description: Add a router or multiplexer to your plugin.
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - router
+  - multiplexer
+---
+
+# Add a router or multiplexer to your plugin
+
+Normally you implement the `QueryData` method in your backend plugin for data queries. But what if you need to support different kinds of queries: metrics, logs, and traces, for instance? That’s where the usage of a query _router_ (also known as a _multiplexer_) comes handy.
+
+The plugin development requirement is that you need to populate the `queryType` property of your query model client-side, see the [`DataQuery`](https://github.com/grafana/grafana/blob/a728e9b4ddb6532b9fa2f916df106e792229e3e0/packages/grafana-data/src/types/query.ts#L47) interface.
+
+With `queryType` populated in queries and sent to your backend plugin below is an example of how you would use the [`datasource.QueryTypeMux`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend/datasource#QueryTypeMux) to multiplex or route different query types to separate query handlers.
+
+Implemented in this way, each query handler can then `json.Unmarshal` each query JSON field in [`DataQuery`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend#DataQuery) to a certain Go struct as shown in this example:
+
+```
+package mydatasource
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
+)
+
+type MyDatasource struct {
+	queryHandler backend.QueryDataHandler
+}
+
+func New() *MyDatasource {
+	ds := &MyDatasource{}
+	queryTypeMux := datasource.NewQueryTypeMux()
+	queryTypeMux.HandleFunc("metrics", ds.handleMetricsQuery)
+	queryTypeMux.HandleFunc("logs", ds.handleLogsQuery)
+	queryTypeMux.HandleFunc("traces", ds.handleTracesQuery)
+	queryTypeMux.HandleFunc("", ds.handleQueryFallback)
+	ds.queryHandler := queryTypeMux
+	return ds
+}
+
+func (d *MyDatasource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	return d.queryHandler.QueryData(ctx, req)
+}
+
+// handleMetricsQuery handle queries of query type "metrics".
+// All queries in backend.QueryDataRequest is guaranteed to only
+// include queries with queryType "metrics".
+func (d *MyDatasource) handleMetricsQuery(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	// implementation...
+}
+
+// handleLogsQuery handle queries of query type "logs".
+// All queries in backend.QueryDataRequest is guaranteed to only
+// include queries with queryType "logs".
+func (d *MyDatasource) handleLogsQuery(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	// implementation...
+}
+
+// handleTracesQuery handle queries of query type "logs".
+// All queries in backend.QueryDataRequest is guaranteed to only
+// include queries with queryType "traces".
+func (d *MyDatasource) handleTracesQuery(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	// implementation...
+}
+
+// handleQueryFallback handle queries without a matching query type handler registered.
+func (d *MyDatasource) handleQueryFallback(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	// implementation...
+}
+```
+
+## Advanced usage
+
+An example of using [`QueryTypeMux`](https://pkg.go.dev/github.com/grafana/grafana-plugin-sdk-go/backend/datasource#QueryTypeMux) can be found for Grafana's built-in Grafana Azure Monitor data source. Refer to this code for examples of implementation:
+
+- [grafana/azuremonitor.go](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L49) at 164ce63e280565cc960fb0e0d9f074ec003d5a2a - See the code at the [grafana/grafana](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L49) repo.
+- [grafana/azuremonitor.go](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L182-L201) at 164ce63e280565cc960fb0e0d9f074ec003d5a2a - See the code at the [grafana/grafana](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L182-L201) repo.
+- [grafana/azuremonitor.go](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L55-L57) at 164ce63e280565cc960fb0e0d9f074ec003d5a2a - See the code at the [grafana/grafana](https://github.com/grafana/grafana/blob/164ce63e280565cc960fb0e0d9f074ec003d5a2a/pkg/tsdb/azuremonitor/azuremonitor.go#L55-L57) repo.


### PR DESCRIPTION
How to add a router or multiplexer to your plugin. Draft topic based on a [community forum post](https://community.grafana.com/t/how-to-add-a-query-multiplexer-router-for-your-datasource/59406).

Fixes [#66401 subtask](https://github.com/grafana/grafana/issues/66401)
