### PR TITLE
e2eTesting: update selectors

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -94,7 +94,7 @@ export const versionedComponents = {
   PanelEditor: {
     General: {
       content: {
-        [MIN_GRAFANA_VERSION]: 'Panel editor content',
+        [MIN_GRAFANA_VERSION]: 'data-testid Panel editor content',
       },
     },
     applyButton: {
@@ -107,7 +107,7 @@ export const versionedComponents = {
     },
     OptionsPane: {
       content: {
-        [MIN_GRAFANA_VERSION]: 'Panel editor option pane content',
+        [MIN_GRAFANA_VERSION]: 'data-testid Panel editor option pane content',
       },
       fieldLabel: {
         [MIN_GRAFANA_VERSION]: (type: string) => `${type} field property editor`,
@@ -162,10 +162,12 @@ export const versionedComponents = {
   },
   OptionsGroup: {
     group: {
-      [MIN_GRAFANA_VERSION]: (title?: string) => (title ? `Options group ${title}` : 'Options group'),
+      [MIN_GRAFANA_VERSION]: (title?: string) =>
+        title ? `data-testid Options group ${title}` : 'data-testid Options group',
     },
     toggle: {
-      [MIN_GRAFANA_VERSION]: (title?: string) => (title ? `Options group ${title} toggle` : 'Options group toggle'),
+      [MIN_GRAFANA_VERSION]: (title?: string) =>
+        title ? `data-testid Options group ${title} toggle` : 'data-testid Options group toggle',
     },
     groupTitle: {
       [MIN_GRAFANA_VERSION]: 'Panel options',

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -94,7 +94,7 @@ export const versionedComponents = {
   PanelEditor: {
     General: {
       content: {
-        [MIN_GRAFANA_VERSION]: 'data-testid Panel editor content',
+        '11.1.0': 'data-testid Panel editor content',
       },
     },
     applyButton: {
@@ -107,7 +107,7 @@ export const versionedComponents = {
     },
     OptionsPane: {
       content: {
-        [MIN_GRAFANA_VERSION]: 'data-testid Panel editor option pane content',
+        '11.1.0': 'data-testid Panel editor option pane content',
       },
       fieldLabel: {
         [MIN_GRAFANA_VERSION]: (type: string) => `${type} field property editor`,
@@ -162,11 +162,10 @@ export const versionedComponents = {
   },
   OptionsGroup: {
     group: {
-      [MIN_GRAFANA_VERSION]: (title?: string) =>
-        title ? `data-testid Options group ${title}` : 'data-testid Options group',
+      '11.1.0': (title?: string) => (title ? `data-testid Options group ${title}` : 'data-testid Options group'),
     },
     toggle: {
-      [MIN_GRAFANA_VERSION]: (title?: string) =>
+      '11.1.0': (title?: string) =>
         title ? `data-testid Options group ${title} toggle` : 'data-testid Options group toggle',
     },
     groupTitle: {

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -95,6 +95,7 @@ export const versionedComponents = {
     General: {
       content: {
         '11.1.0': 'data-testid Panel editor content',
+        [MIN_GRAFANA_VERSION]: 'Panel editor content',
       },
     },
     applyButton: {
@@ -108,6 +109,7 @@ export const versionedComponents = {
     OptionsPane: {
       content: {
         '11.1.0': 'data-testid Panel editor option pane content',
+        [MIN_GRAFANA_VERSION]: 'Panel editor option pane content',
       },
       fieldLabel: {
         [MIN_GRAFANA_VERSION]: (type: string) => `${type} field property editor`,
@@ -163,10 +165,12 @@ export const versionedComponents = {
   OptionsGroup: {
     group: {
       '11.1.0': (title?: string) => (title ? `data-testid Options group ${title}` : 'data-testid Options group'),
+      [MIN_GRAFANA_VERSION]: (title?: string) => (title ? `Options group ${title}` : 'Options group'),
     },
     toggle: {
       '11.1.0': (title?: string) =>
         title ? `data-testid Options group ${title} toggle` : 'data-testid Options group toggle',
+      [MIN_GRAFANA_VERSION]: (title?: string) => (title ? `Options group ${title} toggle` : 'Options group toggle'),
     },
     groupTitle: {
       [MIN_GRAFANA_VERSION]: 'Panel options',


### PR DESCRIPTION
An external contributor updated some e2e selectors which are duplicated in this repo. In order to fix playwright tests in their PR in grafana/grafana I updated the selectors here.

Related to https://github.com/grafana/grafana/pull/78536


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@1.1.1-canary.874.63ebb8f.0
  # or 
  yarn add @grafana/plugin-e2e@1.1.1-canary.874.63ebb8f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
