### PR TITLE
Create-plugin: stop extracting plugin-meta on builds

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -12,7 +12,6 @@ import LiveReloadPlugin from 'webpack-livereload-plugin';
 import path from 'path';
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import { Configuration } from 'webpack';
-import { GrafanaPluginMetaExtractor } from '@grafana/plugin-meta-extractor';
 
 import { getPackageJson, getPluginJson, hasReadme, getEntries, isWSL } from './utils';
 import { SOURCE_DIR, DIST_DIR } from './constants';
@@ -143,7 +142,6 @@ const config = async (env): Promise<Configuration> => {
     },
 
     plugins: [
-      new GrafanaPluginMetaExtractor(),
       new CopyWebpackPlugin({
         patterns: [
           // If src/README.md exists use it; otherwise the root README


### PR DESCRIPTION
### What changed?

After [deciding to add extensions-related meta info to the `plugin.json` manually](https://github.com/grafana/grafana/pull/88288), we now remove the automatic plugin meta info extraction from the builds. (The reason is that we didn't manage to make this work reliably for most of our internal app plugins.)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.11.0-canary.923.7afbfd0.0
  # or 
  yarn add @grafana/create-plugin@4.11.0-canary.923.7afbfd0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
