### PR TITLE
Docs: Clarify some points in documentation and typedocs

### DIFF
--- a/docusaurus/docs/e2e-test-a-plugin/authentication.md
+++ b/docusaurus/docs/e2e-test-a-plugin/authentication.md
@@ -43,6 +43,8 @@ export default defineConfig({
       name: 'run-tests',
       use: {
         ...devices['Desktop Chrome'],
+        // @grafana/plugin-e2e writes the auth state to this file,
+        // the path should not be modified
         storageState: 'playwright/.auth/admin.json',
       },
       dependencies: ['auth'],
@@ -83,6 +85,8 @@ export default defineConfig<PluginOptions>({
         testDir: './tests/viewer',
         use: {
           ...devices['Desktop Chrome'],
+          // @grafana/plugin-e2e writes the auth state to this file,
+          // the path should not be modified
           storageState: 'playwright/.auth/viewer.json',
         },
         dependencies: ['createViewerUserAndAuthenticate'],

--- a/docusaurus/docs/e2e-test-a-plugin/get-started.md
+++ b/docusaurus/docs/e2e-test-a-plugin/get-started.md
@@ -115,6 +115,9 @@ export default defineConfig({
       name: 'run-tests',
       use: {
         ...devices['Desktop Chrome'],
+
+        // @grafana/plugin-e2e writes the auth state to this file,
+        // the path should not be modified
         storageState: 'playwright/.auth/admin.json',
       },
       dependencies: ['auth'],

--- a/docusaurus/docs/e2e-test-a-plugin/get-started.md
+++ b/docusaurus/docs/e2e-test-a-plugin/get-started.md
@@ -134,6 +134,17 @@ To prevent these files from being version controlled, you can add the following 
 /playwright/.auth/
 ```
 
+The `@grafana/plugin-e2e` package also exports a type named `PluginOptions` that you can use to extend the Playwright configuration with the `@grafana/plugin-e2e` specific options.
+
+```ts title="playwright.config.ts"
+import { defineConfig } from '@playwright/test';
+import type { PluginOptions } from '@grafana/plugin-e2e';
+
+export default defineConfig<PluginOptions>({
+    ...
+});
+```
+
 ### Step 4: Start Grafana
 
 Start up the latest version of Grafana on your local machine like this:

--- a/docusaurus/docs/e2e-test-a-plugin/get-started.md
+++ b/docusaurus/docs/e2e-test-a-plugin/get-started.md
@@ -115,7 +115,6 @@ export default defineConfig({
       name: 'run-tests',
       use: {
         ...devices['Desktop Chrome'],
-
         // @grafana/plugin-e2e writes the auth state to this file,
         // the path should not be modified
         storageState: 'playwright/.auth/admin.json',

--- a/docusaurus/docs/e2e-test-a-plugin/introduction.md
+++ b/docusaurus/docs/e2e-test-a-plugin/introduction.md
@@ -14,7 +14,7 @@ sidebar_position: 1
 
 # Introduction to plugin E2E testing
 
-[`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) is a testing tool designed specifically for Grafana plugin developers. It extends [`Playwright test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers; enabling comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. This package simplifies the testing process, ensuring your plugin is robust and compatible with various Grafana environments.
+[`@grafana/plugin-e2e`](https://www.npmjs.com/package/@grafana/plugin-e2e?activeTab=readme) is designed specifically for Grafana plugin developers. It extends [`@playwright/test`](https://playwright.dev/) capabilities with relevant fixtures, models, and expect matchers; enabling comprehensive end-to-end testing of Grafana plugins across multiple versions of Grafana. This package simplifies the testing process, ensuring your plugin is robust and compatible with various Grafana environments.
 
 :::warning
 The `@grafana/plugin-e2e` tool is still in beta and subject to breaking changes.

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -73,7 +73,7 @@ export type CreateDataSourceArgs<T = any> = {
 
 export type CreateDataSourcePageArgs = {
   /**
-   * The data source type to create
+   * The data source type to create. This corresponds to the unique id of the data source plugin (`id` in `plugin.json`).
    */
   type: string;
   /**


### PR DESCRIPTION
This PR clarifies some very minor things that I tripped up on while setting up the E2E tests in `grafana/surrealdb-datasource`. Please consider this a first pass as I intend on taking another pass at this in future.

(@sunker Again, great job on this, feels like a huge step forward from where we were Cypress! 🚀)