### PR TITLE
Plugin E2E: Allow overriding grafanaAPICredentials

### DIFF
--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -49,7 +49,6 @@ export default defineConfig<PluginOptions>({
         user: {
           user: 'admin',
           password: 'admin',
-          skipCreateUser: true,
         },
       },
     },

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -22,15 +22,10 @@ export default defineConfig<PluginOptions>({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:3000',
-
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     grafanaAPIUser: {
       user: 'admin',
-      password: 'admin',
-    },
-    httpCredentials: {
-      username: 'admin',
       password: 'admin',
     },
     featureToggles: {

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -25,6 +25,10 @@ export default defineConfig<PluginOptions>({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    grafanaAPIUser: {
+      user: 'admin',
+      password: 'admin',
+    },
     httpCredentials: {
       username: 'admin',
       password: 'admin',
@@ -41,6 +45,13 @@ export default defineConfig<PluginOptions>({
       name: 'authenticate',
       testDir: './src/auth',
       testMatch: [/.*auth\.setup\.ts/],
+      use: {
+        user: {
+          user: 'admin',
+          password: 'admin',
+          userExists: true,
+        },
+      },
     },
     // Login to Grafana with new user with viewer role and store the cookie on disk for use in other tests
     {

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -22,10 +22,15 @@ export default defineConfig<PluginOptions>({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:3000',
+
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     grafanaAPIUser: {
       user: 'admin',
+      password: 'admin',
+    },
+    httpCredentials: {
+      username: 'admin',
       password: 'admin',
     },
     featureToggles: {

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -49,7 +49,7 @@ export default defineConfig<PluginOptions>({
         user: {
           user: 'admin',
           password: 'admin',
-          userExists: true,
+          skipCreateUser: true,
         },
       },
     },

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig<PluginOptions>({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    grafanaAPIUser: {
+    grafanaAPICredentials: {
       user: 'admin',
       password: 'admin',
     },

--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -1,7 +1,7 @@
 import { test as setup } from '../';
 
 setup('authenticate', async ({ login, createUser, user }) => {
-  if (user && !user.skipCreateUser) {
+  if (user) {
     await createUser();
   }
   await login();

--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -1,7 +1,7 @@
 import { test as setup } from '../';
 
 setup('authenticate', async ({ login, createUser, user }) => {
-  if (user) {
+  if (user && !user.skipCreateUser) {
     await createUser();
   }
   await login();

--- a/packages/plugin-e2e/src/fixtures/commands/createUser.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createUser.ts
@@ -20,7 +20,7 @@ const getUserIdByUsername = async (
   return json.id;
 };
 
-export const createUser: CreateUserFixture = async ({ request, user, grafanaAPIUser }, use) => {
+export const createUser: CreateUserFixture = async ({ request, user, grafanaAPICredentials }, use) => {
   await use(async () => {
     if (!user) {
       throw new Error('Playwright option `User` was not provided');
@@ -32,7 +32,7 @@ export const createUser: CreateUserFixture = async ({ request, user, grafanaAPIU
         login: user?.user,
         password: user?.password,
       },
-      headers: getHeaders(grafanaAPIUser),
+      headers: getHeaders(grafanaAPICredentials),
     });
 
     let userId: number | undefined;
@@ -41,7 +41,7 @@ export const createUser: CreateUserFixture = async ({ request, user, grafanaAPIU
       userId = respJson.id;
     } else if (createUserReq.status() === 412) {
       // user already exists
-      userId = await getUserIdByUsername(request, user?.user, grafanaAPIUser);
+      userId = await getUserIdByUsername(request, user?.user, grafanaAPICredentials);
     } else {
       throw new Error(`Could not create user '${user?.user}': ${await createUserReq.text()}`);
     }
@@ -49,7 +49,7 @@ export const createUser: CreateUserFixture = async ({ request, user, grafanaAPIU
     if (user.role) {
       const updateRoleReq = await request.patch(`/api/org/users/${userId}`, {
         data: { role: user.role },
-        headers: getHeaders(grafanaAPIUser),
+        headers: getHeaders(grafanaAPICredentials),
       });
       const updateRoleReqText = await updateRoleReq.text();
       expect(

--- a/packages/plugin-e2e/src/fixtures/commands/createUser.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createUser.ts
@@ -1,22 +1,26 @@
 import { APIRequestContext, expect, TestFixture } from '@playwright/test';
-import { PlaywrightArgs } from '../../types';
+import { PlaywrightArgs, User } from '../../types';
 
 type CreateUserFixture = TestFixture<() => Promise<void>, PlaywrightArgs>;
 
-const headers = {
-  Authorization: `Basic ${Buffer.from(`admin:admin`).toString('base64')}`,
-};
+const getHeaders = (user: User) => ({
+  Authorization: `Basic ${Buffer.from(`${user.user}:${user.password}`).toString('base64')}`,
+});
 
-const getUserIdByUsername = async (request: APIRequestContext, userName: string): Promise<number> => {
+const getUserIdByUsername = async (
+  request: APIRequestContext,
+  userName: string,
+  grafanaAPIUser: User
+): Promise<number> => {
   const getUserIdByUserNameReq = await request.get(`/api/users/lookup?loginOrEmail=${userName}`, {
-    headers,
+    headers: getHeaders(grafanaAPIUser),
   });
   expect(getUserIdByUserNameReq.ok()).toBeTruthy();
   const json = await getUserIdByUserNameReq.json();
   return json.id;
 };
 
-export const createUser: CreateUserFixture = async ({ request, user }, use) => {
+export const createUser: CreateUserFixture = async ({ request, user, grafanaAPIUser }, use) => {
   await use(async () => {
     if (!user) {
       throw new Error('Playwright option `User` was not provided');
@@ -28,7 +32,7 @@ export const createUser: CreateUserFixture = async ({ request, user }, use) => {
         login: user?.user,
         password: user?.password,
       },
-      headers,
+      headers: getHeaders(grafanaAPIUser),
     });
 
     let userId: number | undefined;
@@ -37,7 +41,7 @@ export const createUser: CreateUserFixture = async ({ request, user }, use) => {
       userId = respJson.id;
     } else if (createUserReq.status() === 412) {
       // user already exists
-      userId = await getUserIdByUsername(request, user?.user);
+      userId = await getUserIdByUsername(request, user?.user, grafanaAPIUser);
     } else {
       throw new Error(`Could not create user '${user?.user}': ${await createUserReq.text()}`);
     }
@@ -45,7 +49,7 @@ export const createUser: CreateUserFixture = async ({ request, user }, use) => {
     if (user.role) {
       const updateRoleReq = await request.patch(`/api/org/users/${userId}`, {
         data: { role: user.role },
-        headers,
+        headers: getHeaders(grafanaAPIUser),
       });
       const updateRoleReqText = await updateRoleReq.text();
       expect(

--- a/packages/plugin-e2e/src/fixtures/commands/gotoDataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/gotoDataSourceConfigPage.ts
@@ -5,14 +5,16 @@ import { DataSourceConfigPage } from '../../models/pages/DataSourceConfigPage';
 type GotoDataSourceConfigPageFixture = TestFixture<(uid: string) => Promise<DataSourceConfigPage>, PlaywrightArgs>;
 
 export const gotoDataSourceConfigPage: GotoDataSourceConfigPageFixture = async (
-  { request, page, selectors, grafanaVersion, grafanaAPIUser },
+  { request, page, selectors, grafanaVersion, grafanaAPICredentials },
   use,
   testInfo
 ) => {
   await use(async (uid) => {
     const response = await request.get(`/api/datasources/uid/${uid}`, {
       headers: {
-        Authorization: `Basic ${Buffer.from(`${grafanaAPIUser.user}:${grafanaAPIUser.password}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${grafanaAPICredentials.user}:${grafanaAPICredentials.password}`).toString(
+          'base64'
+        )}`,
       },
     });
     if (!response.ok()) {

--- a/packages/plugin-e2e/src/fixtures/commands/gotoDataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/gotoDataSourceConfigPage.ts
@@ -12,7 +12,6 @@ export const gotoDataSourceConfigPage: GotoDataSourceConfigPageFixture = async (
   await use(async (uid) => {
     const response = await request.get(`/api/datasources/uid/${uid}`, {
       headers: {
-        // here we call backend as admin user and not on behalf of the logged in user as it might not have required permissions
         Authorization: `Basic ${Buffer.from(`${grafanaAPIUser.user}:${grafanaAPIUser.password}`).toString('base64')}`,
       },
     });

--- a/packages/plugin-e2e/src/fixtures/commands/gotoDataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/gotoDataSourceConfigPage.ts
@@ -5,7 +5,7 @@ import { DataSourceConfigPage } from '../../models/pages/DataSourceConfigPage';
 type GotoDataSourceConfigPageFixture = TestFixture<(uid: string) => Promise<DataSourceConfigPage>, PlaywrightArgs>;
 
 export const gotoDataSourceConfigPage: GotoDataSourceConfigPageFixture = async (
-  { request, page, selectors, grafanaVersion },
+  { request, page, selectors, grafanaVersion, grafanaAPIUser },
   use,
   testInfo
 ) => {
@@ -13,7 +13,7 @@ export const gotoDataSourceConfigPage: GotoDataSourceConfigPageFixture = async (
     const response = await request.get(`/api/datasources/uid/${uid}`, {
       headers: {
         // here we call backend as admin user and not on behalf of the logged in user as it might not have required permissions
-        Authorization: `Basic ${Buffer.from(`admin:admin`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${grafanaAPIUser.user}:${grafanaAPIUser.password}`).toString('base64')}`,
       },
     });
     if (!response.ok()) {

--- a/packages/plugin-e2e/src/fixtures/commands/login.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/login.ts
@@ -1,14 +1,14 @@
 import path from 'path';
 import { expect, TestFixture } from '@playwright/test';
-import { PlaywrightArgs } from '../../types';
+import { PlaywrightArgs, User } from '../../types';
 
 type LoginFixture = TestFixture<() => Promise<void>, PlaywrightArgs>;
 
-const ADMIN_USER = { user: 'admin', password: 'admin' };
+export const DEFAULT_ADMIN_USER: User = { user: 'admin', password: 'admin' };
 
 export const login: LoginFixture = async ({ request, user }, use) => {
   await use(async () => {
-    const data = user ?? ADMIN_USER;
+    const data = user ?? DEFAULT_ADMIN_USER;
     const loginReq = await request.post('/login', { data });
     const text = await loginReq.text();
     expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();

--- a/packages/plugin-e2e/src/fixtures/commands/login.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/login.ts
@@ -1,17 +1,14 @@
 import path from 'path';
 import { expect, TestFixture } from '@playwright/test';
-import { PlaywrightArgs, User } from '../../types';
+import { PlaywrightArgs } from '../../types';
 
 type LoginFixture = TestFixture<() => Promise<void>, PlaywrightArgs>;
 
-export const DEFAULT_ADMIN_USER: User = { user: 'admin', password: 'admin' };
-
 export const login: LoginFixture = async ({ request, user }, use) => {
   await use(async () => {
-    const data = user ?? DEFAULT_ADMIN_USER;
-    const loginReq = await request.post('/login', { data });
+    const loginReq = await request.post('/login', { data: user });
     const text = await loginReq.text();
     expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();
-    await request.storageState({ path: path.join(process.cwd(), `playwright/.auth/${data.user}.json`) });
+    await request.storageState({ path: path.join(process.cwd(), `playwright/.auth/${user?.user}.json`) });
   });
 };

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -8,5 +8,5 @@ export const options: Fixtures<{}, PluginOptions> = {
   featureToggles: [{}, { option: true, scope: 'worker' }],
   provisioningRootDir: [path.join(process.cwd(), 'provisioning'), { option: true, scope: 'worker' }],
   user: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
-  grafanaAPIUser: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
+  grafanaAPICredentials: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
 };

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -1,9 +1,11 @@
 import path = require('path');
 import { Fixtures } from '@playwright/test';
 import { PluginOptions } from './types';
+import { DEFAULT_ADMIN_USER } from './fixtures/commands/login';
 
 export const options: Fixtures<{}, PluginOptions> = {
   user: [undefined, { option: true, scope: 'worker' }],
   featureToggles: [{}, { option: true, scope: 'worker' }],
   provisioningRootDir: [path.join(process.cwd(), 'provisioning'), { option: true, scope: 'worker' }],
+  grafanaAPIUser: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
 };

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -1,11 +1,12 @@
 import path = require('path');
 import { Fixtures } from '@playwright/test';
-import { PluginOptions } from './types';
-import { DEFAULT_ADMIN_USER } from './fixtures/commands/login';
+import { PluginOptions, User } from './types';
+
+export const DEFAULT_ADMIN_USER: User = { user: 'admin', password: 'admin' };
 
 export const options: Fixtures<{}, PluginOptions> = {
-  user: [undefined, { option: true, scope: 'worker' }],
   featureToggles: [{}, { option: true, scope: 'worker' }],
   provisioningRootDir: [path.join(process.cwd(), 'provisioning'), { option: true, scope: 'worker' }],
+  user: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
   grafanaAPIUser: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
 };

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -62,18 +62,13 @@ export type PluginOptions = {
    * You can use different users for different projects. See the fixture createUser for more information on how to create a user,
    * and the fixture login for more information on how to authenticate. Also see https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication
    */
-  user?: User & {
-    /**
-     * Set this to true if the user already exist in the database. If omitted or set to false, the user will be created.
-     */
-    skipCreateUser?: boolean;
-  };
+  user?: User;
 
   /**
-   * The user to use when making requests to the Grafana API. For example when creating users, fetching data sources etc.
-   * If no user is provided, the server default admin/admin user will be used.
+   * The credentials to use when making requests to the Grafana API. For example when creating users, fetching data sources etc.
+   * If no credentials are provided, the server default admin:admin credentials will be used.
    */
-  grafanaAPIUser: User;
+  grafanaAPICredentials: Credentials;
 };
 
 export type PluginFixture = {
@@ -319,6 +314,14 @@ export type User = {
   user: string;
   password: string;
   role?: OrgRole;
+};
+
+export type Credentials = {
+  /**
+   * The username of the user
+   */
+  user: string;
+  password: string;
 };
 
 export type CreateDataSourceArgs<T = any> = {

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -62,7 +62,12 @@ export type PluginOptions = {
    * You can use different users for different projects. See the fixture createUser for more information on how to create a user,
    * and the fixture login for more information on how to authenticate. Also see https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication
    */
-  user?: UserArgs;
+  user?: User & {
+    /**
+     * Set this to true if the user already exist in the database. If omitted or set to false, the user will be created.
+     */
+    skipCreateUser?: boolean;
+  };
 
   /**
    * The user to use when making requests to the Grafana API. For example when creating users, fetching data sources etc.
@@ -307,26 +312,6 @@ export interface Dashboard {
   title?: string;
 }
 
-export type UserArgs = {
-  /**
-   * The username of the user to create. Needs to be unique
-   */
-  user: string;
-  /**
-   * The password of the user to create
-   */
-  password: string;
-  /**
-   * The role of the user to create
-   */
-  role?: OrgRole;
-
-  /**
-   * Set this to true if the user already exist in the database. If omitted or set to false, the user will be created.
-   */
-  skipCreateUser?: boolean;
-};
-
 export type User = {
   /**
    * The username of the user
@@ -337,6 +322,11 @@ export type User = {
    * The passwords
    */
   password: string;
+
+  /**
+   * The role of the user to create
+   */
+  role?: OrgRole;
 };
 
 export type CreateDataSourceArgs<T = any> = {

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -317,15 +317,7 @@ export type User = {
    * The username of the user
    */
   user: string;
-
-  /**
-   * The passwords
-   */
   password: string;
-
-  /**
-   * The role of the user to create
-   */
   role?: OrgRole;
 };
 

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -62,7 +62,13 @@ export type PluginOptions = {
    * You can use different users for different projects. See the fixture createUser for more information on how to create a user,
    * and the fixture login for more information on how to authenticate. Also see https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication
    */
-  user?: CreateUserArgs;
+  user?: UserArgs;
+
+  /**
+   * The user to use when making requests to the Grafana API. For example when creating users, fetching data sources etc.
+   * If no user is provided, the server default admin/admin user will be used.
+   */
+  grafanaAPIUser: User;
 };
 
 export type PluginFixture = {
@@ -301,7 +307,7 @@ export interface Dashboard {
   title?: string;
 }
 
-export type CreateUserArgs = {
+export type UserArgs = {
   /**
    * The username of the user to create. Needs to be unique
    */
@@ -314,6 +320,23 @@ export type CreateUserArgs = {
    * The role of the user to create
    */
   role?: OrgRole;
+
+  /**
+   * Set this to true if the user already exist in the database. If omitted or set to false, the user will be created.
+   */
+  skipCreateUser?: boolean;
+};
+
+export type User = {
+  /**
+   * The username of the user
+   */
+  user: string;
+
+  /**
+   * The passwords
+   */
+  password: string;
 };
 
 export type CreateDataSourceArgs<T = any> = {

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/annotations/annotationEditor.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/annotations/annotationEditor.spec.ts
@@ -5,13 +5,16 @@ import { REDSHIFT_SCHEMAS } from '../mocks/resource';
 test('should load resources and display them as options when clicking on an input', async ({
   annotationEditPage,
   page,
+  selectors,
   readProvisionedDataSource,
 }) => {
   await annotationEditPage.mockResourceResponse('schemas', REDSHIFT_SCHEMAS);
   const ds = await readProvisionedDataSource({ fileName: 'redshift.yaml' });
   await annotationEditPage.datasource.set(ds.name);
   await page.getByLabel('Schema').click();
-  await expect(annotationEditPage.getByGrafanaSelector('Select option')).toContainText(REDSHIFT_SCHEMAS);
+  await expect(annotationEditPage.getByGrafanaSelector(selectors.components.Select.option)).toContainText(
+    REDSHIFT_SCHEMAS
+  );
 });
 
 test('should be able to add a new annotation when annotations already exist', async ({

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/variables/customVariableEditor.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/variables/customVariableEditor.spec.ts
@@ -4,6 +4,7 @@ import { REDSHIFT_SCHEMAS, REDSHIFT_TABLES } from '../mocks/resource';
 test('should load resources and display them as options when clicking on an input', async ({
   variableEditPage,
   page,
+  selectors,
   readProvisionedDataSource,
 }) => {
   await variableEditPage.mockResourceResponse('schemas', REDSHIFT_SCHEMAS);
@@ -12,8 +13,12 @@ test('should load resources and display them as options when clicking on an inpu
   await variableEditPage.setVariableType('Query');
   await variableEditPage.datasource.set(ds.name);
   await page.getByLabel('Schema').click();
-  await expect(variableEditPage.getByGrafanaSelector('Select option')).toContainText(REDSHIFT_SCHEMAS);
+  await expect(variableEditPage.getByGrafanaSelector(selectors.components.Select.option)).toContainText(
+    REDSHIFT_SCHEMAS
+  );
   await page.keyboard.press('Enter');
   await page.getByLabel('Table').click();
-  await expect(variableEditPage.getByGrafanaSelector('Select option')).toContainText(REDSHIFT_TABLES);
+  await expect(variableEditPage.getByGrafanaSelector(selectors.components.Select.option)).toContainText(
+    REDSHIFT_TABLES
+  );
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

In a few places in the code, plugin-e2e uses the Grafana API to administrate users, data sources etc. Before this PR, the Grafana API was always called on behalf of the admin:admin user (the default server admin account) as it has all the necessary permissions. This is working fine in most cases, but in the test environment for the SLO app, this account doesn't exist so they're getting 401 errors when setting up users (more details on how to create users [here](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication#plugins-that-dont-use-rbac)).  

With this PR, the Grafana API is still called on behalf of the admin:admin user by default. However, consumers now have the option to override this user by providing a `grafanaAPIUser` in the playwright config. `grafanaAPIUser` is a Playwright [option](https://playwright.dev/docs/test-configuration#basic-configuration), meaning it can be defined on a global level and on a project level. Also, when specifying the user to use when running the e2e test (not the same thing as the `grafanaAPIUser`), it's now possible to set `skipCreateUser` prop. This gives the consumer the option to **not** create the user in the database. 

This is an example where one user is being used when calling the Grafana API and another one is being used when running the e2e tests.

```ts
export default defineConfig({
    ...
 testDir: './tests',
   use: {
     baseURL: 'http://localhost:3000',
     grafanaAPIUser: {
       user: 'server-admin',
       password: 'server-admin',
     },
    },
    projects: [
    {
      name: 'auth',
      testDir: pluginE2eAuth,
      testMatch: [/.*\.js/],
      use: {
        user: {
          user: 'slo',
          password: 'slo',
          skipCreateUser: true, // this user already exist in the db, so no need to create it during test setup
        },
      },
    },
    {
      name: 'run-tests',
      use: {
        ...devices['Desktop Chrome'],
        storageState: 'playwright/.auth/slo.json',
      },
      dependencies: ['auth'],
    }
  ],
});
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #934

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@1.3.0-canary.930.a85b4bb.0
  # or 
  yarn add @grafana/plugin-e2e@1.3.0-canary.930.a85b4bb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
