### PR TITLE
Create-Plugin: Add version comment to bundled Javascript

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/utils.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/utils.ts
@@ -29,6 +29,11 @@ export function getPluginJson() {
   return require(path.resolve(process.cwd(), `${SOURCE_DIR}/plugin.json`));
 }
 
+export function getCPConfigVersion() {
+  const cprcJson = path.resolve(__dirname, '../', '.cprc.json');
+  return fs.existsSync(cprcJson) ? require(cprcJson).version : { version: 'unknown' };
+}
+
 export function hasReadme() {
   return fs.existsSync(path.resolve(process.cwd(), SOURCE_DIR, 'README.md'));
 }

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -173,7 +173,7 @@ const config = async (env): Promise<Configuration> => {
     plugins: [
       // Insert create plugin version information into the bundle
       new BannerPlugin({
-        banner: "/* [create-plugin] version: " + cpVersion + "*/",
+        banner: "/* [create-plugin] version: " + cpVersion + " */",
         raw: true,
         entryOnly: true,
       }),

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -14,7 +14,7 @@ import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import { type Configuration, BannerPlugin } from 'webpack';
 
-import { getPackageJson, getPluginJson, hasReadme, getEntries, isWSL } from './utils';
+import { getPackageJson, getPluginJson, hasReadme, getEntries, isWSL, getCPConfigVersion } from './utils';
 import { SOURCE_DIR, DIST_DIR } from './constants';
 
 const pluginJson = getPluginJson();

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -141,17 +141,8 @@ const config = async (env): Promise<Configuration> => {
         new TerserPlugin({
           terserOptions: {
             format: {
-              comments: (_, comment) => /^\**!|@preserve|@license|@cc_on|\[create-plugin\]/i.test(comment.value),
+              comments: (_, { type, value }) => type === 'comment2' && value.trim().startsWith('[create-plugin]'),
             },
-          },
-          extractComments: (_, comment) => {
-            const { value, type } = comment;
-            // Keep `[create-plugin]` comments in the output
-            if (type === 'comment2' && value.startsWith('[create-plugin]')) {
-              return false;
-            }
-            // Extract other comments
-            return /^\**!|@preserve|@license|@cc_on/i.test(value);
           },
         }),
       ],

--- a/packages/create-plugin/templates/common/npmrc
+++ b/packages/create-plugin/templates/common/npmrc
@@ -9,6 +9,7 @@ public-hoist-pattern[]="*prettier*"
 
 # Hoist all types packages to the root for better TS support
 public-hoist-pattern[]="@types/*"
+public-hoist-pattern[]="*terser-webpack-plugin*"
 {{#unless usePlaywright}}
 # @grafana/e2e expects cypress to exist in the root of the node_modules directory
 public-hoist-pattern[]="*cypress*"{{/unless}}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds a comment at the top of the bundled JS assets with the version of the create-plugin configs used at build time. This will allow our tooling to more easily understand things like cdn compatibility in the future.

Sample comment:
```
/* [create-plugin] version: 4.12.0 */
```


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related: grafana/grafana-community-team/issues/133

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.14.0-canary.970.e321735.0
  # or 
  yarn add @grafana/create-plugin@4.14.0-canary.970.e321735.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
