### PR TITLE
Plugin meta extractor: add a warning to the README

### DIFF
--- a/packages/plugin-meta-extractor/README.md
+++ b/packages/plugin-meta-extractor/README.md
@@ -1,5 +1,8 @@
 # Grafana / Plugin Meta Extractor
 
+> [!WARNING]  
+> This is an experimental project and may change at any time. It is not yet used in any of our tools and does not reliably work with most of our app plugin implementation patterns.
+
 `@grafana/plugin-meta-extractor` is a cli tool that can be used to extract meta-information from the source code of a Grafana plugin. It is used to generate plugin metadata without the need for manual intervention, which is then used by the Grafana application to understand features or functionalities a plugin supports or uses.
 
 ## Install


### PR DESCRIPTION
### What changed?
Added a warning to the README of the `@grafana/plugin-meta-extractor`, to make it clear that it's still in an experimentation phase ([view how it would look like &rarr;](https://github.com/grafana/plugin-tools/blob/leventebalogh/plugin-meta-extractor-deprecation/packages/plugin-meta-extractor/README.md)).
![Screenshot 2024-05-27 at 11 20 02](https://github.com/grafana/plugin-tools/assets/9974811/8556c1e2-8946-4572-a553-07ca12c8e7f8)

Notes for the reviewer
I only added the `patch` and `release` labels to update the README on npmjs.com as well.