### PR TITLE
Plugin E2E: Interact with Grafana http api on behalf of logged in user

### DIFF
--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -1,24 +1,9 @@
-import path from 'path';
-import { expect } from '@playwright/test';
 import { test as setup } from '../';
-import { DEFAULT_ADMIN_USER } from '../options';
-import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
 
-setup('authenticate', async ({ login, createUser, user, grafanaAPICredentials, browser }) => {
-  const context = await browser.newContext({ storageState: undefined });
-  const loginReq = await context.request.post('/login', { data: grafanaAPICredentials });
-  const text = await loginReq.text();
-  expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();
-  await context.request.storageState({ path: path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`) });
-  const grafanaAPIClient = new GrafanaAPIClient(
-    context.request,
-    path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`)
-  );
-  await grafanaAPIClient.init();
-
-  if (user && (user.user !== DEFAULT_ADMIN_USER.user || user.password !== DEFAULT_ADMIN_USER.password)) {
-    await grafanaAPIClient.createUser(user);
-    // await createUser();
+setup('authenticate', async ({ login, user, createUser, grafanaAPICredentials }) => {
+  // there's no need to create the server admin user
+  if (user && (user.user !== grafanaAPICredentials.user || user.password !== grafanaAPICredentials.password)) {
+    await createUser();
   }
   await login();
 });

--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -5,7 +5,7 @@ import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
 setup('authenticate', async ({ login, user, grafanaAPICredentials, browser }) => {
   const context = await browser.newContext();
   await createAdminClientStorageState(context.request, grafanaAPICredentials);
-  const adminClient = new GrafanaAPIClient(context.request);
+  const adminClient = new GrafanaAPIClient(context.request, grafanaAPICredentials);
 
   // there's no need to create the server admin user
   if (user && (user.user !== grafanaAPICredentials.user || user.password !== grafanaAPICredentials.password)) {

--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -1,9 +1,24 @@
+import path from 'path';
+import { expect } from '@playwright/test';
 import { test as setup } from '../';
 import { DEFAULT_ADMIN_USER } from '../options';
+import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
 
-setup('authenticate', async ({ login, createUser, user }) => {
+setup('authenticate', async ({ login, createUser, user, grafanaAPICredentials, browser }) => {
+  const context = await browser.newContext({ storageState: undefined });
+  const loginReq = await context.request.post('/login', { data: grafanaAPICredentials });
+  const text = await loginReq.text();
+  expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();
+  await context.request.storageState({ path: path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`) });
+  const grafanaAPIClient = new GrafanaAPIClient(
+    context.request,
+    path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`)
+  );
+  await grafanaAPIClient.init();
+
   if (user && (user.user !== DEFAULT_ADMIN_USER.user || user.password !== DEFAULT_ADMIN_USER.password)) {
-    await createUser();
+    await grafanaAPIClient.createUser(user);
+    // await createUser();
   }
   await login();
 });

--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -1,9 +1,15 @@
 import { test as setup } from '../';
+import { createAdminClientStorageState } from '../fixtures/grafanaAPIClient';
+import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
 
-setup('authenticate', async ({ login, user, createUser, grafanaAPICredentials }) => {
+setup('authenticate', async ({ login, user, grafanaAPICredentials, browser }) => {
+  const context = await browser.newContext();
+  await createAdminClientStorageState(context.request, grafanaAPICredentials);
+  const adminClient = new GrafanaAPIClient(context.request);
+
   // there's no need to create the server admin user
   if (user && (user.user !== grafanaAPICredentials.user || user.password !== grafanaAPICredentials.password)) {
-    await createUser();
+    await adminClient.createUser(user);
   }
   await login();
 });

--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -5,7 +5,7 @@ import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
 setup('authenticate', async ({ login, user, grafanaAPICredentials, browser }) => {
   const context = await browser.newContext();
   await createAdminClientStorageState(context.request, grafanaAPICredentials);
-  const adminClient = new GrafanaAPIClient(context.request, grafanaAPICredentials);
+  const adminClient = new GrafanaAPIClient(context.request);
 
   // there's no need to create the server admin user
   if (user && (user.user !== grafanaAPICredentials.user || user.password !== grafanaAPICredentials.password)) {

--- a/packages/plugin-e2e/src/auth/auth.setup.ts
+++ b/packages/plugin-e2e/src/auth/auth.setup.ts
@@ -1,15 +1,8 @@
 import { test as setup } from '../';
-import { createAdminClientStorageState } from '../fixtures/grafanaAPIClient';
-import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
 
-setup('authenticate', async ({ login, user, grafanaAPICredentials, browser }) => {
-  const context = await browser.newContext();
-  await createAdminClientStorageState(context.request, grafanaAPICredentials);
-  const adminClient = new GrafanaAPIClient(context.request);
-
-  // there's no need to create the server admin user
+setup('authenticate', async ({ login, createUser, user, grafanaAPICredentials }) => {
   if (user && (user.user !== grafanaAPICredentials.user || user.password !== grafanaAPICredentials.password)) {
-    await adminClient.createUser(user);
+    await createUser();
   }
   await login();
 });

--- a/packages/plugin-e2e/src/fixtures/commands/createUser.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createUser.ts
@@ -32,7 +32,7 @@ export const createUser: CreateUserFixture = async ({ request, user, grafanaAPIC
         login: user?.user,
         password: user?.password,
       },
-      headers: getHeaders(grafanaAPICredentials),
+      // headers: getHeaders(grafanaAPICredentials),
     });
 
     let userId: number | undefined;
@@ -59,3 +59,43 @@ export const createUser: CreateUserFixture = async ({ request, user, grafanaAPIC
     }
   });
 };
+
+// export const createUser2: CreateUserFixture = async (user: anym ) => {
+//   await use(async () => {
+//     if (!user) {
+//       throw new Error('Playwright option `User` was not provided');
+//     }
+
+//     const createUserReq = await request.post(`/api/admin/users`, {
+//       data: {
+//         name: user?.user,
+//         login: user?.user,
+//         password: user?.password,
+//       },
+//       // headers: getHeaders(grafanaAPICredentials),
+//     });
+
+//     let userId: number | undefined;
+//     if (createUserReq.ok()) {
+//       const respJson = await createUserReq.json();
+//       userId = respJson.id;
+//     } else if (createUserReq.status() === 412) {
+//       // user already exists
+//       userId = await getUserIdByUsername(request, user?.user, grafanaAPICredentials);
+//     } else {
+//       throw new Error(`Could not create user '${user?.user}': ${await createUserReq.text()}`);
+//     }
+
+//     if (user.role) {
+//       const updateRoleReq = await request.patch(`/api/org/users/${userId}`, {
+//         data: { role: user.role },
+//         headers: getHeaders(grafanaAPICredentials),
+//       });
+//       const updateRoleReqText = await updateRoleReq.text();
+//       expect(
+//         updateRoleReq.ok(),
+//         `Could not assign role '${user.role}' to user '${user.user}': ${updateRoleReqText}`
+//       ).toBeTruthy();
+//     }
+//   });
+// };

--- a/packages/plugin-e2e/src/fixtures/commands/createUser.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createUser.ts
@@ -1,101 +1,13 @@
-import { APIRequestContext, expect, TestFixture } from '@playwright/test';
-import { PlaywrightArgs, User } from '../../types';
+import { TestFixture } from '@playwright/test';
+import { PlaywrightArgs } from '../../types';
 
 type CreateUserFixture = TestFixture<() => Promise<void>, PlaywrightArgs>;
 
-const getHeaders = (user: User) => ({
-  Authorization: `Basic ${Buffer.from(`${user.user}:${user.password}`).toString('base64')}`,
-});
-
-const getUserIdByUsername = async (
-  request: APIRequestContext,
-  userName: string,
-  grafanaAPIUser: User
-): Promise<number> => {
-  const getUserIdByUserNameReq = await request.get(`/api/users/lookup?loginOrEmail=${userName}`, {
-    headers: getHeaders(grafanaAPIUser),
-  });
-  expect(getUserIdByUserNameReq.ok()).toBeTruthy();
-  const json = await getUserIdByUserNameReq.json();
-  return json.id;
-};
-
-export const createUser: CreateUserFixture = async ({ request, user, grafanaAPICredentials }, use) => {
+export const createUser: CreateUserFixture = async ({ grafanaAPIClient, user }, use) => {
   await use(async () => {
     if (!user) {
       throw new Error('Playwright option `User` was not provided');
     }
-
-    const createUserReq = await request.post(`/api/admin/users`, {
-      data: {
-        name: user?.user,
-        login: user?.user,
-        password: user?.password,
-      },
-      // headers: getHeaders(grafanaAPICredentials),
-    });
-
-    let userId: number | undefined;
-    if (createUserReq.ok()) {
-      const respJson = await createUserReq.json();
-      userId = respJson.id;
-    } else if (createUserReq.status() === 412) {
-      // user already exists
-      userId = await getUserIdByUsername(request, user?.user, grafanaAPICredentials);
-    } else {
-      throw new Error(`Could not create user '${user?.user}': ${await createUserReq.text()}`);
-    }
-
-    if (user.role) {
-      const updateRoleReq = await request.patch(`/api/org/users/${userId}`, {
-        data: { role: user.role },
-        headers: getHeaders(grafanaAPICredentials),
-      });
-      const updateRoleReqText = await updateRoleReq.text();
-      expect(
-        updateRoleReq.ok(),
-        `Could not assign role '${user.role}' to user '${user.user}': ${updateRoleReqText}`
-      ).toBeTruthy();
-    }
+    await grafanaAPIClient.createUser(user);
   });
 };
-
-// export const createUser2: CreateUserFixture = async (user: anym ) => {
-//   await use(async () => {
-//     if (!user) {
-//       throw new Error('Playwright option `User` was not provided');
-//     }
-
-//     const createUserReq = await request.post(`/api/admin/users`, {
-//       data: {
-//         name: user?.user,
-//         login: user?.user,
-//         password: user?.password,
-//       },
-//       // headers: getHeaders(grafanaAPICredentials),
-//     });
-
-//     let userId: number | undefined;
-//     if (createUserReq.ok()) {
-//       const respJson = await createUserReq.json();
-//       userId = respJson.id;
-//     } else if (createUserReq.status() === 412) {
-//       // user already exists
-//       userId = await getUserIdByUsername(request, user?.user, grafanaAPICredentials);
-//     } else {
-//       throw new Error(`Could not create user '${user?.user}': ${await createUserReq.text()}`);
-//     }
-
-//     if (user.role) {
-//       const updateRoleReq = await request.patch(`/api/org/users/${userId}`, {
-//         data: { role: user.role },
-//         headers: getHeaders(grafanaAPICredentials),
-//       });
-//       const updateRoleReqText = await updateRoleReq.text();
-//       expect(
-//         updateRoleReq.ok(),
-//         `Could not assign role '${user.role}' to user '${user.user}': ${updateRoleReqText}`
-//       ).toBeTruthy();
-//     }
-//   });
-// };

--- a/packages/plugin-e2e/src/fixtures/commands/gotoDataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/gotoDataSourceConfigPage.ts
@@ -1,28 +1,16 @@
 import { TestFixture } from '@playwright/test';
-import { DataSourceSettings, PlaywrightArgs } from '../../types';
+import { PlaywrightArgs } from '../../types';
 import { DataSourceConfigPage } from '../../models/pages/DataSourceConfigPage';
 
 type GotoDataSourceConfigPageFixture = TestFixture<(uid: string) => Promise<DataSourceConfigPage>, PlaywrightArgs>;
 
 export const gotoDataSourceConfigPage: GotoDataSourceConfigPageFixture = async (
-  { request, page, selectors, grafanaVersion, grafanaAPICredentials },
+  { request, page, selectors, grafanaVersion, grafanaAPIClient },
   use,
   testInfo
 ) => {
   await use(async (uid) => {
-    const response = await request.get(`/api/datasources/uid/${uid}`, {
-      headers: {
-        Authorization: `Basic ${Buffer.from(`${grafanaAPICredentials.user}:${grafanaAPICredentials.password}`).toString(
-          'base64'
-        )}`,
-      },
-    });
-    if (!response.ok()) {
-      throw new Error(
-        `Failed to get datasource by uid: ${response.statusText()}. If you're using a provisioned data source, make sure it has a UID`
-      );
-    }
-    const settings: DataSourceSettings = await response.json();
+    const settings = await grafanaAPIClient.getDataSourceSettingsByUID(uid);
     const dataSourceConfigPage = new DataSourceConfigPage(
       { page, selectors, grafanaVersion, request, testInfo },
       settings

--- a/packages/plugin-e2e/src/fixtures/commands/login.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/login.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { expect, TestFixture } from '@playwright/test';
+import { TestFixture } from '@playwright/test';
 import { PlaywrightArgs } from '../../types';
 
 type LoginFixture = TestFixture<() => Promise<void>, PlaywrightArgs>;
@@ -8,7 +8,9 @@ export const login: LoginFixture = async ({ request, user }, use) => {
   await use(async () => {
     const loginReq = await request.post('/login', { data: user });
     const text = await loginReq.text();
-    expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();
+    if (!loginReq.ok()) {
+      throw new Error(`Could not login to Grafana using user '${user?.user}': ${text}`);
+    }
     await request.storageState({ path: path.join(process.cwd(), `playwright/.auth/${user?.user}.json`) });
   });
 };

--- a/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
@@ -14,8 +14,8 @@ export const createAdminClientStorageState = async (request: APIRequestContext, 
   await request.storageState({ path: adminClientStorageState });
 };
 
-export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ browser, grafanaAPICredentials }, use) => {
+export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ browser }, use) => {
   const context = await browser.newContext({ storageState: undefined });
   await context.request.storageState({ path: adminClientStorageState });
-  await use(new GrafanaAPIClient(context.request, grafanaAPICredentials));
+  await use(new GrafanaAPIClient(context.request));
 };

--- a/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
@@ -14,8 +14,8 @@ export const createAdminClientStorageState = async (request: APIRequestContext, 
   await request.storageState({ path: adminClientStorageState });
 };
 
-export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ browser }, use) => {
+export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ browser, grafanaAPICredentials }, use) => {
   const context = await browser.newContext({ storageState: undefined });
   await context.request.storageState({ path: adminClientStorageState });
-  await use(new GrafanaAPIClient(context.request));
+  await use(new GrafanaAPIClient(context.request, grafanaAPICredentials));
 };

--- a/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
@@ -1,20 +1,21 @@
 import path from 'path';
-import { TestFixture, expect } from '@playwright/test';
-import { PlaywrightArgs } from '../types';
+import { TestFixture, expect, APIRequestContext } from '@playwright/test';
+import { PlaywrightArgs, User } from '../types';
 import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
 
 type GrafanaAPIClientFixture = TestFixture<GrafanaAPIClient, PlaywrightArgs>;
 
-export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ grafanaAPICredentials, browser }, use, testInfo) => {
-  const context = await browser.newContext({ storageState: undefined });
-  const fileName = path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`);
+const adminClientStorageState = path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`);
 
-  //   if (!fs.existsSync(fileName)) {
-  const loginReq = await context.request.post('/login', { data: grafanaAPICredentials });
+export const createAdminClientStorageState = async (request: APIRequestContext, grafanaAPICredentials: User) => {
+  const loginReq = await request.post('/login', { data: grafanaAPICredentials });
   const text = await loginReq.text();
   await expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();
-  //   }
+  await request.storageState({ path: adminClientStorageState });
+};
 
-  const a = await context.request.storageState({ path: fileName });
+export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ browser }, use) => {
+  const context = await browser.newContext({ storageState: undefined });
+  await context.request.storageState({ path: adminClientStorageState });
   await use(new GrafanaAPIClient(context.request));
 };

--- a/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
@@ -1,0 +1,16 @@
+// import { TestFixture } from '@playwright/test';
+// import { PlaywrightArgs } from '../types';
+// import { ExplorePage } from '../models/pages/ExplorePage';
+// import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
+
+// type GrafanaAPIClientFixture = TestFixture<ExplorePage, PlaywrightArgs>;
+
+// export const grafanaAPIClient: GrafanaAPIClientFixture = async (
+//   { page, selectors, grafanaVersion, request },
+//   use,
+//   testInfo
+// ) => {
+//   const grafanaAPIClient = new GrafanaAPIClient();
+//   await grafanaAPIClient.goto();
+//   await use(grafanaAPIClient);
+// };

--- a/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
@@ -1,16 +1,20 @@
-// import { TestFixture } from '@playwright/test';
-// import { PlaywrightArgs } from '../types';
-// import { ExplorePage } from '../models/pages/ExplorePage';
-// import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
+import path from 'path';
+import { TestFixture, expect } from '@playwright/test';
+import { PlaywrightArgs } from '../types';
+import { GrafanaAPIClient } from '../models/GrafanaAPIClient';
 
-// type GrafanaAPIClientFixture = TestFixture<ExplorePage, PlaywrightArgs>;
+type GrafanaAPIClientFixture = TestFixture<GrafanaAPIClient, PlaywrightArgs>;
 
-// export const grafanaAPIClient: GrafanaAPIClientFixture = async (
-//   { page, selectors, grafanaVersion, request },
-//   use,
-//   testInfo
-// ) => {
-//   const grafanaAPIClient = new GrafanaAPIClient();
-//   await grafanaAPIClient.goto();
-//   await use(grafanaAPIClient);
-// };
+export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ grafanaAPICredentials, browser }, use, testInfo) => {
+  const context = await browser.newContext({ storageState: undefined });
+  const fileName = path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`);
+
+  //   if (!fs.existsSync(fileName)) {
+  const loginReq = await context.request.post('/login', { data: grafanaAPICredentials });
+  const text = await loginReq.text();
+  await expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();
+  //   }
+
+  const a = await context.request.storageState({ path: fileName });
+  await use(new GrafanaAPIClient(context.request));
+};

--- a/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaAPIClient.ts
@@ -14,8 +14,16 @@ export const createAdminClientStorageState = async (request: APIRequestContext, 
   await request.storageState({ path: adminClientStorageState });
 };
 
-export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ browser }, use) => {
+export const grafanaAPIClient: GrafanaAPIClientFixture = async ({ browser, grafanaAPICredentials }, use) => {
   const context = await browser.newContext({ storageState: undefined });
+  const loginReq = await context.request.post('/login', { data: grafanaAPICredentials });
+  if (!loginReq.ok()) {
+    console.log(
+      `Could not login to grafana using credentials '${
+        grafanaAPICredentials?.user
+      }'. Find information on how user can be managed in the plugin-e2e docs: https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication#managing-users  : ${await loginReq.text()}`
+    );
+  }
   await context.request.storageState({ path: adminClientStorageState });
   await use(new GrafanaAPIClient(context.request));
 };

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -2,7 +2,7 @@ import { test as base, expect as baseExpect } from '@playwright/test';
 
 import { AlertPageOptions, AlertVariant, ContainTextOptions, PluginFixture, PluginOptions } from './types';
 import { annotationEditPage } from './fixtures/annotationEditPage';
-// import { GrafanaAPIClient } from './models/GrafanaAPIClient';
+import { grafanaAPIClient } from './fixtures/grafanaAPIClient';
 import { createDataSource } from './fixtures/commands/createDataSource';
 import { createDataSourceConfigPage } from './fixtures/commands/createDataSourceConfigPage';
 import { createUser } from './fixtures/commands/createUser';
@@ -64,7 +64,7 @@ export const test = base.extend<PluginFixture, PluginOptions>({
   selectors: e2eSelectors,
   grafanaVersion,
   login,
-  // grafanaAPIClient,
+  grafanaAPIClient,
   createDataSourceConfigPage,
   page,
   dashboardPage,

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -2,6 +2,7 @@ import { test as base, expect as baseExpect } from '@playwright/test';
 
 import { AlertPageOptions, AlertVariant, ContainTextOptions, PluginFixture, PluginOptions } from './types';
 import { annotationEditPage } from './fixtures/annotationEditPage';
+// import { GrafanaAPIClient } from './models/GrafanaAPIClient';
 import { createDataSource } from './fixtures/commands/createDataSource';
 import { createDataSourceConfigPage } from './fixtures/commands/createDataSourceConfigPage';
 import { createUser } from './fixtures/commands/createUser';
@@ -63,6 +64,7 @@ export const test = base.extend<PluginFixture, PluginOptions>({
   selectors: e2eSelectors,
   grafanaVersion,
   login,
+  // grafanaAPIClient,
   createDataSourceConfigPage,
   page,
   dashboardPage,

--- a/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
@@ -1,4 +1,4 @@
-import { APIRequestContext, expect } from '@playwright/test';
+import { APIRequestContext } from '@playwright/test';
 import { DataSourceSettings, User } from '../types';
 
 export class GrafanaAPIClient {

--- a/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
@@ -1,26 +1,14 @@
 import { APIRequestContext, expect } from '@playwright/test';
-import { User } from '../types';
+import { DataSourceSettings, User } from '../types';
 
 export class GrafanaAPIClient {
-  constructor(private request: APIRequestContext, private storageState: string) {}
-
-  async init() {
-    // const loginReq = await this.request.post('/login', { data: this.grafanaAPICredentials });
-    // const text = await loginReq.text();
-    // expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();
-    // await this.request.storageState({ path: path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`) });
-    await this.request.storageState({ path: this.storageState });
-  }
+  constructor(private request: APIRequestContext) {}
 
   async getUserIdByUsername(userName: string) {
-    try {
-      const getUserIdByUserNameReq = await this.request.get(`/api/users/lookup?loginOrEmail=${userName}`);
-      await expect(getUserIdByUserNameReq.ok()).toBeTruthy();
-      const json = await getUserIdByUserNameReq.json();
-      return json.id;
-    } catch (error) {
-      console.log(error);
-    }
+    const getUserIdByUserNameReq = await this.request.get(`/api/users/lookup?loginOrEmail=${userName}`);
+    await expect(getUserIdByUserNameReq.ok()).toBeTruthy();
+    const json = await getUserIdByUserNameReq.json();
+    return json.id;
   }
 
   async createUser(user: User) {
@@ -30,7 +18,6 @@ export class GrafanaAPIClient {
         login: user?.user,
         password: user?.password,
       },
-      // headers: getHeaders(grafanaAPICredentials),
     });
     let userId: number | undefined;
     if (createUserReq.ok()) {
@@ -54,5 +41,16 @@ export class GrafanaAPIClient {
         `Could not assign role '${user.role}' to user '${user.user}': ${updateRoleReqText}`
       ).toBeTruthy();
     }
+  }
+
+  async getDataSourceSettingsByUID(uid: string) {
+    const response = await this.request.get(`/api/datasources/uid/${uid}`);
+    if (!response.ok()) {
+      throw new Error(
+        `Failed to get datasource by uid: ${response.statusText()}. If you're using a provisioned data source, make sure it has a UID`
+      );
+    }
+    const settings: DataSourceSettings = await response.json();
+    return settings;
   }
 }

--- a/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
@@ -1,0 +1,58 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import { User } from '../types';
+
+export class GrafanaAPIClient {
+  constructor(private request: APIRequestContext, private storageState: string) {}
+
+  async init() {
+    // const loginReq = await this.request.post('/login', { data: this.grafanaAPICredentials });
+    // const text = await loginReq.text();
+    // expect.soft(loginReq.ok(), `Could not log in to Grafana: ${text}`).toBeTruthy();
+    // await this.request.storageState({ path: path.join(process.cwd(), `playwright/.auth/grafanaAPICredentials.json`) });
+    await this.request.storageState({ path: this.storageState });
+  }
+
+  async getUserIdByUsername(userName: string) {
+    try {
+      const getUserIdByUserNameReq = await this.request.get(`/api/users/lookup?loginOrEmail=${userName}`);
+      await expect(getUserIdByUserNameReq.ok()).toBeTruthy();
+      const json = await getUserIdByUserNameReq.json();
+      return json.id;
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  async createUser(user: User) {
+    const createUserReq = await this.request.post(`/api/admin/users`, {
+      data: {
+        name: user?.user,
+        login: user?.user,
+        password: user?.password,
+      },
+      // headers: getHeaders(grafanaAPICredentials),
+    });
+    let userId: number | undefined;
+    if (createUserReq.ok()) {
+      const respJson = await createUserReq.json();
+      userId = respJson.id;
+    } else if (createUserReq.status() === 412) {
+      // user already exists
+      userId = await this.getUserIdByUsername(user?.user);
+    } else {
+      throw new Error(`Could not create user '${user?.user}': ${await createUserReq.text()}`);
+    }
+
+    if (user.role) {
+      const updateRoleReq = await this.request.patch(`/api/org/users/${userId}`, {
+        data: { role: user.role },
+      });
+      const updateRoleReqText = await updateRoleReq.text();
+      console.log(updateRoleReqText);
+      await expect(
+        updateRoleReq.ok(),
+        `Could not assign role '${user.role}' to user '${user.user}': ${updateRoleReqText}`
+      ).toBeTruthy();
+    }
+  }
+}

--- a/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
@@ -2,7 +2,7 @@ import { APIRequestContext, expect } from '@playwright/test';
 import { DataSourceSettings, User } from '../types';
 
 export class GrafanaAPIClient {
-  constructor(private request: APIRequestContext) {}
+  constructor(private request: APIRequestContext, private grafanaAPICredentials: User) {}
 
   async getUserIdByUsername(userName: string) {
     const getUserIdByUserNameReq = await this.request.get(`/api/users/lookup?loginOrEmail=${userName}`);
@@ -27,7 +27,11 @@ export class GrafanaAPIClient {
       // user already exists
       userId = await this.getUserIdByUsername(user?.user);
     } else {
-      throw new Error(`Could not create user '${user?.user}': ${await createUserReq.text()}`);
+      throw new Error(
+        `Could not create user '${
+          user?.user
+        }'. Find information on how user can be managed in the plugin-e2e docs: https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication#managing-users  : ${await createUserReq.text()}`
+      );
     }
 
     if (user.role) {
@@ -35,7 +39,6 @@ export class GrafanaAPIClient {
         data: { role: user.role },
       });
       const updateRoleReqText = await updateRoleReq.text();
-      console.log(updateRoleReqText);
       await expect(
         updateRoleReq.ok(),
         `Could not assign role '${user.role}' to user '${user.user}': ${updateRoleReqText}`

--- a/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
@@ -2,7 +2,7 @@ import { APIRequestContext, expect } from '@playwright/test';
 import { DataSourceSettings, User } from '../types';
 
 export class GrafanaAPIClient {
-  constructor(private request: APIRequestContext, private grafanaAPICredentials: User) {}
+  constructor(private request: APIRequestContext) {}
 
   async getUserIdByUsername(userName: string) {
     const getUserIdByUserNameReq = await this.request.get(`/api/users/lookup?loginOrEmail=${userName}`);

--- a/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
@@ -6,7 +6,6 @@ export class GrafanaAPIClient {
 
   async getUserIdByUsername(userName: string) {
     const getUserIdByUserNameReq = await this.request.get(`/api/users/lookup?loginOrEmail=${userName}`);
-    await expect(getUserIdByUserNameReq.ok()).toBeTruthy();
     const json = await getUserIdByUserNameReq.json();
     return json.id;
   }
@@ -38,11 +37,9 @@ export class GrafanaAPIClient {
       const updateRoleReq = await this.request.patch(`/api/org/users/${userId}`, {
         data: { role: user.role },
       });
-      const updateRoleReqText = await updateRoleReq.text();
-      await expect(
-        updateRoleReq.ok(),
-        `Could not assign role '${user.role}' to user '${user.user}': ${updateRoleReqText}`
-      ).toBeTruthy();
+      if (!updateRoleReq.ok()) {
+        throw new Error(`Could not assign role '${user.role}' to user '${user.user}': ${await updateRoleReq.text()}`);
+      }
     }
   }
 

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -75,7 +75,6 @@ export type PluginOptions = {
 };
 
 export type PluginFixture = {
-  grafanaAPIClient: GrafanaAPIClient;
   /**
    * The Grafana version that was detected when the test runner was started.
    *
@@ -194,6 +193,19 @@ export type PluginFixture = {
    * Function that checks if a feature toggle is enabled. Only works for frontend feature toggles.
    */
   isFeatureToggleEnabled<T = object>(featureToggle: keyof T): Promise<boolean>;
+
+  /**
+   * Client that allows you to use certain endpoints in the Grafana http API.
+   *
+   * Note that this client doesn't call the Grafana HTTP API on behalf of the logged in user -
+   * it uses the {@link types.grafanaAPICredentials} credentials. These defaults to admin:admin, but you may override this
+   * by specifying grafanaAPICredentials in the playwright config options.
+   *
+   * This fixture reuses storage state in all tests, so don't forget to add a dependency to the auth setup project in the playwright config.
+   * See https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication for more info.
+   */
+
+  grafanaAPIClient: GrafanaAPIClient;
 
   /**
    * Isolated {@link DashboardPage} instance for each test.

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -75,7 +75,7 @@ export type PluginOptions = {
 };
 
 export type PluginFixture = {
-  // grafanaAPIClient: GrafanaAPIClient;
+  grafanaAPIClient: GrafanaAPIClient;
   /**
    * The Grafana version that was detected when the test runner was started.
    *

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -197,12 +197,12 @@ export type PluginFixture = {
   /**
    * Client that allows you to use certain endpoints in the Grafana http API.
    *
-   * Note that this client doesn't call the Grafana HTTP API on behalf of the logged in user -
-   * it uses the {@link types.grafanaAPICredentials} credentials. These defaults to admin:admin, but you may override this
+   The GrafanaAPIClient doesn't call the Grafana HTTP API on behalf of the logged in user -
+   * it uses the {@link types.grafanaAPICredentials} credentials. grafanaAPICredentials defaults to admin:admin, but you may override this
    * by specifying grafanaAPICredentials in the playwright config options.
    *
-   * This fixture reuses storage state in all tests, so don't forget to add a dependency to the auth setup project in the playwright config.
-   * See https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/use-authentication for more info.
+   * Note that storage state for the admin client is not persisted throughout the test suite. For every test where the grafanaAPICredentials fixtures is used,
+   * new storage state is created.
    */
 
   grafanaAPIClient: GrafanaAPIClient;

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -19,6 +19,7 @@ import { PanelEditPage } from './models/pages/PanelEditPage';
 import { VariableEditPage } from './models/pages/VariableEditPage';
 import { VariablePage } from './models/pages/VariablePage';
 import { AlertRuleEditPage } from './models/pages/AlertRuleEditPage';
+import { GrafanaAPIClient } from './models/GrafanaAPIClient';
 
 export type PluginOptions = {
   /**
@@ -74,6 +75,7 @@ export type PluginOptions = {
 };
 
 export type PluginFixture = {
+  // grafanaAPIClient: GrafanaAPIClient;
   /**
    * The Grafana version that was detected when the test runner was started.
    *

--- a/packages/plugin-e2e/tests/as-admin-user/permissions/createUserUsingInvalidCredentials.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/permissions/createUserUsingInvalidCredentials.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '../../../src';
+
+test.use({ grafanaAPICredentials: { user: 'test', password: 'test' } });
+test('should throw error when credentials are invalid', async ({ grafanaAPIClient }) => {
+  await expect(grafanaAPIClient.createUser({ user: 'testuser1', password: 'pass' })).rejects.toThrowError(
+    /Could not create user 'testuser1'.*/
+  );
+});

--- a/packages/plugin-e2e/tests/as-admin-user/permissions/createUserUsingValidCredentials.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/permissions/createUserUsingValidCredentials.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from '../../../src';
+
+test('should be possible to create user when credentials are valid', async ({ grafanaAPIClient }) => {
+  await expect(grafanaAPIClient.createUser({ user: 'testuser1', password: 'pass' })).resolves.toBeUndefined();
+  await expect(await grafanaAPIClient.getUserIdByUsername('testuser1')).toBeTruthy();
+});

--- a/packages/plugin-e2e/tests/as-viewer-user/permissions/createUserUsingInvalidCredentials.spec.ts
+++ b/packages/plugin-e2e/tests/as-viewer-user/permissions/createUserUsingInvalidCredentials.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '../../../src';
+
+test.use({ grafanaAPICredentials: { user: 'test', password: 'test' } });
+test('should throw error when credentials are invalid', async ({ grafanaAPIClient }) => {
+  await expect(grafanaAPIClient.createUser({ user: 'testuser1', password: 'pass' })).rejects.toThrowError(
+    /Could not create user 'testuser1'.*/
+  );
+});

--- a/packages/plugin-e2e/tests/as-viewer-user/permissions/createUserUsingValidCredentials.spec.ts
+++ b/packages/plugin-e2e/tests/as-viewer-user/permissions/createUserUsingValidCredentials.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '../../../src';
+
+test('using grafanaAPIClient should not change storage state for logged in user', async ({
+  grafanaAPIClient,
+  page,
+}) => {
+  // assert one can create user on behalf of the admin credentials
+  await expect(grafanaAPIClient.createUser({ user: 'testuser1', password: 'pass' })).resolves.toBeUndefined();
+  await expect(await grafanaAPIClient.getUserIdByUsername('testuser1')).toBeTruthy();
+
+  // but logged in user should still only have viewer persmissions
+  await page.goto('/');
+  const homePageTitle = await page.title();
+  await page.goto('/datasources', { waitUntil: 'networkidle' });
+  expect(await page.title()).toEqual(homePageTitle);
+});


### PR DESCRIPTION
**What this PR does / why we need it**:

If a plugin has implemented RBAC, it may be necessary to run different tests suites for different user roles. Plugin-e2e offers a declarative way to create new users with a role in a setup project. In the following example, a new users with `Viewer` role is created in the setup project, and all tests in the `run-tests-for-viewer` project starts already authenticated as that user. 

```ts
//playwright.config.ts
projects: [
      {
        name: 'createViewerUserAndAuthenticate',
        testDir: pluginE2eAuth,
        testMatch: [/.*auth\.setup\.ts/],
        use: {
          user: {
            user: 'viewer',
            password: 'password',
            role: 'Viewer',
          },
        },
      },
      {
        name: 'run-tests-for-viewer',
        testDir: './tests/viewer',
        use: {
          ...devices['Desktop Chrome'],
          // @grafana/plugin-e2e writes the auth state to this file,
          // the path should not be modified
          storageState: 'playwright/.auth/viewer.json',
        },
        dependencies: ['createViewerUserAndAuthenticate'],
      },
  ]

```

It's important to keep in mind that two different users (or credentials) are in play here. First, it's the credentials used to call the Grafana Http API to create the new user. These credentials requires elevated permissions. Secondly, it's the user being used to run the tests, which in this case has restricted permissions (viewer role). 

Until now, the admin user used to interact with the Grafana http api has been using basic auth. This is not ideal since basic auth is [disabled](https://github.com/grafana/plugin-tools/blob/504f10037eb05025a48d54d04c2f242c1ee48042/packages/create-plugin/templates/common/.config/Dockerfile#L19) for scaffolded plugins. This PR changes that so that any interaction with the Grafana http api is done on behalf of a logged in user. Additionally, I've refactored the code so that all interactions with the Grafana api is encapsulated in a GrafanaAPIClient file. This helps separating the two concepts. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/plugin-tools/issues/968

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.13.0-canary.965.69c1edd.0
  npm install @grafana/plugin-e2e@1.6.0-canary.965.69c1edd.0
  # or 
  yarn add @grafana/create-plugin@4.13.0-canary.965.69c1edd.0
  yarn add @grafana/plugin-e2e@1.6.0-canary.965.69c1edd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
