### PR TITLE
Add condition about backend to success message

### DIFF
--- a/packages/create-plugin/src/commands/generate/print-success-message.ts
+++ b/packages/create-plugin/src/commands/generate/print-success-message.ts
@@ -15,7 +15,8 @@ export function printGenerateSuccessMessage(answers: CliArgs) {
           '- `mage -v build:linux` to build the plugin backend code. Rerun this command every time you edit your backend files.',
         ]
       : []),
-    '- `docker-compose up` to start a grafana development server. Restart this command after each time you run mage to run your new backend code.',
+    '- `docker-compose up` to start a grafana development server. ' +
+      (answers.hasBackend ? 'Restart this command after each time you run mage to run your new backend code.' : ''),
     '- Open http://localhost:3000 in your browser to create a dashboard to begin developing your plugin.',
   ];
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If created plugin does not have a backend, we do not need to show the message that we need to rerun docker after backend has been changed

**Which issue(s) this PR fixes**:
Fixes #772

