### PR TITLE
Plugin E2E: Add plugin options in readme snippet

### DIFF
--- a/packages/plugin-e2e/README.md
+++ b/packages/plugin-e2e/README.md
@@ -39,9 +39,11 @@ Open the Playwright config file that was generated when Playwright was installed
 ```ts
 import { dirname } from 'path';
 import { defineConfig, devices } from '@playwright/test';
+import type { PluginOptions } from '@grafana/plugin-e2e';
+
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 
-export default defineConfig({
+export default defineConfig<PluginOptions>({
   testDir: './tests', // change this to the directory that was chosen when installing Playwright
   reporter: 'html',
   use: {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the readme snippet so that it's using PluginOptions.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@1.0.1-canary.860.4742b1e.0
  # or 
  yarn add @grafana/plugin-e2e@1.0.1-canary.860.4742b1e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
