### PR TITLE
Create Plugin: Fix backend dev env for arm64 hosts

### DIFF
--- a/packages/create-plugin/src/commands/generate/print-success-message.ts
+++ b/packages/create-plugin/src/commands/generate/print-success-message.ts
@@ -13,7 +13,7 @@ export function printGenerateSuccessMessage(answers: TemplateData) {
     `- \`${packageManagerName} run dev\` to build (and watch) the plugin frontend code.`,
     ...(answers.hasBackend
       ? [
-          '- `mage -v build:linux` to build the plugin backend code. Rerun this command every time you edit your backend files.',
+          '- `mage -v build:backend` to build the plugin backend code. Rerun this command every time you edit your backend files.',
         ]
       : []),
     '- `docker-compose up` to start a grafana development server.',

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -1,13 +1,14 @@
-ARG TARGETARCH
 ARG grafana_version=latest
 ARG grafana_image=grafana-enterprise
 
 FROM grafana/${grafana_image}:${grafana_version}
 
 ARG development=false
+ARG TARGETARCH
 
 {{#if hasBackend}}
 ARG GO_VERSION=1.21.6
+ARG GO_ARCH=${TARGETARCH:-amd64}
 {{/if}}
 
 ENV DEV "${development}"
@@ -49,11 +50,11 @@ COPY supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 {{#if hasBackend}}
 # Installing Go
 RUN if [ "${development}" = "true" ]; then \
-    curl -O -L https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    curl -O -L https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
     rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
     echo "export PATH=$PATH:/usr/local/go/bin:~/go/bin" >> ~/.bashrc && \
-    rm -f go${GO_VERSION}.linux-${TARGETARCH}.tar.gz; \
+    rm -f go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
     fi
 
 # Installing delve for debugging

--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -1,3 +1,4 @@
+ARG TARGETARCH
 ARG grafana_version=latest
 ARG grafana_image=grafana-enterprise
 
@@ -7,7 +8,6 @@ ARG development=false
 
 {{#if hasBackend}}
 ARG GO_VERSION=1.21.6
-ARG GO_ARCH=amd64
 {{/if}}
 
 ENV DEV "${development}"
@@ -49,11 +49,11 @@ COPY supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 {{#if hasBackend}}
 # Installing Go
 RUN if [ "${development}" = "true" ]; then \
-    curl -O -L https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+    curl -O -L https://golang.org/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
     rm -rf /usr/local/go && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${TARGETARCH}.tar.gz && \
     echo "export PATH=$PATH:/usr/local/go/bin:~/go/bin" >> ~/.bashrc && \
-    rm -f go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \
+    rm -f go${GO_VERSION}.linux-${TARGETARCH}.tar.gz; \
     fi
 
 # Installing delve for debugging

--- a/packages/create-plugin/templates/common/docker-compose.yaml
+++ b/packages/create-plugin/templates/common/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
     user: root
     container_name: '{{ pluginId }}'
 
-    platform: 'linux/amd64'
     build:
       context: ./.config
       args:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Draft as requires testing across OS...

This PR changes the docker file and docker compose to not force `amd64` which causes a mismatch between the go arch, docker arch and the host arch causing dlv to fail to work. The linked issue has [further investigative info](https://github.com/grafana/plugin-tools/issues/913#issuecomment-2173096648).

With the changes in this PR I can successfully connect with dlv using an M2 Macbook.

![image](https://github.com/grafana/plugin-tools/assets/73201/4594eb98-b560-4b7f-8366-3e34c82d13c9)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #913

**Special notes for your reviewer**:

To test run the following in terminal...

```
npx @grafana/create-plugin@4.14.1-canary.990.e4ea168.0 --pluginName=test \
--pluginDescription="test plugin" \
--orgName=test \
--pluginType=datasource \
--hasBackend \
--hasGithubWorkflows \
--hasGithubLevitateWorkflow && \
cd test-test-datasource && \
npm i && \
npm run build && \
mage build:backend && \
DEVELOPMENT=true docker compose up
```

- Once the docker container has started up attempt to connect from the host via delve `dlv connect localhost:2345`.
- If that succeeds next try setting a breakpoint with `break datasource.go:100`.
- Navigate to datasource config page for the test datasource
- Click health check and acknowledge it's taking it's time...
- Back in terminal send delve two `continue` commands and you should see the health check complete successfully.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.14.1-canary.990.e4ea168.0
  # or 
  yarn add @grafana/create-plugin@4.14.1-canary.990.e4ea168.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
