### PR TITLE
Webpack: Generate meta-data using the plugin-meta-extractor during builds

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -12,6 +12,7 @@ import LiveReloadPlugin from 'webpack-livereload-plugin';
 import path from 'path';
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import { Configuration } from 'webpack';
+import { GrafanaPluginMetaExtractor } from '@grafana/plugin-meta-extractor';
 
 import { getPackageJson, getPluginJson, hasReadme, getEntries, isWSL } from './utils';
 import { SOURCE_DIR, DIST_DIR } from './constants';
@@ -142,6 +143,7 @@ const config = async (env): Promise<Configuration> => {
     },
 
     plugins: [
+      new GrafanaPluginMetaExtractor(),
       new CopyWebpackPlugin({
         patterns: [
           // If src/README.md exists use it; otherwise the root README

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -23,7 +23,8 @@
     "@grafana/e2e-selectors": "{{ grafanaVersion }}",{{/unless}}
     "@grafana/eslint-config": "^7.0.0",{{#if usePlaywright}}
     "@grafana/plugin-e2e": "^1.0.1",{{/if}}
-    "@grafana/tsconfig": "^1.2.0-rc1",{{#if usePlaywright}}
+    "@grafana/tsconfig": "^1.2.0-rc1",
+    "@grafana/plugin-meta-extractor": "^1.0.0",{{#if usePlaywright}}
     "@playwright/test": "^1.41.2",{{/if}}
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -24,7 +24,7 @@
     "@grafana/eslint-config": "^7.0.0",{{#if usePlaywright}}
     "@grafana/plugin-e2e": "^1.0.1",{{/if}}
     "@grafana/tsconfig": "^1.2.0-rc1",
-    "@grafana/plugin-meta-extractor": "^1.0.0",{{#if usePlaywright}}
+    "@grafana/plugin-meta-extractor": "^0.0.1",{{#if usePlaywright}}
     "@playwright/test": "^1.41.2",{{/if}}
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",


### PR DESCRIPTION
> [!NOTE]  
> This PR depends on https://github.com/grafana/plugin-tools/pull/805 and also the `@grafana/plugin-meta-extractor` package to be published.

### What changed?
Updated the webpack configuration to analyze plugin code during builds and auto-generate a `plugin.generated.json` file which holds information about extensions the plugin wants to register. (This can later be used by Grafana core to decide when a certain plugin should be preloaded.)

### What should I do as a plugin dev?
Run `npx @grafana/create-plugin@latest update` once this PR is merged and a new version of `@grafana/create-plugin` is published.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.10.0-canary.871.60a4cf1.0
  # or 
  yarn add @grafana/create-plugin@4.10.0-canary.871.60a4cf1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
