### PR TITLE
Create Plugin: Improve handling of e2e in update cmd

### DIFF
--- a/packages/create-plugin/src/types.ts
+++ b/packages/create-plugin/src/types.ts
@@ -30,7 +30,6 @@ export type TemplateData = {
   reactRouterVersion: string;
   usePlaywright: boolean;
   useCypress: boolean;
-  e2eTestCmd: string;
   hasGithubWorkflows: boolean;
   hasGithubLevitateWorkflow: boolean;
 };

--- a/packages/create-plugin/src/types.ts
+++ b/packages/create-plugin/src/types.ts
@@ -29,6 +29,7 @@ export type TemplateData = {
   useReactRouterV6: boolean;
   reactRouterVersion: string;
   usePlaywright: boolean;
+  useCypress: boolean;
   e2eTestCmd: string;
   hasGithubWorkflows: boolean;
   hasGithubLevitateWorkflow: boolean;

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -107,10 +107,6 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
   const getReactRouterVersion = (pluginType: string) => (shouldUseReactRouterV6(pluginType) ? '6.22.0' : '5.2.0');
   const isAppType = (pluginType: string) => pluginType === PLUGIN_TYPES.app || pluginType === PLUGIN_TYPES.scenes;
   const isNPM = (packageManagerName: string) => packageManagerName === 'npm';
-  const getE2eTestCmd = (packageManagerName: string) =>
-    useCypress
-      ? `${packageManagerName} exec cypress install && ${packageManagerName} exec grafana-e2e run`
-      : 'playwright test';
 
   let templateData: TemplateData;
 
@@ -137,7 +133,6 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
       reactRouterVersion: getReactRouterVersion(cliArgs.pluginType),
       usePlaywright,
       useCypress,
-      e2eTestCmd: getE2eTestCmd(packageManagerName),
       hasGithubWorkflows: cliArgs.hasGithubWorkflows,
       hasGithubLevitateWorkflow: cliArgs.hasGithubLevitateWorkflow,
     };
@@ -167,7 +162,6 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
       reactRouterVersion: getReactRouterVersion(pluginJson.type),
       usePlaywright,
       useCypress,
-      e2eTestCmd: getE2eTestCmd(packageManagerName),
       hasGithubWorkflows: isFile(path.join(githubFolder, 'ci.yml')),
       hasGithubLevitateWorkflow: isFile(path.join(githubFolder, 'is-compatible.yml')),
     };

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -98,6 +98,7 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
   const currentVersion = getVersion();
   const grafanaVersion = EXTRA_TEMPLATE_VARIABLES.grafanaVersion;
   const usePlaywright = features.usePlaywright === true || isFile(path.join(process.cwd(), 'playwright.config.ts'));
+  //@grafana/e2e was deprecated in Grafana 11
   const useCypress =
     !usePlaywright && semverLt(grafanaVersion, '11.0.0') && fs.existsSync(path.join(process.cwd(), 'cypress'));
   const bundleGrafanaUI = features.bundleGrafanaUI ?? DEFAULT_FEATURE_FLAGS.bundleGrafanaUI;

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -11,7 +11,7 @@
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "{{ packageManagerName }} run lint{{#if isNPM}} --{{/if}} --fix",{{#if usePlaywright}}
     "e2e": "playwright test",{{/if}}{{#if useCypress}}
-    "e2e": "${packageManagerName} exec cypress install && ${packageManagerName} exec grafana-e2e run",
+    "e2e": "{{ packageManagerName }} exec cypress install && {{ packageManagerName }} exec grafana-e2e run",
     "e2e:update": "{{ packageManagerName }} exec cypress install && {{ packageManagerName }} exec grafana-e2e run --update-screenshots",{{/if}}
     "server": "docker-compose up --build",
     "sign": "npx --yes @grafana/sign-plugin@latest"
@@ -23,7 +23,7 @@
     "@grafana/e2e": "{{ grafanaVersion }}",
     "@grafana/e2e-selectors": "{{ grafanaVersion }}",{{/if}}
     "@grafana/eslint-config": "^7.0.0",{{#if usePlaywright}}
-    "@grafana/plugin-e2e": "^1.0.1",{{/if}}
+    "@grafana/plugin-e2e": "^1.2.0",{{/if}}
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@grafana/plugin-meta-extractor": "^0.0.2",{{#if usePlaywright}}
     "@playwright/test": "^1.41.2",{{/if}}

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -9,18 +9,19 @@
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "typecheck": "tsc --noEmit",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
-    "lint:fix": "{{ packageManagerName }} run lint{{#if isNPM}} --{{/if}} --fix",
-    "e2e": "{{{ e2eTestCmd }}}",{{#unless usePlaywright}}
-    "e2e:update": "{{ packageManagerName }} exec cypress install && {{ packageManagerName }} exec grafana-e2e run --update-screenshots",{{/unless}}
+    "lint:fix": "{{ packageManagerName }} run lint{{#if isNPM}} --{{/if}} --fix",{{#if usePlaywright}}
+    "e2e": "playwright test",{{/if}}{{#if useCypress}}
+    "e2e": "${packageManagerName} exec cypress install && ${packageManagerName} exec grafana-e2e run",
+    "e2e:update": "{{ packageManagerName }} exec cypress install && {{ packageManagerName }} exec grafana-e2e run --update-screenshots",{{/if}}
     "server": "docker-compose up --build",
     "sign": "npx --yes @grafana/sign-plugin@latest"
   },
   "author": "{{ sentenceCase orgName }}",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@babel/core": "^7.21.4",{{#unless usePlaywright}}
+    "@babel/core": "^7.21.4",{{#if useCypress}}
     "@grafana/e2e": "{{ grafanaVersion }}",
-    "@grafana/e2e-selectors": "{{ grafanaVersion }}",{{/unless}}
+    "@grafana/e2e-selectors": "{{ grafanaVersion }}",{{/if}}
     "@grafana/eslint-config": "^7.0.0",{{#if usePlaywright}}
     "@grafana/plugin-e2e": "^1.0.1",{{/if}}
     "@grafana/tsconfig": "^1.2.0-rc1",


### PR DESCRIPTION
**What this PR does / why we need it**:

While @Ukochka was updating the plugins in the example repo (see  [this](https://github.com/grafana/grafana-plugin-examples/pull/298) PR for example), we noticed the `create-plugin update` cmd is not behaving quite the way we want. In case the plugin did not have any e2e tests at all (Playwright nor Cypress), grafana/e2e scripts and deps were added to the package.json file. 

This PR ensures that cypress specific stuff should **only** be added to package.json in case: 
* playwright should be used
* Grafana version is lower than 11 (grafana/e2e was deprecated in 11)
* a `cypress` folder exist in the plugin root dir

**Which issue(s) this PR fixes**:
Fixes #919

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.10.5-canary.920.29fa67c.0
  # or 
  yarn add @grafana/create-plugin@4.10.5-canary.920.29fa67c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
