### PR TITLE
Create Plugin: Fix bad baseUrl path in webpack configuration

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -84,7 +84,7 @@ const config = async (env): Promise<Configuration> => {
             loader: 'swc-loader',
             options: {
               jsc: {
-                baseUrl: path.resolve(__dirname, 'src'),
+                baseUrl: path.resolve(process.cwd(), SOURCE_DIR),
                 target: 'es2015',
                 loose: false,
                 parser: {


### PR DESCRIPTION
Fixes #931

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.11.2-canary.932.01e174f.0
  # or 
  yarn add @grafana/create-plugin@4.11.2-canary.932.01e174f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
