### PR TITLE
Chore: Run unit tests on the CI for every plugin scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,10 @@ jobs:
         run: npm run build
         working-directory: ./${{ matrix.workingDir }}
 
+      - name: Test plugin frontend
+        run: npm run test:ci
+        working-directory: ./${{ matrix.workingDir }}
+
       - name: Install playwright dependencies
         if: ${{ matrix.workingDir != 'myorg-nobackend-scenesapp' }}
         run: npm exec playwright install chromium


### PR DESCRIPTION
### What changed?

This PR updates the CI workflow to run the unit tests for every scaffolded plugin. For some reason we didn't have this until now - I am not sure if it is me missing something or we just forgot it / skipped it in the past.