### PR TITLE
Create plugin: CI workflow improvements

### DIFF
--- a/docusaurus/docs/e2e-test-a-plugin/ci.md
+++ b/docusaurus/docs/e2e-test-a-plugin/ci.md
@@ -46,9 +46,9 @@ queryString="current-package-manager"
   <summary> <h3>Frontend plugin workflow</h3> </summary>
   <CodeSnippets
 snippets={[
-{ component: BEPluginWorkflowNPM, label: 'npm' },
-{ component: BEPluginWorkflowYarn, label: 'yarn' },
-{ component: BEPluginWorkflowPNPM, label: 'pnpm' }
+{ component: FEPluginNPM, label: 'npm' },
+{ component: FEPluginYarn, label: 'yarn' },
+{ component: FEPluginPNPM, label: 'pnpm' }
 ]}
 groupId="package-manager"
 queryString="current-package-manager"

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.npm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.npm.md
@@ -72,6 +72,8 @@ jobs:
         id: run-tests
         run: npx playwright test
 
+      # If your repository is public, uploading the Playwright report will make it public on the Internet.
+      # Beware not to expose sensitive information.
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.npm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.npm.md
@@ -72,13 +72,13 @@ jobs:
         id: run-tests
         run: npx playwright test
 
-      # If your repository is public, uploading the Playwright report will make it public on the Internet.
-      # Beware not to expose sensitive information.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
-        with:
-          name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
-          retention-days: 30
+      # Uncomment this step to upload the Playwright report to Github artifacts.
+      # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
+      #   with:
+      #     name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
+      #     path: playwright-report/
+      #     retention-days: 30
 ```

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.pnpm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.pnpm.md
@@ -74,6 +74,8 @@ jobs:
         id: run-tests
         run: pnpm playwright test
 
+      # If your repository is public, uploading the Playwright report will make it public on the Internet.
+      # Beware not to expose sensitive information.
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{(always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.pnpm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.pnpm.md
@@ -74,13 +74,13 @@ jobs:
         id: run-tests
         run: pnpm playwright test
 
-      # If your repository is public, uploading the Playwright report will make it public on the Internet.
-      # Beware not to expose sensitive information.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{(always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
-        with:
-          name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
-          retention-days: 30
+      # Uncomment this step to upload the Playwright report to Github artifacts.
+      # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: ${{(always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
+      #   with:
+      #     name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
+      #     path: playwright-report/
+      #     retention-days: 30
 ```

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.yarn.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.yarn.md
@@ -72,6 +72,8 @@ jobs:
         id: run-tests
         run: yarn playwright test
 
+      # If your repository is public, uploading the Playwright report will make it public on the Internet.
+      # Beware not to expose sensitive information.
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.yarn.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.yarn.md
@@ -72,13 +72,13 @@ jobs:
         id: run-tests
         run: yarn playwright test
 
-      # If your repository is public, uploading the Playwright report will make it public on the Internet.
-      # Beware not to expose sensitive information.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
-        with:
-          name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
-          retention-days: 30
+      # Uncomment this step to upload the Playwright report to Github artifacts.
+      # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
+      #   with:
+      #     name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
+      #     path: playwright-report/
+      #     retention-days: 30
 ```

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.npm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.npm.md
@@ -64,6 +64,8 @@ jobs:
         id: run-tests
         run: npx playwright test
 
+      # If your repository is public, uploading the Playwright report will make it public on the Internet.
+      # Beware not to expose sensitive information.
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.npm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.npm.md
@@ -64,13 +64,13 @@ jobs:
         id: run-tests
         run: npx playwright test
 
-      # If your repository is public, uploading the Playwright report will make it public on the Internet.
-      # Beware not to expose sensitive information.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
-        with:
-          name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
-          retention-days: 30
+      # Uncomment this step to upload the Playwright report to Github artifacts.
+      # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
+      #   with:
+      #     name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
+      #     path: playwright-report/
+      #     retention-days: 30
 ```

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.pnpm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.pnpm.md
@@ -66,6 +66,8 @@ jobs:
         id: run-tests
         run: pnpm playwright test
 
+      # If your repository is public, uploading the Playwright report will make it public on the Internet.
+      # Beware not to expose sensitive information.
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.pnpm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.pnpm.md
@@ -66,13 +66,13 @@ jobs:
         id: run-tests
         run: pnpm playwright test
 
-      # If your repository is public, uploading the Playwright report will make it public on the Internet.
-      # Beware not to expose sensitive information.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
-        with:
-          name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
-          retention-days: 30
+      # Uncomment this step to upload the Playwright report to Github artifacts.
+      # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
+      #   with:
+      #     name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
+      #     path: playwright-report/
+      #     retention-days: 30
 ```

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.yarn.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.yarn.md
@@ -64,13 +64,13 @@ jobs:
         id: run-tests
         run: yarn playwright test
 
-      # If your repository is public, uploading the Playwright report will make it public on the Internet.
-      # Beware not to expose sensitive information.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
-        with:
-          name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
-          path: playwright-report/
-          retention-days: 30
+      # Uncomment this step to upload the Playwright report to Github artifacts.
+      # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}
+      #   with:
+      #     name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
+      #     path: playwright-report/
+      #     retention-days: 30
 ```

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.yarn.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.yarn.md
@@ -64,6 +64,8 @@ jobs:
         id: run-tests
         run: yarn playwright test
 
+      # If your repository is public, uploading the Playwright report will make it public on the Internet.
+      # Beware not to expose sensitive information.
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: ${{ (always() && steps.run-tests.outcome == 'success') || (failure() && steps.run-tests.outcome == 'failure') }}

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           interval: 500
 
       - name: Install Playwright Browsers
-        run: {{ packageManagerName }} playwright install chromium --with-deps
+        run: {{ packageManagerName }} exec playwright install chromium --with-deps
 
       - name: Run Playwright tests
         id: run-tests

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
           name: $\{{ matrix.GRAFANA_IMAGE.NAME }}-v$\{{ matrix.GRAFANA_IMAGE.VERSION }}-$\{{github.run_id}}-server-log
           path: grafana-server.log
           retention-days: 5
-
+  
       # If your repository is public, uploading the Playwright report will make it public on the Internet.
       # Beware not to expose sensitive information.
       - name: Upload artifacts
@@ -213,3 +213,14 @@ jobs:
           name: playwright-report-$\{{ matrix.GRAFANA_IMAGE.NAME }}-v$\{{ matrix.GRAFANA_IMAGE.VERSION }}-$\{{github.run_id}}
           path: playwright-report/
           retention-days: 5
+
+{{#if_eq orgName "grafana"}}
+      # Repos in the grafana Github org can publish the report to GCS so that they can be browsed without having to download them.
+      # Beware this will make the report public on the Internet, so do not uncomment this step if the report contains sensitive information.
+      # - name: Publish report to GCS
+      #   if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
+      #   uses: grafana/plugin-actions/publish-report@main
+      #   with:
+      #     grafana-version: ${{ matrix.GRAFANA_IMAGE.VERSION }}
+      #     path: playwright-report
+{{/if_eq}}

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           interval: 500
 
       - name: Install Playwright Browsers
-        run: npx playwright install chromium --with-deps
+        run: {{ packageManagerName }} playwright install chromium --with-deps
 
       - name: Run Playwright tests
         id: run-tests

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -11,11 +11,7 @@ on:
       - master
       - main
 
-permissions:
-  contents: read
-{{#if_eq orgName "grafana"}}
-  id-token: write
-{{/if_eq}}
+permissions: read-all
 
 jobs:
   build:
@@ -217,14 +213,3 @@ jobs:
           name: playwright-report-$\{{ matrix.GRAFANA_IMAGE.NAME }}-v$\{{ matrix.GRAFANA_IMAGE.VERSION }}-$\{{github.run_id}}
           path: playwright-report/
           retention-days: 5
-
-{{#if_eq orgName "grafana"}}
-      # Repos in the grafana Github org can publish the report to GCS so that they can be browsed without having to download them.
-      # This will make the report public on the Internet, so beware to skip this step if the report contains sensitive information.
-      - name: Publish report to GCS
-        if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
-        uses: grafana/plugin-actions/publish-report@main
-        with:
-          grafana-version: ${{ matrix.GRAFANA_IMAGE.VERSION }}
-          path: playwright-report
-{{/if_eq}}

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -216,11 +216,11 @@ jobs:
 
 {{#if_eq orgName "grafana"}}
       # Repos in the grafana Github org can publish the report to GCS so that they can be browsed without having to download them.
-      # Beware this will make the report public on the Internet, so do not uncomment this step if the report contains sensitive information.
-      # - name: Publish report to GCS
-      #   if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
-      #   uses: grafana/plugin-actions/publish-report@main
-      #   with:
-      #     grafana-version: ${{ matrix.GRAFANA_IMAGE.VERSION }}
-      #     path: playwright-report
+      # This will make the report public on the Internet, so beware to skip this step if the report contains sensitive information.
+      - name: Publish report to GCS
+        if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
+        uses: grafana/plugin-actions/publish-report@main
+        with:
+          grafana-version: ${{ matrix.GRAFANA_IMAGE.VERSION }}
+          path: playwright-report
 {{/if_eq}}

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ on:
       - master
       - main
 
-permissions: read-all
+permissions:
+  contents: read
+{{#if_eq orgName "grafana"}}
+  id-token: write
+{{/if_eq}}
 
 jobs:
   build:

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -141,11 +141,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            provisioning
-            tests
-            .config
 
       - name: Download plugin
         if: needs.build.outputs.has-backend == 'true'

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -204,12 +204,12 @@ jobs:
           path: grafana-server.log
           retention-days: 5
   
-      # If your repository is public, uploading the Playwright report will make it public on the Internet.
-      # Beware not to expose sensitive information.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
-        with:
-          name: playwright-report-$\{{ matrix.GRAFANA_IMAGE.NAME }}-v$\{{ matrix.GRAFANA_IMAGE.VERSION }}-$\{{github.run_id}}
-          path: playwright-report/
-          retention-days: 5
+      # Uncomment this step to upload the Playwright report to Github artifacts.
+      # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v4
+      #   if: $\{{ always() && steps.run-tests.outcome == 'failure' }}
+      #   with:
+      #     name: playwright-report-$\{{ matrix.GRAFANA_IMAGE.NAME }}-v$\{{ matrix.GRAFANA_IMAGE.VERSION }}-$\{{github.run_id}}
+      #     path: playwright-report/
+      #     retention-days: 5


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is making a few changes to the e2e related workflow bits:
* Use the right snippet in the article that walks through how to run e2e tests in ci
* Not doing a sparse checkout of the repo anymore in the e2e test job. Doing a sparse checkout have little benefits, and may cause confusion when contributors wants to go beyond the basic steps in the workflow. See [this](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1713902551454569) thread for example. 
* Adds step that uploads Playwright report to GCS in case org is Grafana. Please note that even though someone were to falsely specify grafana as the org, this step would still not work for them as it requires access to id-tokens that are only available for repos within the grafana org. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.7.1-canary.890.babb00f.0
  npm install @grafana/plugin-e2e@1.1.2-canary.890.babb00f.0
  # or 
  yarn add @grafana/create-plugin@4.7.1-canary.890.babb00f.0
  yarn add @grafana/plugin-e2e@1.1.2-canary.890.babb00f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
