### PR TITLE
Docs: Remove prompts content from update command page

### DIFF
--- a/docusaurus/docs/migration-guides/update-create-plugin-versions.mdx
+++ b/docusaurus/docs/migration-guides/update-create-plugin-versions.mdx
@@ -27,4 +27,4 @@ To update an existing plugin to use a newer version of the `create-plugin` tool,
   queryString="current-package-manager"
 />
 
-This command reruns the original scaffolding commands against the configuration files, dependencies, and scripts. It automatically uses the latest version of the `create-plugin` tool. It prompts you to confirm any destructive operations before it runs.
+This command reruns the original scaffolding commands against the configuration files, dependencies, and scripts. It automatically uses the latest version of the `create-plugin` tool.

--- a/docusaurus/docs/migration-guides/update-create-plugin-versions.mdx
+++ b/docusaurus/docs/migration-guides/update-create-plugin-versions.mdx
@@ -17,7 +17,6 @@ import UpdateYarn from '@snippets/createplugin-update.yarn.md';
 
 To update an existing plugin to use a newer version of the `create-plugin` tool, run the following command:
 
-
 <CodeSnippets
   snippets={[
     { component: UpdateNPM, label: 'npm' },
@@ -28,35 +27,4 @@ To update an existing plugin to use a newer version of the `create-plugin` tool,
   queryString="current-package-manager"
 />
 
-
 This command reruns the original scaffolding commands against the configuration files, dependencies, and scripts. It automatically uses the latest version of the `create-plugin` tool. It prompts you to confirm any destructive operations before it runs.
-
-:::tip
-We recommended that you normally agree to all prompts so that configs, dependencies, and scripts are kept in sync.
-:::
-
-## Prompts
-
-When you run the `update` command, you are prompted with the following questions. The default for each prompt is `No`.
-
-### Would you like to update the project's configuration?
-
-Select `y` to replace the files inside the `.config` directory. By doing so, you can make sure that the plugin is built and tested with the latest Grafana recommended configurations.
-
-### Would you like to update the following dependencies in the `package.json`?
-
-Select from the following choices:
-
-- **`Yes, all of them`:** This updates all existing dependencies and adds any missing dependencies to `package.json`.
-- **`Yes, but only the outdated ones`:** This updates all existing dependencies in `package.json`.
-- **`No`:** This choice skips this step, thus preventing any dependency updates.
-
-Note that if there are no dependencies then you will not see this prompt.
-
-### Would you like to update the scripts in your `package.json`? All scripts using grafana-toolkit will be replaced.
-
-Select 'y' to update any npm scripts in the `package.json` file to match the latest configurations. Any scripts that previously used `grafana-toolkit` are replaced.
-
-:::warning
-We strongly recommend that you consult the [changelog](https://github.com/grafana/plugin-tools/blob/main/CHANGELOG.md) for potential breaking changes before making changes to your configuration.
-:::


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR removes the **Prompts** content from the create plugin update command docs page as they don't exist when the command if run these days...

![image](https://github.com/grafana/plugin-tools/assets/73201/cf1aa80c-241d-4dd5-91ab-d466eb240426)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
