### PR TITLE
Create plugin: Disable development mode by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,21 @@ jobs:
         run: npm run test:ci
         working-directory: ./${{ matrix.workingDir }}
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '~1.21'
+          check-latest: true
+          cache-dependency-path: ./${{ matrix.workingDir }}/go.sum
+        if: ${{ matrix.hasBackend == true }}
+
+      - name: Build plugin backend
+        uses: magefile/mage-action@v3
+        with:
+          version: latest
+          args: -v build:linux
+          workdir: ./${{ matrix.workingDir }}
+        if: ${{ matrix.hasBackend == true }}
+
       - name: Install playwright dependencies
         if: ${{ matrix.workingDir != 'myorg-nobackend-scenesapp' }}
         run: npm exec playwright install chromium
@@ -161,21 +176,6 @@ jobs:
           GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
         working-directory: ./${{ matrix.workingDir }}
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '~1.21'
-          check-latest: true
-          cache-dependency-path: ./${{ matrix.workingDir }}/go.sum
-        if: ${{ matrix.hasBackend == true }}
-
-      - name: Build plugin backend
-        uses: magefile/mage-action@v3
-        with:
-          version: latest
-          args: -v build:linux
-          workdir: ./${{ matrix.workingDir }}
-        if: ${{ matrix.hasBackend == true }}
 
   release:
     runs-on: ubuntu-latest

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -39,7 +39,7 @@ To start your plugin development project, run the following commands in the orde
 1. <SyncCommand cmd="run dev" />: Builds and watches the plugin frontend code.
 1. `mage -v build:linux`: Builds the plugin backend code. Rerun this command every time that you edit your backend files.
 1. <SyncCommand cmd="run server" />: Starts a Grafana development server running on
-   [http://localhost:3000](http://localhost:3000). The plugin will be reloaded on every code change and a debugger can be attached on port `2345`.
+   [http://localhost:3000](http://localhost:3000).
 
 ### Configure the Grafana version
 
@@ -76,7 +76,7 @@ This example assigns the environment variable `GRAFANA_IMAGE` to the build arg `
 
 ### Debugging Backend plugin
 
-If you're developing a plugin with a backend part, the docker compose file will also expose the port `2345` for debugging, from a headless delve instance running inside the docker environment.
+If you're developing a plugin with a backend part, run `npm run server` with `DEVELOPMENT=true`. The docker compose file exposes the port `2345` for debugging, from a headless delve instance that will run inside the docker environment.
 You can attach a debugger client to this port to debug your backend code.
 For example, in VSCode, you can add a `launch.json` configuration like this:
 
@@ -130,20 +130,3 @@ You will also notice that the `docker-compose.yaml` file also has the following 
 ```
 
 they are necessary to allow delve to attach to the running process and debug it and should not be used in production environments.
-
-If you wish to test your plugin in a environment closer to production you can disable the development mode by modifying the `docker-compose.yaml`:
-
-```yaml title="docker-compose.yaml"
-version: '3.7'
-
-services:
-  grafana:
-    container_name: 'myorg-basic-app'
-    build:
-      context: ./.config
-      args:
-        development: ${DEVELOPMENT:-true}
-```
-
-Doing that, the docker environment will only run grafana and load the content of your projects `dist` directory. Thefore before doing that you should build your plugin with `mage -v build:backend` and <SyncCommand cmd="run server" /> to generate the plugin files.
-In the example you can also use the `DEVELOPMENT` environment variable to control the development mode.

--- a/packages/create-plugin/src/commands/generate/print-success-message.ts
+++ b/packages/create-plugin/src/commands/generate/print-success-message.ts
@@ -16,10 +16,7 @@ export function printGenerateSuccessMessage(answers: TemplateData) {
           '- `mage -v build:linux` to build the plugin backend code. Rerun this command every time you edit your backend files.',
         ]
       : []),
-    '- `docker-compose up` to start a grafana development server. ' +
-      (answers.hasBackend
-        ? 'The plugin backend will be reloaded on every code change and a debugger can be attached on port `2345`.'
-        : ''),
+    '- `docker-compose up` to start a grafana development server.',
     '- Open http://localhost:3000 in your browser to create a dashboard to begin developing your plugin.',
   ];
 

--- a/packages/create-plugin/templates/backend-app/.vscode/launch.json
+++ b/packages/create-plugin/templates/backend-app/.vscode/launch.json
@@ -11,6 +11,23 @@
       "args": [
         "-standalone"
       ]
+    },
+    {
+      "name": "Attach to plugin backend in docker",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "showLog": true,
+      "trace": "log",
+      "logOutput": "rpc",
+      "substitutePath": [
+        {
+          "from": "${workspaceFolder}",
+          "to": "/root/{{ pluginId }}"
+        }
+      ]
     }
   ]
 }

--- a/packages/create-plugin/templates/backend/.vscode/launch.json
+++ b/packages/create-plugin/templates/backend/.vscode/launch.json
@@ -11,6 +11,23 @@
       "args": [
         "-standalone"
       ]
+    },
+    {
+      "name": "Attach to plugin backend in docker",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "port": 2345,
+      "host": "127.0.0.1",
+      "showLog": true,
+      "trace": "log",
+      "logOutput": "rpc",
+      "substitutePath": [
+        {
+          "from": "${workspaceFolder}",
+          "to": "/root/{{ pluginId }}"
+        }
+      ]
     }
   ]
 }

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -3,7 +3,7 @@ ARG grafana_image=grafana-enterprise
 
 FROM grafana/${grafana_image}:${grafana_version}
 
-ARG development=true
+ARG development=false
 
 {{#if hasBackend}}
 ARG GO_VERSION=1.21.6

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -3,7 +3,7 @@ ARG grafana_image=grafana-enterprise
 
 FROM grafana/${grafana_image}:${grafana_version}
 
-ARG development=false
+ARG development=true
 
 {{#if hasBackend}}
 ARG GO_VERSION=1.21.6

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       args:
         grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}} }
         grafana_version: ${GRAFANA_VERSION:-{{~grafanaVersion~}} }
-        development: ${DEVELOPMENT:-true}
+        development: ${DEVELOPMENT:-false}
     ports:
       - 3000:3000/tcp
 {{#if hasBackend}}

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       args:
         grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}} }
         grafana_version: ${GRAFANA_VERSION:-{{~grafanaVersion~}} }
-        development: ${DEVELOPMENT:-false}
+        development: ${DEVELOPMENT:-true}
     ports:
       - 3000:3000/tcp
 {{#if hasBackend}}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The backend debug environment isn't working correctly on macOS, while we fix the issue we are going to disable the development environment by default.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.10.4-canary.910.1cb4369.0
  # or 
  yarn add @grafana/create-plugin@4.10.4-canary.910.1cb4369.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

**Special notes for your reviewer**:
I also had to change the order of some steps in e2e tests in CI, because it was relying on the binary built by the development environment. Now since the development environment is disabled by default, we need to build the plugin binary before running the tests.
