### PR TITLE
Create Plugin: Run e2e tests against multiple Grafana versions in CI workflow

### DIFF
--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -209,6 +209,8 @@ jobs:
           path: grafana-server.log
           retention-days: 5
 
+      # If your repository is public, uploading the Playwright report will make it public on the Internet.
+      # Beware not to expose sensitive information.
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: $\{{ always() && steps.run-tests.outcome == 'failure' }}

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -15,7 +15,13 @@ permissions: read-all
 
 jobs:
   build:
+    name: Build, lint and unit tests
     runs-on: ubuntu-latest
+    outputs:
+      plugin-id: $\{{ steps.metadata.outputs.plugin-id }}
+      plugin-version: $\{{ steps.metadata.outputs.plugin-version }}
+      has-e2e: $\{{ steps.check-for-e2e.outputs.has-e2e }}
+      has-backend: $\{{ steps.check-for-backend.outputs.has-backend }}
     env:
       GRAFANA_ACCESS_POLICY_TOKEN: $\{{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
     steps:
@@ -79,40 +85,6 @@ jobs:
             echo "has-e2e=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install Playwright Browsers
-        if: steps.check-for-e2e.outputs.has-e2e == 'true'
-        run: {{ packageManagerName }} exec playwright install --with-deps
-
-      - name: Start grafana docker
-        if: steps.check-for-e2e.outputs.has-e2e == 'true'
-        run: docker-compose up -d
-
-      - name: Wait for Grafana to start
-        if: steps.check-for-e2e.outputs.has-e2e == 'true'
-        uses: nev7n/wait_for_response@v1
-        with:
-          url: 'http://localhost:3000/'
-          responseCode: 200
-          timeout: 60000
-          interval: 500
-
-      - name: Run e2e tests
-        id: run-e2e-tests
-        if: steps.check-for-e2e.outputs.has-e2e == 'true'
-        run: {{ packageManagerName }} run e2e
-
-      - name: Stop grafana docker
-        if: steps.check-for-e2e.outputs.has-e2e == 'true'
-        run: docker-compose down
-
-      - name: Archive E2E output
-        uses: actions/upload-artifact@v4
-        if: steps.check-for-e2e.outputs.has-e2e == 'true' && steps.run-e2e-tests.outcome != 'success'
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 5
-
       - name: Sign plugin
         run: {{ packageManagerName }} run sign
         if: $\{{ env.GRAFANA_ACCESS_POLICY_TOKEN != '' }}
@@ -141,4 +113,106 @@ jobs:
         with:
           name: $\{{ steps.metadata.outputs.plugin-id }}-$\{{ steps.metadata.outputs.plugin-version }}
           path: $\{{ steps.metadata.outputs.plugin-id }}
+          retention-days: 5
+
+  resolve-versions:
+    name: Resolve e2e images
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    needs: build
+    if: $\{{ needs.build.outputs.has-e2e == 'true' }}
+    outputs:
+      matrix: $\{{ steps.resolve-versions.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Resolve Grafana E2E versions
+        id: resolve-versions
+        uses: grafana/plugin-actions/e2e-version@main
+
+  playwright-tests:
+    needs: [resolve-versions, build]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        GRAFANA_IMAGE: $\{{fromJson(needs.resolve-versions.outputs.matrix)}}
+    name: e2e test $\{{ matrix.GRAFANA_IMAGE.name }}@$\{{ matrix.GRAFANA_IMAGE.VERSION }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            provisioning
+            tests
+            .config
+
+      - name: Download plugin
+        if: needs.build.outputs.has-backend == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          name: $\{{ needs.build.outputs.plugin-id }}-$\{{ needs.build.outputs.plugin-version }}
+
+      - name: Execute permissions on binary
+        if: needs.build.outputs.has-backend == 'true'
+        run: |
+          chmod +x ./dist/gpx_cicd_linux_amd64
+
+{{#if_eq packageManagerName "pnpm"}}
+      # pnpm action uses the packageManager field in package.json to
+      # understand which version to install.
+      - uses: pnpm/action-setup@v3
+{{/if_eq}}
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: '{{ packageManagerName }}'
+
+      - name: Install dev dependencies
+        run: {{ packageManagerInstallCmd }}
+
+      - name: Start Grafana
+        run: |
+          docker-compose pull
+          GRAFANA_VERSION=$\{{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=$\{{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+
+      - name: Wait for Grafana to start
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: 'http://localhost:3000/'
+          responseCode: 200
+          timeout: 60000
+          interval: 500
+
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run Playwright tests
+        id: run-tests
+        run: {{ packageManagerName }} run e2e
+
+      - name: Docker logs
+        if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
+        run: |
+          docker logs {{ pluginId }} >& grafana-server.log
+
+      - name: Stop grafana docker
+        run: docker-compose down
+
+      - name: Upload server log
+        uses: actions/upload-artifact@v4
+        if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
+        with:
+          name: $\{{ matrix.GRAFANA_IMAGE.NAME }}-v$\{{ matrix.GRAFANA_IMAGE.VERSION }}-$\{{github.run_id}}-server-log
+          path: grafana-server.log
+          retention-days: 5
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
+        with:
+          name: playwright-report-$\{{ matrix.GRAFANA_IMAGE.NAME }}-v$\{{ matrix.GRAFANA_IMAGE.VERSION }}-$\{{github.run_id}}
+          path: playwright-report/
           retention-days: 5


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the CI workflow so that it uses the [e2e-versions](https://github.com/grafana/plugin-actions/tree/main/e2e-version) Action to run e2e tests against all versions that the plugin is supposed to be compatible with. 

In the following example, test run failed in grafana 10.4.1. The test report and the grafana server log are uploaded as artifacts. 

![Screenshot 2024-04-11 at 09 53 41](https://github.com/grafana/plugin-tools/assets/2388950/cfdf223d-4e7d-4b13-9c56-ba45d78f1d9c)
![Screenshot 2024-04-11 at 09 53 58](https://github.com/grafana/plugin-tools/assets/2388950/a8f6ab46-2449-4677-9cd1-7ee75e1734df)

Tested in [this](https://github.com/sunker/sunker-cicd-datasource/pull/1) PR. 

**Which issue(s) this PR fixes**:

The [release](https://github.com/grafana/plugin-actions/tree/main/build-plugin) workflow currently doesn't run e2e tests at all. I guess we should change that at some point too.  

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.7.0-canary.870.6afd6d2.0
  # or 
  yarn add @grafana/create-plugin@4.7.0-canary.870.6afd6d2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
