### PR TITLE
Create plugin: update scaffolded tests when creating an app plugin

### DIFF
--- a/packages/create-plugin/templates/app/tests/appConfig.spec.ts
+++ b/packages/create-plugin/templates/app/tests/appConfig.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures';
 
 test('should be possible to save app configuration', async ({ appConfigPage, page }) => {
-  const saveForm = page.getByRole('button', { name: /Save API settings/i });
+  const saveButton = page.getByRole('button', { name: /Save API settings/i });
 
   // reset the configured secret
   await page.getByRole('button', { name: /reset/i }).click();
@@ -14,6 +14,6 @@ test('should be possible to save app configuration', async ({ appConfigPage, pag
   // listen for the server response on the saved form
   const saveResponse = appConfigPage.waitForSettingsResponse();
 
-  await saveForm.click();
+  await saveButton.click();
   await expect(saveResponse).toBeOK();
 });

--- a/packages/create-plugin/templates/app/tests/appNavigation.spec.ts
+++ b/packages/create-plugin/templates/app/tests/appNavigation.spec.ts
@@ -1,26 +1,25 @@
-import pluginJson from '../src/plugin.json';
-import { test, expect } from '@grafana/plugin-e2e';
+import { test, expect } from './fixtures';
 import { ROUTES } from '../src/constants';
 
 test.describe('navigating app', () => {
-  test('page one should render successfully', async ({ page }) => {
-    await page.goto(`/a/${pluginJson.id}/${ROUTES.One}`);
+  test('page one should render successfully', async ({ gotoPage, page }) => {
+    await gotoPage(`/${ROUTES.One}`);
     await expect(page.getByText('This is page one.')).toBeVisible();
   });
 
-  test('page two should render successfully', async ({ page }) => {
-    await page.goto(`/a/${pluginJson.id}/${ROUTES.Two}`);
+  test('page two should render successfully', async ({ gotoPage, page }) => {
+    await gotoPage(`/${ROUTES.Two}`);
     await expect(page.getByText('This is page two.')).toBeVisible();
   });
 
-  test('page three should support an id parameter', async ({ page }) => {
-    await page.goto(`/a/${pluginJson.id}/${ROUTES.Three}/123456`);
+  test('page three should support an id parameter', async ({ gotoPage, page }) => {
+    await gotoPage(`/${ROUTES.Three}/123456`);
     await expect(page.getByText('ID: 123456')).toBeVisible();
   });
 
-  test('page three should render sucessfully', async ({ page }) => {
+  test('page three should render sucessfully', async ({ gotoPage, page }) => {
     // wait for page to successfully render
-    await page.goto(`/a/${pluginJson.id}/${ROUTES.One}`);
+    await gotoPage(`/${ROUTES.One}`);
     await expect(page.getByText('This is page one.')).toBeVisible();
 
     // navigating to page four with full width layout without sidebar menu

--- a/packages/create-plugin/templates/app/tests/fixtures.ts
+++ b/packages/create-plugin/templates/app/tests/fixtures.ts
@@ -1,18 +1,25 @@
-import { AppConfigPage, test as base } from '@grafana/plugin-e2e';
+import { AppConfigPage, AppPage, test as base } from '@grafana/plugin-e2e';
 import pluginJson from '../src/plugin.json';
 
-type AppTestFixture = { appConfigPage: AppConfigPage };
+type AppTestFixture = {
+  appConfigPage: AppConfigPage;
+  gotoPage: (path?: string) => Promise<AppPage>;
+};
 
 export const test = base.extend<AppTestFixture>({
-  appConfigPage: async ({ page, selectors, grafanaVersion, request }, use, testInfo) => {
-    const configPage = new AppConfigPage(
-      { page, selectors, grafanaVersion, request, testInfo },
-      {
-        pluginId: pluginJson.id,
-      }
-    );
-    await configPage.goto();
+  appConfigPage: async ({ gotoAppConfigPage }, use) => {
+    const configPage = await gotoAppConfigPage({
+      pluginId: pluginJson.id,
+    });
     await use(configPage);
+  },
+  gotoPage: async ({ gotoAppPage }, use) => {
+    await use((path) =>
+      gotoAppPage({
+        path,
+        pluginId: pluginJson.id,
+      })
+    );
   },
 });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR will update the E2E tests scaffolded when creating an app plugin to use the latest and the greatest APIs from plugin-e2e. Instead of repeating the pluginId in multiple tests we define it once in the test fixture.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.8.0-canary.892.e66359c.0
  npm install @grafana/plugin-e2e@1.2.0-canary.892.e66359c.0
  # or 
  yarn add @grafana/create-plugin@4.8.0-canary.892.e66359c.0
  yarn add @grafana/plugin-e2e@1.2.0-canary.892.e66359c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
