### PR TITLE
Create Plugins: Use non dev docker image on e2e

### DIFF
--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -142,7 +142,8 @@ services:
     build:
       context: ./.config
       args:
-        development: "false"
+        development: ${DEVELOPMENT:-true}
 ```
 
 Doing that, the docker environment will only run grafana and load the content of your projects `dist` directory. Thefore before doing that you should build your plugin with `mage -v build:backend` and <SyncCommand cmd="run server" /> to generate the plugin files.
+In the example you can also use the `DEVELOPMENT` environment variable to control the development mode.

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       args:
         grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}} }
         grafana_version: ${GRAFANA_VERSION:-{{~grafanaVersion~}} }
+        development: ${DEVELOPMENT:-true}
     ports:
       - 3000:3000/tcp
 {{#if hasBackend}}

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Start Grafana
         run: |
           docker-compose pull
-          DEVELOPMENT="false" GRAFANA_VERSION=$\{{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=$\{{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+          DEVELOPMENT=false GRAFANA_VERSION=$\{{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=$\{{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Start grafana docker
         if: steps.check-for-e2e.outputs.has-e2e == 'true'
         run: docker-compose up -d
+        env:
+          DEVELOPMENT: "false"
 
       - name: Wait for Grafana to start
         if: steps.check-for-e2e.outputs.has-e2e == 'true'

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Start Grafana
         run: |
           docker-compose pull
-          GRAFANA_VERSION=$\{{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=$\{{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+          DEVELOPMENT="false" GRAFANA_VERSION=$\{{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=$\{{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

1. This PR changes the `docker-compose.yaml` template to add the possibility to run commands `DEVELOPMENT=false docker compose up -d` to easily disable the development mode in our docker environment.
2. Change the e2e ci template to use the non development docker image which is lighter and faster to build than the development one.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.8.0-canary.883.4c6a829.0
  npm install @grafana/plugin-e2e@1.2.0-canary.883.4c6a829.0
  # or 
  yarn add @grafana/create-plugin@4.8.0-canary.883.4c6a829.0
  yarn add @grafana/plugin-e2e@1.2.0-canary.883.4c6a829.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
