### PR TITLE
Create Plugin: polyfill `TextEncoder` for Jest tests in scaffolded plugins

### DIFF
--- a/packages/create-plugin/templates/common/.config/jest-setup.js
+++ b/packages/create-plugin/templates/common/.config/jest-setup.js
@@ -6,6 +6,9 @@
  */
 
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+                                                                                                          
+Object.assign(global, { TextDecoder, TextEncoder });
 
 // https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 Object.defineProperty(global, 'matchMedia', {

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -53,6 +53,7 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "4.8.4",
+    "util": "^0.12.5",
     "webpack": "^5.86.0",
     "webpack-cli": "^5.1.4",
     "webpack-livereload-plugin": "^3.0.2"

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -53,7 +53,6 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "4.8.4",
-    "util": "^0.12.5",
     "webpack": "^5.86.0",
     "webpack-cli": "^5.1.4",
     "webpack-livereload-plugin": "^3.0.2"


### PR DESCRIPTION
### What changed?

I started to see `ReferenceError: TextEncoder is not defined` errors when scaffolding an app plugin with the latest version of **create-plugin**, and polyfilling the `TextEncoder` seemed to solve the problem. I don't yet understand why this started to happen now, maybe due to an update in any of the `@grafana` packages? 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.9.3-canary.899.c6eb38b.0
  # or 
  yarn add @grafana/create-plugin@4.9.3-canary.899.c6eb38b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
