### PR TITLE
Docs: Update the docs for UI-Extensions

### DIFF
--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -71,7 +71,7 @@ The unique identifier of your extension point. It must begin with `plugins/<PLUG
 
 ##### `options?.context` - _object (Optional)_
 
-As an arbitrary object, it contains information related to your extension point that you would like to share with the extensions. For example: `{ baseUrl: '/foo/bar' }`. This parameter is not available for component extensions because you can pass contextual information using the component props. 
+As an arbitrary object, it contains information related to your extension point that you would like to share with the extensions. For example: `{ baseUrl: '/foo/bar' }`. This parameter is not available for component extensions because you can pass contextual information using the component props.
 
 :::note
 
@@ -199,11 +199,11 @@ function AppMenuExtensionPoint({ referenceId }) {
 
 :::note
 
-**This feature is only available in Grafana versions 10.1.0 and above.
+\*\*This feature is only available in Grafana versions 10.1.0 and above.
 
 :::
 
-Component type extensions are simple React components, which gives much more freedom on what they are able to do. You can pass contextual information to the extension components using props.
+Component type extensions are simple React components, which gives you much more freedom in what you can make them do. You can pass contextual information to the extension components using props.
 
 ```tsx title="src/components/Toolbar.tsx"
 import { usePluginComponentExtensions } from '@grafana/runtime';
@@ -263,9 +263,9 @@ The unique identifier of your extension point. It must begin with `plugins/<PLUG
 
 ##### `options?.context` - _object (Optional)_
 
-As an arbitrary object, it contains information related to your extension point which you would like to share with the extensions. For example: `{ baseUrl: '/foo/bar' }`. 
+As an arbitrary object, it contains information related to your extension point which you would like to share with the extensions. For example: `{ baseUrl: '/foo/bar' }`.
 
-This parameter is not available for component extensions; for those, you can pass contextual information using the component props. 
+This parameter is not available for component extensions; for those, you can pass contextual information using the component props.
 
 :::note
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -15,7 +15,7 @@ keywords:
   - apps
 ---
 
-In this guide you will learn how to provide an extension point so that other app plugins can add their extensions to your plugin.
+In this guide you will learn how to provide an extension point so that app plugins can add their extensions to your plugin.
 
 ## What is an extension point?
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -163,7 +163,7 @@ import { useMemo } from 'react';
 import { usePluginLinkExtensions } from '@grafana/runtime';
 
 function AppMenuExtensionPoint({ referenceId }) {
-  // Instead of just defining the object here (which would result in a new object on every render),
+  // Instead of defining the object here (which would result in a new object on every render),
   // we use `useMemo()` to only update the context object when its "dynamic" dependencies change.
   const context = useMemo(
     () => ({

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -15,7 +15,6 @@ keywords:
   - apps
 ---
 
-
 In this guide you will learn how to provide an extension point so that other app plugins can add their extensions to your plugin.
 
 ## What is an extension point?
@@ -52,7 +51,7 @@ You can easily create an extension point using the following functions (they liv
 
 :::note
 
-In case the `context` object is created dynamically, make sure to wrap it into a `useMemo()` to prevent unnecesssary rerenders. [More info](#)
+In case the `context` object is created dynamically, make sure to wrap it into a `useMemo()` to prevent unnecesssary rerenders. [More info](#example---rendering-link-extensions-dynamic-context)
 
 :::
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -1,6 +1,6 @@
 ---
 id: create-an-extension-point
-title: Create an extension point in your app plugin
+title: Create an extension point
 sidebar_label: Create an extension point
 sidebar_position: 2
 description: Learn how to provide an extension point so that other applications can contribute their extensions.
@@ -15,19 +15,25 @@ keywords:
   - apps
 ---
 
-Providing an extension point within your UI enables other plugins to contribute supplementary capabilities, and leverage the context within the current view to guide users to a potential next step. Here's what you need to know about extension points.
+## What is an extension point?
 
-Firstly, you will need to define an extension point ID. This is basically just a string describing the part of the UI where the extension point lives. Extension developers should be able to figure out where in the UI the extension will be added by reading the extension point ID.
+An extension point is a place in the UI which you make extendable by other plugins using extensions. These extensions can be either be links or simple React components (that can basically impelement anything). It's up to you how you are displaying the handling or displaying the extensions, we have some examples below.
+
+You can also share contextual information with the extensions using a `context` object or component props (see the examples below).
+
+### Requirements
+
+- **an extension point ID** _(string)_
+  - In case it's an extension point in core Grafana, it must start with `grafana/`
+  - In case it's inside a plugin, it must start with `plugin/<PLUGIN_ID>/`
+  - It must be unique
+- **an app plugin** - _currently only app plugins can create extension points_
 
 :::note
 
-Extension points living in core Grafana must start with `grafana/` and extension points living in plugins must have IDs starting with `plugins/` followed by the plugin ID, for example, `plugins/<PLUGIN_ID>/`.
+Consider the design the UI of the extension point so it supports a scenario where multiple extensions are being added without breaking the UI. Also consider if there is any information from the current view that should be shared with the extensions added to the extension point. It could be information from the current view that could let the extending plugin prefill values or other data in the functionality being added via the extension.
 
 :::
-
-The second thing you need to consider is how to design the UI of the extension point so it supports a scenario where multiple extensions are being added without breaking the UI.
-
-Finally, consider if there is any information from the current view that should be shared with the extensions added to the extension point. It could be information from the current view that could let the extending plugin prefill values or other data in the functionality being added via the extension.
 
 ## Create an extension point
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -31,13 +31,13 @@ Finally, consider if there is any information from the current view that should 
 
 ## Create an extension point
 
-Use the `getPluginLinkExtensions` method in `@grafana/runtime` to create an extension point within your plugin.
-
 :::danger
 
 When you create an extension point in a plugin, you create a public interface for other plugins to interact with. Changes to the extension point ID or its context could break any plugin that attempts to register a link inside your plugin.
 
 :::
+
+Use the `getPluginLinkExtensions` method in `@grafana/runtime` to create an extension point within your plugin.
 
 The `getPluginLinkExtensions` method takes an object consisting of the `extensionPointId`, which must begin `plugins/<PLUGIN_ID>`, and any contextual information that you want to provide. The `getPluginLinkExtensions` method returns a list of extension links that your program can then loop over.
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -200,12 +200,6 @@ function AppMenuExtensionPoint({ referenceId }) {
 
 #### Example - rendering component extensions
 
-:::note
-
-\*\*This feature is only available in Grafana versions 10.1.0 and above.
-
-:::
-
 Component type extensions are simple React components, which gives you much more freedom in what you can make them do. You can pass contextual information to the extension components using props.
 
 ```tsx title="src/components/Toolbar.tsx"

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -81,7 +81,7 @@ The provided context object always gets frozen (turned immutable) before being s
 
 ##### `options?.limitPerPlugin` - _number (Optional)_
 
-Use thie parameter to set the maximum value for how many extensions should be returned from the same plugin. It can be useful in cases when there is limited space on the UI to display extensions.
+Use this parameter to set the maximum value for how many extensions should be returned from the same plugin. It can be useful in cases when there is limited space on the UI to display extensions.
 
 #### Return value
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -31,7 +31,7 @@ You can also share contextual information with the extensions using a `context` 
   - In case it's an extension point in core Grafana, it must start with `grafana/`
   - In case it's inside a plugin, it must start with `plugin/<PLUGIN_ID>/`
   - It must be unique
-- **an app plugin** - _currently only app plugins can create extension points_
+- **an app plugin** - _apart from core Grafana, currently only app plugins can create extension points and register extensions._
 
 :::note
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -57,7 +57,7 @@ In case the `context` object is created dynamically, make sure to wrap it into a
 
 :::
 
-The `usePluginExtensions` React hooks returns the list of extensions that are registered for a certain extension point ID. The hook dynamically updates its return value when the list of extensions changes. This behavior usually happens when extensions are registered during runtime due to dynamic plugin loading.
+The `usePluginExtensions` React hooks return the list of extensions that are registered for a certain extension point ID. The hook dynamically updates its return value when the list of extensions changes. This behavior usually happens when extensions are registered during runtime due to dynamic plugin loading.
 
 #### Syntax
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -19,7 +19,7 @@ keywords:
 
 An extension point is a place in the UI which you make extendable by other plugins using extensions. These extensions can be either be links or simple React components (that can basically impelement anything). It's up to you how you are displaying the handling or displaying the extensions, we have some examples below.
 
-You can also share contextual information with the extensions using a `context` object or component props (see the examples below).
+You can also share contextual information with the extensions using a `context` object or component props (see the following examples).
 
 ### Requirements
 
@@ -31,7 +31,7 @@ You can also share contextual information with the extensions using a `context` 
 
 :::note
 
-Consider the design the UI of the extension point so it supports a scenario where multiple extensions are being added without breaking the UI. Also consider if there is any information from the current view that should be shared with the extensions added to the extension point. It could be information from the current view that could let the extending plugin prefill values or other data in the functionality being added via the extension.
+Consider the design of the UI of the extension point so it supports a scenario where multiple extensions can be added without breaking the UI. Also consider if there is any information from the current view that should be shared with the extensions added to the extension point. It could be information from the current view that could let the extending plugin prefill values or other data in the extension's functionality.
 
 :::
 
@@ -45,15 +45,15 @@ When you create an extension point in a plugin, you create a public interface fo
 
 You can easily create an extension point using the following functions (they live in `@grafana/runtime`) to fetch extensions for a certain extension point ID:
 
-### `usePluginExtensions()`
+### The `usePluginExtensions()` hook
 
 :::note
 
-**Performance tip:** in case the `context` object is created dynamically, make sure to wrap it into a `useMemo()` to prevent unnecesssary rerenders. [More info](#)
+In case the `context` object is created dynamically, make sure to wrap it into a `useMemo()` to prevent unnecesssary rerenders. [More info](#)
 
 :::
 
-The `usePluginExtensions` react hooks returns the list of extensions that are registered for a certain extension point ID. The hook will dynamically update its return value when the list of extensions changes - this usually happens when extensions are registered during runtime due to dynamic plugin loading.
+The `usePluginExtensions` React hooks returns the list of extensions that are registered for a certain extension point ID. The hook dynamically updates its return value when the list of extensions changes. This behavior usually happens when extensions are registered during runtime due to dynamic plugin loading.
 
 #### Syntax
 
@@ -67,15 +67,21 @@ usePluginComponentExtensions(options); // Only returns extensions that have type
 
 ##### `options.extensionPointId` - _string_
 
-The unique identifier of your extension point. It must begin with `plugins/<PLUGIN_ID>`, for example: `plugins/myorg-super-app`.
+The unique identifier of your extension point. It must begin with `plugins/<PLUGIN_ID>`. For example: `plugins/myorg-super-app`.
 
 ##### `options?.context` - _object (Optional)_
 
-An arbitrary object, that contains information related to your extension point which you would like to share with the extensions, for example: `{ baseUrl: '/foo/bar' }`. This parameter is not available for component extensions, for those you can pass contextual information using the component props. **Note:** the provided context object always gets frozen (turned immutable) before being shared with the extensions.
+As an arbitrary object, it contains information related to your extension point that you would like to share with the extensions. For example: `{ baseUrl: '/foo/bar' }`. This parameter is not available for component extensions because you can pass contextual information using the component props. 
+
+:::note
+
+The provided context object always gets frozen (turned immutable) before being shared with the extensions.
+
+:::
 
 ##### `options?.limitPerPlugin` - _number (Optional)_
 
-It can be used to limit maximum how many extensions should be returned from the same plugin. It can be useful in cases when there is limited space on the UI to display extensions.
+Use thie parameter to set the maximum value for how many extensions should be returned from the same plugin. It can be useful in cases when there is limited space on the UI to display extensions.
 
 #### Return value
 
@@ -105,7 +111,7 @@ The hooks return an object in the following format:
 
 #### Example - rendering link extensions (static context)
 
-In the following example we render a link component all link-type extensions that other plugins registered for the `plugins/another-app-plugin/menu` extension point ID.
+The following example shows how to render a link component all link-type extensions that other plugins registered for the `plugins/another-app-plugin/menu` extension point ID.
 
 ```tsx
 import { usePluginLinkExtensions } from '@grafana/runtime';
@@ -145,12 +151,12 @@ function AppMenuExtensionPoint() {
 
 #### Example - rendering link extensions (dynamic context)
 
-In this example we are creating the context object dynamically. Although this is a common practice, we have to be aware, that the `usePluginLinkExtensions()` hook will rerender in the following scenarios:
+The following example shows how to create the context object dynamically. Although this is a common practice, you should be aware that the `usePluginLinkExtensions()` hook will re-render in the following scenarios:
 
-- IF the `context` object changes _(so the extensions can react to the context changes)_
-- IF the extension-registry changes
+- If the `context` object changes _(so the extensions can react to the context changes)_
+- If the extension-registry changes
 
-Because of these we have to make sure, that we only change the `context` object if its content changes, otherwise we will cause unnecessary rerenders. The following example shows how to approach these scenarios in a safe way:
+Be sure to only change the `context` object if its content changes; otherwise, you could create unnecessary re-renders. The following example shows how to approach these scenarios in a safe way:
 
 ```tsx
 import { useMemo } from 'react';
@@ -193,7 +199,7 @@ function AppMenuExtensionPoint({ referenceId }) {
 
 :::note
 
-**Available in Grafana >=10.1.0** <br /> (_Component type extensions are only available in Grafana 10.1.0 and above._)
+**This feature is only available in Grafana versions 10.1.0 and above.
 
 :::
 
@@ -230,14 +236,14 @@ export const Toolbar = () => {
 };
 ```
 
-### `getPluginExtensions()` - _deprecated_
+### The `getPluginExtensions()` method - _deprecated_
 
 The `getPluginExtensions` method takes an object consisting of the `extensionPointId`, which must begin `plugins/<PLUGIN_ID>`, and any contextual information that you want to provide. The `getPluginLinkExtensions` method returns a list of extension links that your program can then loop over.
 
 :::note
 
 This function only returns the state of the extensions registry (the extensions registered by plugins) at a given time. If there are extensions registered by plugins after that point in time, you won't receive them. <br />
-**We strongly suggest to use the reactive [`usePluginExtensions()`](#usepluginextensions) hook instead wherever possible.**
+As a best practice, use the reactive [`usePluginExtensions()`](#usepluginextensions) hook instead wherever possible.
 
 :::
 
@@ -253,15 +259,23 @@ getPluginComponentExtensions(options); // Only returns extensions that have type
 
 ##### `options.extensionPointId` - _string_
 
-The unique identifier of your extension point. It must begin with `plugins/<PLUGIN_ID>`, for example: `plugins/myorg-super-app`.
+The unique identifier of your extension point. It must begin with `plugins/<PLUGIN_ID>`. For example: `plugins/myorg-super-app`.
 
 ##### `options?.context` - _object (Optional)_
 
-An arbitrary object, that contains information related to your extension point which you would like to share with the extensions, for example: `{ baseUrl: '/foo/bar' }`. This parameter is not available for component extensions, for those you can pass contextual information using the component props. **Note:** the provided context object always gets frozen (turned immutable) before being shared with the extensions.
+As an arbitrary object, it contains information related to your extension point which you would like to share with the extensions. For example: `{ baseUrl: '/foo/bar' }`. 
+
+This parameter is not available for component extensions; for those, you can pass contextual information using the component props. 
+
+:::note
+
+The provided context object always gets frozen (turned immutable) before being shared with the extensions.
+
+:::
 
 ##### `options?.limitPerPlugin` - _number (Optional)_
 
-It can be used to limit maximum how many extensions should be returned from the same plugin. It can be useful in cases when there is limited space on the UI to display extensions.
+Use this method to specify the maximum amount of extensions that should be returned from the same plugin. It can be useful in cases when there is limited space on the UI to display extensions.
 
 #### Return value
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -111,7 +111,7 @@ The hooks return an object in the following format:
 
 #### Example - rendering link extensions (static context)
 
-The following example shows how to render a link component all link-type extensions that other plugins registered for the `plugins/another-app-plugin/menu` extension point ID.
+The following example shows how to render a link component as link-type extensions that other plugins registered for the `plugins/another-app-plugin/menu` extension point ID.
 
 ```tsx
 import { usePluginLinkExtensions } from '@grafana/runtime';

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -31,7 +31,7 @@ You can also share contextual information with the extensions using a `context` 
 
 :::note
 
-Consider the design of the UI of the extension point so it supports a scenario where multiple extensions can be added without breaking the UI. Also consider if there is any information from the current view that should be shared with the extensions added to the extension point. It could be information from the current view that could let the extending plugin prefill values or other data in the extension's functionality.
+When designing the UI make sure the extension point supports a scenario where multiple extensions can be added without breaking the UI. Also consider if there is any information from the current view that should be shared with the extensions added to the extension point. It could be information from the current view that could let the extending plugin pre-fill values or other data in the extension's functionality.
 
 :::
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -15,6 +15,9 @@ keywords:
   - apps
 ---
 
+
+In this guide you will learn how to provide an extension point so that other app plugins can add their extensions to your plugin.
+
 ## What is an extension point?
 
 An extension point is a place in the UI which you make extendable by other plugins using extensions. These extensions can be either be links or simple React components (that can basically impelement anything). It's up to you how you are displaying the handling or displaying the extensions, we have some examples below.

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -19,7 +19,7 @@ In this guide you will learn how to provide an extension point so that app plugi
 
 ## What is an extension point?
 
-An extension point is a place in the UI which you make extendable by other plugins using extensions. These extensions can either be links or React components that can implement virtually anything. 
+An extension point is a place in the UI which you make extendable by other plugins using extensions. These extensions can either be links or React components that can implement virtually anything.
 
 In the extension point you can control how you want to handle the displaying of extensions to users. You can also share contextual information with the extensions using a `context` object or component props. Refer to the examples below to learn more.
 
@@ -71,7 +71,7 @@ usePluginComponentExtensions(options); // Only returns extensions that have type
 
 ##### `options.extensionPointId` - _string_
 
-The unique identifier of your extension point. It must begin with `plugins/<PLUGIN_ID>`. For example: `plugins/myorg-super-app`.
+The unique identifier of your extension point. It must begin with `plugins/<PLUGIN_ID>` for plugins and `grafana/` for core Grafana extension points. For example: `plugins/myorg-super-app`.
 
 ##### `options?.context` - _object (Optional)_
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -79,7 +79,7 @@ An object containing information related to your extension point that you would 
 
 :::note
 
-The provided context object always gets frozen (turned immutable) before being shared with the extensions.
+The provided context object is made immutable before being shared with the extensions.
 
 :::
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -71,7 +71,7 @@ The unique identifier of your extension point. It must begin with `plugins/<PLUG
 
 ##### `options?.context` - _object (Optional)_
 
-As an arbitrary object, it contains information related to your extension point that you would like to share with the extensions. For example: `{ baseUrl: '/foo/bar' }`. This parameter is not available for component extensions because you can pass contextual information using the component props.
+An object containing information related to your extension point that you would like to share with the extensions. For example: `{ baseUrl: '/foo/bar' }`. This parameter is not available for component extensions, instead you should pass contextual information using the component props.
 
 :::note
 

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -116,8 +116,8 @@ The following example shows how to render a link component as link-type extensio
 ```tsx
 import { usePluginLinkExtensions } from '@grafana/runtime';
 
-// We are defining the `context` outside of the React component for performance reasons.
-// (In case we would declare it inside the component below, then it would result in a new object on every render,
+// We define the `context` outside of the React component for performance reasons.
+// (Declaring it inside the component would result in a new object on every render,
 // which would unnecessarily trigger the `usePluginLinkExtensions()` hook.)
 const context = {
   referenceId: '12345',

--- a/docusaurus/docs/ui-extensions/create-an-extension-point.md
+++ b/docusaurus/docs/ui-extensions/create-an-extension-point.md
@@ -19,7 +19,9 @@ In this guide you will learn how to provide an extension point so that app plugi
 
 ## What is an extension point?
 
-An extension point is a place in the UI which you make extendable by other plugins using extensions. These extensions can be either be links or simple React components (that can basically impelement anything). It's up to you how you are displaying the handling or displaying the extensions, we have some examples below.
+An extension point is a place in the UI which you make extendable by other plugins using extensions. These extensions can either be links or React components that can implement virtually anything. 
+
+In the extension point you can control how you want to handle the displaying of extensions to users. You can also share contextual information with the extensions using a `context` object or component props. Refer to the examples below to learn more.
 
 You can also share contextual information with the extensions using a `context` object or component props (see the following examples).
 


### PR DESCRIPTION
### What changed?
With [making the extensions registry reactive](https://github.com/grafana/grafana/pull/83085), we need to update the docs as well to give information about the React hooks and what other implications the change might causes.

[View it on dev &rarr;](https://grafana-dev.com/developers/plugin-tools/ui-extensions/create-an-extension-point)