### PR TITLE
Chore: removing version from docker compose file as it is deprecated

### DIFF
--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.0'
-
 services:
   grafana:
     user: root


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Specifying version in docker-compose file has been deprecated for a while and now it shows a warning. It still works properly but we can start removing it for newly scaffolded plugins as it has no value.

**Which issue(s) this PR fixes**:
It removes warnings like this:

```
docker-compose.yaml: `version` is obsolete
```
More on why https://docs.docker.com/compose/compose-file/04-version-and-name/
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
