### PR TITLE
Plugin-E2E: Allow setting custom visualization

### DIFF
--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -81,7 +81,7 @@ export class PanelEditPage extends GrafanaPage {
   /**
    * Sets the visualization for the panel. This method will open the visualization picker, select the given visualization
    */
-  async setVisualization(visualization: Visualization) {
+  async setVisualization(visualization: Visualization | string) {
     // toggle options pane if panel edit is not visible
     const showPanelEditElement = this.getByGrafanaSelector('Show options pane');
     const showPanelEditElementCount = await showPanelEditElement.count();


### PR DESCRIPTION
**What this PR does / why we need it**:

The panel edit page api allows you to select a panel visualization. Currently, you're only allowed to specify a viz name defined in [this](https://github.com/grafana/plugin-tools/blob/de38cf50fbad8da7d4c0924057e6a718d12939b5/packages/plugin-e2e/src/types.ts#L565) type (the most common panel plugin names). However, users need to be able to specify any viz name so they can set custom visualizations. This PR changes signature of the `setVisualization` method so that it also accepts strings too. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
