### PR TITLE
Plugin E2E: Fix - skip creating user if it's the default server admin

### DIFF
--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -23,7 +23,7 @@
     "@grafana/e2e": "{{ grafanaVersion }}",
     "@grafana/e2e-selectors": "{{ grafanaVersion }}",{{/if}}
     "@grafana/eslint-config": "^7.0.0",{{#if usePlaywright}}
-    "@grafana/plugin-e2e": "^1.2.0",{{/if}}
+    "@grafana/plugin-e2e": "1.2.0",{{/if}}
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@grafana/plugin-meta-extractor": "^0.0.2",{{#if usePlaywright}}
     "@playwright/test": "^1.41.2",{{/if}}

--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -1,7 +1,8 @@
 import { test as setup } from '../';
+import { DEFAULT_ADMIN_USER } from '../options';
 
 setup('authenticate', async ({ login, createUser, user }) => {
-  if (user) {
+  if (user && (user.user !== DEFAULT_ADMIN_USER.user || user.password !== DEFAULT_ADMIN_USER.password)) {
     await createUser();
   }
   await login();


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue related to creating user that was introduced in plugin-e2e@1.3.0 ([this](https://github.com/grafana/plugin-tools/pull/930) PR). 

In that PR, `user` became a Playwright option with a default value of `admin:admin`. Since the default user is always provided, plugin-e2e would try to create if. Normally this should be fine - if the user already exist, server will return a 412 which will be logged and swallowed by plugin-e2e. However, that doesn't seem to be the case when it's trying to create the server admin account. Then we're getting the following error:
```json
  Error: Could not create user 'admin': {
      "accessErrorId": "ACE8544459724",
      "message": "You'll need additional permissions to perform this action. Permissions needed: users:create",
      "title": "Access denied"
    }
```

The solution is to not create user if its username and pass matches the default users.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Some of the scaffolding tests in CI were failing because they were using the broken 1.3.0 version of plugin-e2e which this PR aims to fix. So I have to pin the plugin-e2e version to 1.2.0 to get those tests to work. Will open a follow up PR that changes version to ^1.3.1 as soon as it's released. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.11.2-canary.941.a7ef49a.0
  npm install @grafana/plugin-e2e@1.3.1-canary.941.a7ef49a.0
  # or 
  yarn add @grafana/create-plugin@4.11.2-canary.941.a7ef49a.0
  yarn add @grafana/plugin-e2e@1.3.1-canary.941.a7ef49a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
