### PR TITLE
Plugin E2E: Fix menuitemclick in Grafana <=9.1.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,8 @@ jobs:
         id: resolve-versions
         uses: grafana/plugin-actions/e2e-version@main
         with:
-          version-resolver-type: version-support-policy
+          version-resolver-type: plugin-grafana-dependency
+          grafana-dependency: '>=8.5.0'
 
   playwright-tests:
     needs: resolve-versions

--- a/packages/plugin-e2e/src/models/components/Panel.ts
+++ b/packages/plugin-e2e/src/models/components/Panel.ts
@@ -52,10 +52,12 @@ export class Panel extends GrafanaPage {
       panelMenu = this.locator.getByRole('heading');
       this.ctx.page.locator(`[aria-label="Panel header item ${options?.parentItem}"]`);
       this.ctx.page.locator(`[aria-label="Panel header item ${item}"]`);
+      parentMenuItem = this.ctx.page.getByText(options?.parentItem ?? '');
+      menuItem = this.ctx.page.getByTestId('panel-dropdown').getByText(item);
     }
 
     await panelMenu.click({ force: true });
-    options?.parentItem && parentMenuItem.hover();
+    options?.parentItem && (await parentMenuItem.hover());
     await menuItem.click();
   }
 

--- a/packages/plugin-e2e/src/models/components/Panel.ts
+++ b/packages/plugin-e2e/src/models/components/Panel.ts
@@ -50,10 +50,8 @@ export class Panel extends GrafanaPage {
     // before 9.5.0, there were no proper selectors for the panel menu items
     if (semver.lt(this.ctx.grafanaVersion, '9.5.0')) {
       panelMenu = this.locator.getByRole('heading');
-      this.ctx.page.locator(`[aria-label="Panel header item ${options?.parentItem}"]`);
-      this.ctx.page.locator(`[aria-label="Panel header item ${item}"]`);
       parentMenuItem = this.ctx.page.getByText(options?.parentItem ?? '');
-      menuItem = this.ctx.page.getByTestId('panel-dropdown').getByText(item);
+      menuItem = this.ctx.page.getByRole('menu').getByText(item);
     }
 
     await panelMenu.click({ force: true });


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes CI so that e2e tests are targeting a larger range of Grafana versions. Since plugin-e2e APIs are supposed to be compatible with Grafana =>8.5.5, it's important that we cover these older versions in tests. 

While doing this, I discovered that clicking menu items doesn't work as expected in versions older than 9.2.0, so adding a fix for that. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
