### PR TITLE
Plugin E2E: Add more selectors

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -66,6 +66,7 @@ export type Components = {
     toggleVizPicker: string;
     OptionsPane: {
       content: string;
+      fieldLabel: (type: string) => string;
       fieldInput: (title: string) => string;
     };
   };

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -30,6 +30,16 @@ export type Components = {
     applyTimeRange: string;
     absoluteTimeRangeTitle: string;
   };
+
+  Menu: {
+    MenuComponent: (title: string) => string;
+    MenuGroup: (title: string) => string;
+    MenuItem: (title: string) => string;
+    SubMenu: {
+      container: string;
+      icon: string;
+    };
+  };
   Panels: {
     Panel: {
       title: (title: string) => string;
@@ -55,6 +65,7 @@ export type Components = {
     applyButton: string;
     toggleVizPicker: string;
     OptionsPane: {
+      content: string;
       fieldInput: (title: string) => string;
     };
   };

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -97,6 +97,9 @@ export const versionedComponents = {
       content: {
         [MIN_GRAFANA_VERSION]: 'Panel editor option pane content',
       },
+      fieldLabel: {
+        [MIN_GRAFANA_VERSION]: (type: string) => `${type} field property editor`,
+      },
       fieldInput: {
         '11.0.0': (title: string) => `data-testid Panel editor option pane field input ${title}`,
       },

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -22,6 +22,25 @@ export const versionedComponents = {
       [MIN_GRAFANA_VERSION]: 'data-testid-absolute-time-range-narrow',
     },
   },
+  Menu: {
+    MenuComponent: {
+      [MIN_GRAFANA_VERSION]: (title: string) => `${title} menu`,
+    },
+    MenuGroup: {
+      [MIN_GRAFANA_VERSION]: (title: string) => `${title} menu group`,
+    },
+    MenuItem: { [MIN_GRAFANA_VERSION]: (title: string) => `${title} menu item` },
+    SubMenu: {
+      container: {
+        '10.3.0': 'data-testid SubMenu container',
+        [MIN_GRAFANA_VERSION]: 'SubMenu',
+      },
+      icon: {
+        '10.3.0': 'data-testid SubMenu icon',
+        [MIN_GRAFANA_VERSION]: 'SubMenu icon',
+      },
+    },
+  },
   Panels: {
     Panel: {
       title: {
@@ -75,6 +94,9 @@ export const versionedComponents = {
       [MIN_GRAFANA_VERSION]: 'toggle-viz-picker',
     },
     OptionsPane: {
+      content: {
+        [MIN_GRAFANA_VERSION]: 'Panel editor option pane content',
+      },
       fieldInput: {
         '11.0.0': (title: string) => `data-testid Panel editor option pane field input ${title}`,
       },


### PR DESCRIPTION

**What this PR does / why we need it**:

Adding a few more versioned selectors that I'd like to use when testing panel plugins. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@0.25.1-canary.845.40ca0ec.0
  # or 
  yarn add @grafana/plugin-e2e@0.25.1-canary.845.40ca0ec.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
