### PR TITLE
Plugin E2E: Use new e2e selectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ nx-cloud.env
 
 # End to End tests
 playwright-report/
+packages/plugin-e2e/test-results/
 packages/plugin-e2e/playwright/.cache/
 packages/plugin-e2e/playwright/.auth
 .nx/cache

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -161,9 +161,6 @@ export type Pages = {
         };
         List: {
           url: (uid: string) => string;
-          /**
-           * @deprecated use addAnnotationCTAV2 from Grafana 8.3 instead
-           */
           addAnnotationCTA: string;
           addAnnotationCTAV2: string;
         };

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -99,16 +99,7 @@ export type Components = {
   CodeEditor: {
     container: string;
   };
-  Variables: {
-    variableOption: string;
-  };
-  Annotations: {
-    annotationsTypeInput: string;
-    annotationsChoosePanelInput: string;
-  };
-  Tooltip: {
-    container: string;
-  };
+  Annotations: {};
   QueryField: {
     container: string;
   };

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -54,6 +54,9 @@ export type Components = {
     };
     applyButton: string;
     toggleVizPicker: string;
+    OptionsPane: {
+      fieldInput: (title: string) => string;
+    };
   };
   RefreshPicker: {
     runButtonV2: string;

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -99,7 +99,12 @@ export type Components = {
   CodeEditor: {
     container: string;
   };
-  Annotations: {};
+  Annotations: {
+    editor: {
+      testButton: string;
+      resultContainer: string;
+    };
+  };
   QueryField: {
     container: string;
   };

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -91,6 +91,7 @@ export type Components = {
   };
   TimeZonePicker: {
     containerV2: string;
+    changeTimeSettingsButton: string;
   };
   CodeEditor: {
     container: string;

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -176,10 +176,10 @@ export const versionedComponents = {
   Annotations: {
     editor: {
       testButton: {
-        '10.3.0': 'data-testid annotations-test-button',
+        '11.0.0': 'data-testid annotations-test-button',
       },
       resultContainer: {
-        '10.3.0': 'data-testid annotations-query-result-container',
+        '11.0.0': 'data-testid annotations-query-result-container',
       },
     },
   },

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -74,6 +74,11 @@ export const versionedComponents = {
       '10.0.0': 'data-testid toggle-viz-picker',
       [MIN_GRAFANA_VERSION]: 'toggle-viz-picker',
     },
+    OptionsPane: {
+      fieldInput: {
+        '11.0.0': (title: string) => `data-testid Panel editor option pane field input ${title}`,
+      },
+    },
   },
   RefreshPicker: {
     runButtonV2: {

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -158,6 +158,9 @@ export const versionedComponents = {
       '8.3.0': 'data-testid Time zone picker select container',
       [MIN_GRAFANA_VERSION]: 'Folder picker select container',
     },
+    changeTimeSettingsButton: {
+      '11.0.0': 'data-testid Time zone picker Change time settings button',
+    },
   },
   CodeEditor: {
     container: {

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -173,6 +173,16 @@ export const versionedComponents = {
       [MIN_GRAFANA_VERSION]: 'Code editor container',
     },
   },
+  Annotations: {
+    editor: {
+      testButton: {
+        '10.3.0': 'data-testid annotations-test-button',
+      },
+      resultContainer: {
+        '10.3.0': 'data-testid annotations-query-result-container',
+      },
+    },
+  },
   QueryField: {
     container: {
       '10.3.0': 'data-testid Query field',

--- a/packages/plugin-e2e/src/models/components/TimeRange.ts
+++ b/packages/plugin-e2e/src/models/components/TimeRange.ts
@@ -1,3 +1,4 @@
+import * as semver from 'semver';
 import { PluginTestCtx, TimeRangeArgs } from '../../types';
 import { GrafanaPage } from '../pages/GrafanaPage';
 
@@ -10,25 +11,29 @@ export class TimeRange extends GrafanaPage {
    * Opens the time picker and sets the time range to the provided values
    */
   async set({ from, to, zone }: TimeRangeArgs) {
+    const { TimeZonePicker, TimePicker } = this.ctx.selectors.components;
     try {
-      await this.getByTestIdOrAriaLabel(this.ctx.selectors.components.TimePicker.openButton).click();
+      await this.getByTestIdOrAriaLabel(TimePicker.openButton).click();
     } catch (e) {
       // seems like in older versions of Grafana the time picker markup is rendered twice
       await this.ctx.page.locator('[aria-controls="TimePickerContent"]').last().click();
     }
 
     if (zone) {
-      //todo: add an e2e selector for the time zone picker and use it in grafana ui
-      await this.ctx.page.getByRole('button', { name: 'Change time settings' }).click();
-      await this.getByTestIdOrAriaLabel(this.ctx.selectors.components.TimeZonePicker.containerV2).fill(zone);
+      const changeTimeSettingsButton = semver.gte(this.ctx.grafanaVersion, '11.0.0')
+        ? this.getByTestIdOrAriaLabel(TimeZonePicker.changeTimeSettingsButton)
+        : this.ctx.page.getByRole('button', { name: 'Change time settings' });
+
+      await changeTimeSettingsButton.click();
+      await this.getByTestIdOrAriaLabel(TimeZonePicker.containerV2).fill(zone);
     }
-    await this.getByTestIdOrAriaLabel(this.ctx.selectors.components.TimePicker.absoluteTimeRangeTitle).click();
-    const fromField = await this.getByTestIdOrAriaLabel(this.ctx.selectors.components.TimePicker.fromField);
+    await this.getByTestIdOrAriaLabel(TimePicker.absoluteTimeRangeTitle).click();
+    const fromField = await this.getByTestIdOrAriaLabel(TimePicker.fromField);
     await fromField.clear();
     await fromField.fill(from);
-    const toField = await this.getByTestIdOrAriaLabel(this.ctx.selectors.components.TimePicker.toField);
+    const toField = await this.getByTestIdOrAriaLabel(TimePicker.toField);
     await toField.clear();
     await toField.fill(to);
-    await this.getByTestIdOrAriaLabel(this.ctx.selectors.components.TimePicker.applyTimeRange).click();
+    await this.getByTestIdOrAriaLabel(TimePicker.applyTimeRange).click();
   }
 }

--- a/packages/plugin-e2e/src/models/pages/AnnotationEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AnnotationEditPage.ts
@@ -1,3 +1,4 @@
+import * as semver from 'semver';
 import { DataSourcePicker } from '../components/DataSourcePicker';
 import { DashboardEditViewArgs, NavigateOptions, PluginTestCtx, RequestOptions } from '../../types';
 import { GrafanaPage } from './GrafanaPage';
@@ -30,8 +31,11 @@ export class AnnotationEditPage extends GrafanaPage {
       (resp) => resp.url().includes(this.ctx.selectors.apis.DataSource.query),
       options
     );
-    //TODO: add new selector and use it in grafana/ui
-    await this.ctx.page.getByRole('button', { name: 'TEST' }).click();
+
+    const testButton = semver.gte(this.ctx.grafanaVersion, '11.0.0')
+      ? this.getByTestIdOrAriaLabel(this.ctx.selectors.components.Annotations.editor.testButton)
+      : this.ctx.page.getByRole('button', { name: 'TEST' });
+    await testButton.click();
     return responsePromise;
   }
 }

--- a/packages/plugin-e2e/src/models/pages/AnnotationPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AnnotationPage.ts
@@ -24,19 +24,21 @@ export class AnnotationPage extends GrafanaPage {
    * Clicks the add new annotation button and returns the annotation edit page
    */
   async clickAddNew() {
-    const { Dashboard } = this.ctx.selectors.pages;
+    const { addAnnotationCTAV2, addAnnotationCTA } = this.ctx.selectors.pages.Dashboard.Settings.Annotations.List;
 
     if (!this.dashboard?.uid) {
       //the dashboard doesn't have any annotations yet (except for the built-in one)
       if (semver.gte(this.ctx.grafanaVersion, '8.3.0')) {
-        await this.getByTestIdOrAriaLabel(Dashboard.Settings.Annotations.List.addAnnotationCTAV2).click();
+        await this.getByTestIdOrAriaLabel(addAnnotationCTAV2).click();
       } else {
-        await this.getByTestIdOrAriaLabel(Dashboard.Settings.Annotations.List.addAnnotationCTA).click();
+        await this.getByTestIdOrAriaLabel(addAnnotationCTA).click();
       }
     } else {
       //the dashboard already has annotations
-      //TODO: add new selector and use it in grafana/ui
-      await this.ctx.page.getByRole('button', { name: 'New query' }).click();
+      const newQueryButton = semver.gte(this.ctx.grafanaVersion, '11.0.0')
+        ? this.getByTestIdOrAriaLabel(addAnnotationCTAV2)
+        : this.ctx.page.getByRole('button', { name: 'New query' });
+      await newQueryButton.click();
     }
 
     const editIndex = await this.ctx.page.evaluate(() => {

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -66,14 +66,15 @@ export class PanelEditPage extends GrafanaPage {
   /**
    * Sets the title of the panel. This method will open the panel options, set the title and close the panel options.
    */
-  async setPanelTitle(title: string) {
-    const { OptionsGroup } = this.ctx.selectors.components;
+  async setPanelTitle(titleText: string) {
+    const TITLE = 'Title';
+    const { OptionsGroup, PanelEditor } = this.ctx.selectors.components;
     await this.collapseSection(OptionsGroup.groupTitle);
-    //TODO: add new selector and use it in grafana/ui
-    const vizInput = await this.getByTestIdOrAriaLabel(OptionsGroup.group(OptionsGroup.groupTitle))
-      .locator('input')
-      .first();
-    await vizInput.fill(title);
+
+    const vizInput = semver.gte(this.ctx.grafanaVersion, '11.0.0')
+      ? this.getByTestIdOrAriaLabel(PanelEditor.OptionsPane.fieldInput(TITLE))
+      : this.getByTestIdOrAriaLabel(OptionsGroup.group(OptionsGroup.groupTitle)).locator('input').first();
+    await vizInput.fill(titleText);
     await this.ctx.page.keyboard.press('Tab');
   }
 

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/annotations/annotationEditor.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/annotations/annotationEditor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../../../../src';
+import { test, expect, AnnotationPage } from '../../../../src';
 import { REDSHIFT_SCHEMAS } from '../mocks/resource';
 
 test('should load resources and display them as options when clicking on an input', async ({
@@ -11,4 +11,18 @@ test('should load resources and display them as options when clicking on an inpu
   await annotationEditPage.datasource.set(ds.name);
   await page.getByLabel('Schema').click();
   await expect(annotationEditPage.getByTestIdOrAriaLabel('Select option')).toContainText(REDSHIFT_SCHEMAS);
+});
+
+test('should be able to add a new annotation when there annotations already exist', async ({
+  page,
+  selectors,
+  grafanaVersion,
+  request,
+  readProvisionedDashboard,
+}, testInfo) => {
+  const dashboard = await readProvisionedDashboard({ fileName: 'redshift.json' });
+  const annotationPage = new AnnotationPage({ page, selectors, grafanaVersion, request, testInfo }, dashboard);
+  await annotationPage.goto();
+  await annotationPage.clickAddNew();
+  await expect(page).toHaveTitle(/New annotation.*/);
 });

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/annotations/annotationQueryRunner.integration.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/annotations/annotationQueryRunner.integration.spec.ts
@@ -1,3 +1,4 @@
+import * as semver from 'semver';
 import semverLt from 'semver/functions/lt';
 import { test, expect } from '../../../../src';
 
@@ -34,8 +35,12 @@ test('should run successfully if valid Google Sheets query was provided', async 
 test('should run successfully if valid Redshift query was provided in provisioned dashboard', async ({
   gotoAnnotationEditPage,
   readProvisionedDashboard,
+  grafanaVersion,
 }) => {
   const dashboard = await readProvisionedDashboard({ fileName: 'redshift.json' });
   const annotationEditPage = await gotoAnnotationEditPage({ dashboard, id: '1' });
   await expect(annotationEditPage.runQuery()).toBeOK();
+  if (semver.gte(grafanaVersion, '11.0.0')) {
+    await expect(annotationEditPage).toHaveAlert('warning', { hasText: 'No events found' });
+  }
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces a few unsafe locators with proper selectors defined grafana/e2e-selectors (and in the versioned selectors in plugin-e2e). The new selectors where recently added to the main branch of Grafana, hence we'll have to use the unsafe locator for versions before 11. This should be fine though as no one will ever backport selector updates to older version of Grafana. 

Also updating related docs. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/plugin-tools/issues/724

**Special notes for your reviewer**:
The selectors were added to Grafana in the following PRs.

https://github.com/grafana/grafana/pull/83248
https://github.com/grafana/grafana/pull/83246
https://github.com/grafana/grafana/pull/83240
https://github.com/grafana/grafana/pull/83230
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.3.0-canary.833.13a3f6f.0
  npm install @grafana/plugin-e2e@0.23.0-canary.833.13a3f6f.0
  # or 
  yarn add @grafana/create-plugin@4.3.0-canary.833.13a3f6f.0
  yarn add @grafana/plugin-e2e@0.23.0-canary.833.13a3f6f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
