### PR TITLE
Create Plugin: Remove meta-extractor from package.json

### DIFF
--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -24,8 +24,7 @@
     "@grafana/e2e-selectors": "{{ grafanaVersion }}",{{/if}}
     "@grafana/eslint-config": "^7.0.0",{{#if usePlaywright}}
     "@grafana/plugin-e2e": "1.2.0",{{/if}}
-    "@grafana/tsconfig": "^1.2.0-rc1",
-    "@grafana/plugin-meta-extractor": "^0.0.2",{{#if usePlaywright}}
+    "@grafana/tsconfig": "^1.2.0-rc1",{{#if usePlaywright}}
     "@playwright/test": "^1.41.2",{{/if}}
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Create plugin during scaffold or update adds the meta extractor package to a plugins dependencies even though it's not used. I noticed it whilst playing around with [automating create-plugin updates](https://github.com/jackw/heywesty-trafficlight-panel/pull/10/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R55) via a workflow.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.11.4-canary.946.28f38dd.0
  # or 
  yarn add @grafana/create-plugin@4.11.4-canary.946.28f38dd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
