### PR TITLE
Improve content and order for the frontend data proxy documentation

### DIFF
--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -91,7 +91,7 @@ export class DataSource extends DataSourceApi {
 
   async query(options: DataQueryRequest): Promise<DataQueryResponse> {
     const response = getBackendSrv().fetch<TODO[]>({
-      // see `this.baseUrl` set in the constructor
+      // You can see above that `this.baseUrl` is set in the constructor
       // in this example we assume the configured url is
       // https://jsonplaceholder.typicode.com
       /// if you inspect `this.baseUrl` you'll see the Grafana data proxy url

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -28,7 +28,7 @@ This guide explains how the data proxy works and explores common issues in its u
 Instead of performing a request directly from the browser to the server, you perform the request through the Grafana backend server, which handles it and returns the response to the plugin.
 
 - **Without data proxy**: The requests go directly from the browser to the third-party server.
-- **With data proxy**: The requests go from the browser to the Grafana backend and then to the third-party server. In this case, there are no restrictions in CORS, and you can instruct Grafana to send the request authenticated or using sensitive data stored in the plugin configuration.
+- **With data proxy**: The requests go from the browser to the Grafana backend and then to the third-party server. In this case, there are no restrictions in CORS, and you can instruct Grafana to send the request authenticated by using sensitive data stored in the plugin configuration.
 
 :::note
 You can only make use of the data proxy from data source and app plugins. _You can't use the data proxy from panel plugins._

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -208,7 +208,7 @@ const dataProxyUrl = `api/plugin-proxy/${PLUGIN_ID}/yourRoutePath`;
 
 Here is an example of a function that fetches data from the data proxy in an app plugin:
 
-Declare the route in `src/plugin.json`. You may also use authenticated requests and jsonData interpolation like in data source plugins.
+Declare the route in `src/plugin.json`. You may also use authenticated requests and `jsonData` interpolation like in data source plugins.
 
 ```json title="src/plugin.json"
 "routes": [

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -196,7 +196,7 @@ export function ConfigEditor(props: Props) {
 
 In your data source plugin, you can now fetch data by using the proxy URL.
 
-See the [previous example](#step-2-create-your-configuration-page) as the code is the same.
+Refer to the [previous example](#step-2-create-your-configuration-page), as the code is the same.
 
 ## Use the data proxy within an app plugin
 

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -58,7 +58,7 @@ export function ConfigEditor(props: DataSourcePluginOptionsEditorProps) {
 }
 ```
 
-The `DataSourceHttpSettings` will display a form with all the options for the user to configure an http endpoint, including authentication, TLS, cookies and timeout.
+The `DataSourceHttpSettings` will display a form with all the options for the user to configure an HTTP endpoint, including authentication, TLS, cookies, and timeout.
 
 ### Step 2: Use the data proxy in your data source plugin
 

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -200,7 +200,7 @@ Refer to the [previous example](#step-2-create-your-configuration-page), as the 
 
 ## Use the data proxy within an app plugin
 
-The setup of routes in your `plugin.json` metadata remains the same as in a data source plugin; however, since app plugins don't receive the URL as part of the props, the URL is constructed like this:
+The setup of routes in your `plugin.json` metadata remains the same as in a data source plugin. However, since app plugins don't receive the URL as part of the props, the URL is constructed like this:
 
 ```typescript
 const dataProxyUrl = `api/plugin-proxy/${PLUGIN_ID}/yourRoutePath`;

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -271,21 +271,4 @@ With this configuration, the Grafana server output shows the requests going out 
 
 ## Send special headers using the data proxy
 
-You can send special headers using the data proxy. Here's an example of a route with special headers:
-
-```json title="src/plugin.json"
-"routes": [
-    {
-        "path": "example",
-        "url": "https://api.example.com",
-        "headers": [
-            {
-                "name": "MyHeader",
-                // you can also use jsonData interpolation in headers
-                "content": "{{ .JsonData.headerValue }}"
-            }
-        ]
-    }]
-```
-
-Notice you can also use `.jsonData` interpolation when configuring headers.
+You can send special headers using the data proxy. To learn about adding headers to the data proxy, refer to our [documentation](./add-authentication-for-data-source-plugins.md).

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -151,7 +151,7 @@ You first need to set up the routes in your `plugin.json` metadata.
 ],
 ```
 
-Notice the `url` value contains an interpolation of the `apiUrl` from the `jsonData`. Your configuration page must set `apiUrl` in the Configuration page from user input.
+Notice that the `url` value contains an interpolation of `jsonData.apiUrl`. Your configuration page must take care of setting the `apiUrl` in the `jsonData` object based on the user input.
 
 :::note
 You must build your plugin and restart the Grafana server every time you modify your `plugin.json` file.

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -62,7 +62,7 @@ The `DataSourceHttpSettings` will display a form with all the options for the us
 
 ### Step 2: Use the data proxy in your data source plugin
 
-Once the user has entered the endpoint details in the data source configuration page, you can query the data proxy url that is passed in the data source instanceSettings (`DataSourceInstanceSettings.url`).
+Once the user has entered the endpoint details in the data source configuration page, you can query the data proxy URL that is passed in the data source instance settings (`DataSourceInstanceSettings.url`).
 
 ```typescript title="src/dataSource.ts"
 import {

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -27,46 +27,51 @@ This guide explains how the data proxy works and explores common issues in its u
 
 Instead of performing a request directly from the browser to the server, you perform the request through the Grafana backend server, which handles it and returns the response to the plugin.
 
-- **Without data proxy**: Without a data proxy the requests go directly from the browser to the third-party server.
-- **With data proxy**: Because the request to the third-party server happens from the Grafana backend, there are no restrictions in CORS, and you can instruct Grafana to send the request authenticated or using sensitive data stored in the plugin configuration.
-
-## How to use the data proxy
-
-Notice that you can only make use of the data proxy from data source and app plugins. _You can't use the data proxy from panel plugins._
-
-### Step 1: Declare your route in your plugin metadata
-
-You first need to set up the routes in your `plugin.json` metadata.
-
-```json title="src/plugin.json"
-"routes": [
-	{
-	  "path": "placeholder",
-	  "url": "https://jsonplaceholder.typicode.com"
-	}
-],
-```
-
-You can see more advanced options to define your routes to include dynamic parameters.
+- **Without data proxy**: The requests go directly from the browser to the third-party server.
+- **With data proxy**: The requests go from the browser to the Grafana backend and then to the third-party server. In this case, there are no restrictions in CORS, and you can instruct Grafana to send the request authenticated or using sensitive data stored in the plugin configuration.
 
 :::note
-
-You must build your plugin and restart the Grafana server every time you modify your `plugin.json` file.
-
+You can only make use of the data proxy from data source and app plugins. _You can't use the data proxy from panel plugins._
 :::
 
-### Step 2: Fetch data from your frontend code
+## How to use the data proxy in data source plugins
 
-In your data source plugin, you can now fetch data by using the proxy URL. Here's a minimal example for your data source plugin using [JSONPlaceholder](https://jsonplaceholder.typicode.com/):
+The easiest way to use the data proxy from a datasource plugin is using the [`DataSourceHttpSettings`](https://developers.grafana.com/ui/latest/index.html?path=/docs/data-source-datasourcehttpsettings--docs) component.
 
-```typescript
+### Step 1: Use the `DataSourceHttpSettings` component in your data source plugin configuration page
+
+```typescript title="src/ConfigEditor.tsx"
+import React from 'react';
+import { DataSourceHttpSettings } from '@grafana/ui';
+import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+
+export function ConfigEditor(props: DataSourcePluginOptionsEditorProps) {
+  const { onOptionsChange, options } = props;
+
+  return (
+    <DataSourceHttpSettings
+      defaultUrl="https://jsonplaceholder.typicode.com/"
+      dataSourceConfig={options}
+      onChange={onOptionsChange}
+    />
+  );
+}
+```
+
+The `DataSourceHttpSettings` will display a form with all the options for the user to configure an http endpoint, including authentication, TLS, cookies and timeout.
+
+### Step 2: Use the data proxy in your data source plugin
+
+Once the user had input the endpoint details in the data source configuration page, you can query the data proxy url that is passed in the data source instanceSettings (`DataSourceInstanceSettings.url`).
+
+```typescript title="src/dataSource.ts"
 import {
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
   DataSourceInstanceSettings,
   FieldType,
-  MutableDataFrame,
+  PartialDataFrame,
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
@@ -86,10 +91,11 @@ export class DataSource extends DataSourceApi {
 
   async query(options: DataQueryRequest): Promise<DataQueryResponse> {
     const response = getBackendSrv().fetch<TODO[]>({
-      // notice we are using the `placeholder` as defined
-      // in the routes "path". Everything passed after will
-      // be appended to the API URL
-      url: `${this.baseUrl}/placeholder/todos`,
+      // see `this.baseUrl` set in the constructor
+      // in this example we assume the configured url is
+      // https://jsonplaceholder.typicode.com
+      /// if you inspect `this.baseUrl` you'll see the Grafana data proxy url
+      url: `${this.baseUrl}/todos`,
     });
     // backendSrv fetch returns an observable object
     // we should unwrap with rxjs
@@ -99,14 +105,14 @@ export class DataSource extends DataSourceApi {
     // we'll return the same todos for all queries in this example
     // in a real data source each target should fetch the data
     // as necessary.
-    const data = options.targets.map((target) => {
-      return new MutableDataFrame({
+    const data: PartialDataFrame[] = options.targets.map((target) => {
+      return {
         refId: target.refId,
         fields: [
           { name: 'Id', type: FieldType.number, values: todos.map((todo) => todo.id) },
           { name: 'Title', type: FieldType.string, values: todos.map((todo) => todo.title) },
         ],
-      });
+      };
     });
 
     return { data };
@@ -121,30 +127,42 @@ export class DataSource extends DataSourceApi {
 }
 ```
 
-## Dynamic values and settings interpolation in routes
+:: note
+The user must first configure the data source in the configuration page before the data source can query
+the endpoint via the data source. If the data source is not configured, the data proxy won't know which
+endpoint to send the request to.
+::
 
-You can use dynamic values for handling user input, authenticating requests, debugging, or handling special headers.
+## How to use the data proxy in data source plugins with a custom configuration page
 
-### Interpolation with user-provided values
+If you don't want to use the `DataSourceHttpSettings` component and instead create your own configuration page
+you will have to do some additonal setup in your plugin.
 
-It is most likely that your plugin won't have a hard-coded API URL, but it will instead use user-provided values. For these cases, you can use interpolation of variables in your routes.
+### Step 1: Declare your route in your plugin metadata
 
-**Example:**
+You first need to set up the routes in your `plugin.json` metadata.
 
 ```json title="src/plugin.json"
 "routes": [
 	{
-	  "path": "interpolation",
+	  "path": "myRoutePath",
 	  "url": "{{ .JsonData.apiUrl }}"
 	}
 ],
 ```
 
-The configuration page should ask the user to populate this `apiUrl`. Grafana uses the `apiUrl` value when calling this endpoint.
+Notice the `url` value contains an interpolation of the `apiUrl` from the `jsonData`. Your configuration page must set `apiUrl` in the Configuration page from user input.
 
-Here's an example of a configuration form:
+:::note
+You must build your plugin and restart the Grafana server every time you modify your `plugin.json` file.
+:::
+
+### Step 2: Create your configuration page
 
 ```typescript title="src/ConfigEditor.tsx"
+import React, { ChangeEvent } from 'react';
+import { InlineField, Input } from '@grafana/ui';
+
 export function ConfigEditor(props: Props) {
   const { onOptionsChange, options } = props;
   const { jsonData } = options;
@@ -169,23 +187,55 @@ export function ConfigEditor(props: Props) {
         width={40}
       />
     </InlineField>
+    {/* The rest of your configuration page form */}
   );
 }
 ```
 
-Once the field is set correctly, you may use it inside your data source. Following the previous example for the data source code, you can now simply use it like so:
+### Step 3: Fetch data from your frontend code
+
+In your data source plugin, you can now fetch data by using the proxy URL.
+
+See the [previous example](#step-2-create-your-configuration-page) as the code is the same.
+
+## Use the data proxy within an app plugin
+
+The setup of routes in your `plugin.json` metadata remains the same as in a data source plugin; however, since app plugins don't receive the URL as part of the props, the URL is constructed like this:
 
 ```typescript
-const response = getBackendSrv().fetch<TODO[]>({
-  // Notice we use `interpolation` as defined
-  // in the route path.
-  // See the previous examples to see where
-  // this.baseUrl comes from.
-  url: `${this.baseUrl}/interpolation`,
-});
+const dataProxyUrl = `api/plugin-proxy/${your - plugin - id}/yourRoutePath`;
 ```
 
-### Use other HTTP methods (for example, POST, PUT, DELETE) with the data proxy
+Here is an example of a function that fetches data from the data proxy in an app plugin:
+
+Declare the route in `src/plugin.json`. You may also use authenticated requests and jsonData interpolation like in data source plugins.
+
+```json title="src/plugin.json"
+"routes": [
+{
+        "path": "myRoutePath",
+        "url": "https://api.example.com",
+        // jsonData interpolation is also possible
+        //"url": "{{ .JsonData.apiUrl }}",
+}]
+```
+
+In your App plugin code you can then fetch data using the data proxy by constructing the data proxy url like this.
+
+```typescript title="src/dataproxy-api-example.ts"
+import { getBackendSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
+
+async function getDataFromApi() {
+  const dataProxyUrl = `api/plugin-proxy/${your - plugin - id}/myRoutePath`;
+  const response = getBackendSrv().fetch<TODO[]>({
+    url: dataProxyUrl,
+  });
+  return await lastValueFrom(response);
+}
+```
+
+## Use other HTTP methods (for example, POST, PUT, DELETE) with the data proxy
 
 You can specify the method directly in the `fetch` method. Your routes in `src/plugin.json` remain the same:
 
@@ -197,11 +247,11 @@ const response = getBackendSrv().fetch<TODO[]>({
 });
 ```
 
-### Add authentication to your requests using the data proxy
+## Add authentication to your requests using the data proxy
 
 To learn about adding authentication to the data proxy, refer to our [documentation](./add-authentication-for-data-source-plugins.md).
 
-### Debug requests from the data proxy
+## Debug requests from the data proxy
 
 If you want to debug the requests that are going from the Grafana backend to your API, enable the data proxy logging in the [configuration](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#dataproxy).
 
@@ -219,34 +269,23 @@ logging = true
 
 With this configuration, the Grafana server output shows the requests going out to your API from the data proxy.
 
-### Send special headers using the data proxy
+## Send special headers using the data proxy
 
 You can send special headers using the data proxy. Here's an example of a route with special headers:
 
 ```json title="src/plugin.json"
 "routes": [
-{
-	"path": "example",
-	"url": "https://api.example.com",
-	"headers": [
-		{
-		"name": "MyHeader",
-		"content": "{{ .JsonData.headerValue }}"
-		}
-	]
-}]
+    {
+        "path": "example",
+        "url": "https://api.example.com",
+        "headers": [
+            {
+                "name": "MyHeader",
+                // you can also use jsonData interpolation in headers
+                "content": "{{ .JsonData.headerValue }}"
+            }
+        ]
+    }]
 ```
 
-## Use the data proxy within an app plugin
-
-The setup of routes in your `plugin.json` metadata remains the same as in a data source plugin; however, since app plugins don't receive the URL as part of the props, the URL is constructed like this:
-
-```typescript
-const url = `api/plugin-proxy/${meta.id}/yourRoutePath`;
-```
-
-:::note
-
-The plugin ID is not your plugin name (for example, `myorg-plugin-app`) but the app ID. The app ID is part of the meta prop passed to the app plugin constructor. You can also get the plugin meta inside React with the hook `usePluginContext()`.
-
-:::
+Notice you can also use `.jsonData` interpolation when configuring headers.

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -227,7 +227,7 @@ import { getBackendSrv } from '@grafana/runtime';
 import { lastValueFrom } from 'rxjs';
 
 async function getDataFromApi() {
-  const dataProxyUrl = `api/plugin-proxy/${your - plugin - id}/myRoutePath`;
+  const dataProxyUrl = `api/plugin-proxy/${PLUGIN_ID}/myRoutePath`;
   const response = getBackendSrv().fetch<TODO[]>({
     url: dataProxyUrl,
   });

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -220,7 +220,7 @@ Declare the route in `src/plugin.json`. You may also use authenticated requests 
 }]
 ```
 
-In your App plugin code you can then fetch data using the data proxy by constructing the data proxy url like this.
+In your app plugin's code, you can then fetch data using the data proxy by constructing the data proxy URL like this:
 
 ```typescript title="src/dataproxy-api-example.ts"
 import { getBackendSrv } from '@grafana/runtime';

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -203,7 +203,7 @@ See the [previous example](#step-2-create-your-configuration-page) as the code i
 The setup of routes in your `plugin.json` metadata remains the same as in a data source plugin; however, since app plugins don't receive the URL as part of the props, the URL is constructed like this:
 
 ```typescript
-const dataProxyUrl = `api/plugin-proxy/${your - plugin - id}/yourRoutePath`;
+const dataProxyUrl = `api/plugin-proxy/${PLUGIN_ID}/yourRoutePath`;
 ```
 
 Here is an example of a function that fetches data from the data proxy in an app plugin:

--- a/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
+++ b/docusaurus/docs/create-a-plugin/extend-a-plugin/fetch-data-from-frontend.md
@@ -62,7 +62,7 @@ The `DataSourceHttpSettings` will display a form with all the options for the us
 
 ### Step 2: Use the data proxy in your data source plugin
 
-Once the user had input the endpoint details in the data source configuration page, you can query the data proxy url that is passed in the data source instanceSettings (`DataSourceInstanceSettings.url`).
+Once the user has entered the endpoint details in the data source configuration page, you can query the data proxy url that is passed in the data source instanceSettings (`DataSourceInstanceSettings.url`).
 
 ```typescript title="src/dataSource.ts"
 import {


### PR DESCRIPTION
**What this PR does / why we need it**:

In a [previous PR](https://github.com/grafana/plugin-tools/pull/889) the document page about fetching data from frontend using the grafana data proxy was introduced.

This PR enhances the existing documentation by starting with a simpler approach using `DataSourceHttpSettings` and 
removing some complicated code from the App plugins usage example

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
