### PR TITLE
Docs: Adds clarification notes to data proxy configuration

### DIFF
--- a/docusaurus/docs/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins.md
@@ -253,6 +253,10 @@ Here's an example of adding `name` and `content` as URL parameters:
 ]
 ```
 
+:::note
+Be aware that `urlParams` configuration is only supported in Data source plugins. It is **NOT** supported in App plugins.
+:::
+
 #### Add a request body to a proxy route
 
 Here's an example of adding `username` and `password` to the request body:
@@ -296,6 +300,10 @@ Any parameters defined in `tokenAuth.params` are encoded as `application/x-www-f
   ]
 }
 ```
+
+:::note
+Be aware that `tokenAuth` configuration is only supported in Data source plugins. It is **NOT** supported in App plugins.
+:::
 
 ## Authenticate using a backend plugin
 

--- a/docusaurus/docs/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins.md
@@ -254,7 +254,7 @@ Here's an example of adding `name` and `content` as URL parameters:
 ```
 
 :::note
-Be aware that `urlParams` configuration is only supported in Data source plugins. It is **NOT** supported in App plugins.
+Be aware that `urlParams` configuration is only supported in data source plugins. It is _not_ supported in app plugins.
 :::
 
 #### Add a request body to a proxy route

--- a/docusaurus/docs/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/add-authentication-for-data-source-plugins.md
@@ -302,7 +302,7 @@ Any parameters defined in `tokenAuth.params` are encoded as `application/x-www-f
 ```
 
 :::note
-Be aware that `tokenAuth` configuration is only supported in Data source plugins. It is **NOT** supported in App plugins.
+Be aware that `tokenAuth` configuration is only supported in data source plugins. It is _not_ supported in app plugins.
 :::
 
 ## Authenticate using a backend plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -3439,7 +3439,7 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
@@ -3453,7 +3453,7 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.8.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -3461,7 +3461,7 @@
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -3483,7 +3483,7 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.24.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -3497,7 +3497,7 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.42.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3637,7 +3637,7 @@
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -3650,7 +3650,7 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -3662,7 +3662,7 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@hutson/parse-repository-url": {
@@ -11030,7 +11030,7 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -11931,7 +11931,7 @@
     },
     "node_modules/eslint": {
       "version": "8.42.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -12141,7 +12141,7 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -12152,7 +12152,7 @@
     },
     "node_modules/eslint/node_modules/doctrine": {
       "version": "3.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
@@ -12163,7 +12163,7 @@
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -12174,7 +12174,7 @@
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.2",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -12189,7 +12189,7 @@
     },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -12200,7 +12200,7 @@
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.24.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -12214,7 +12214,7 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
@@ -12241,7 +12241,7 @@
     },
     "node_modules/esquery": {
       "version": "1.5.0",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -12630,7 +12630,7 @@
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-loops": {
@@ -12726,7 +12726,7 @@
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -12957,7 +12957,7 @@
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.1.0",
@@ -12969,7 +12969,7 @@
     },
     "node_modules/flatted": {
       "version": "3.2.5",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -13881,7 +13881,7 @@
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/gray-matter": {
@@ -16926,7 +16926,7 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-stringify-pretty-compact": {
@@ -17605,7 +17605,7 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -18193,7 +18193,7 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.pullall": {
@@ -21347,7 +21347,7 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/natural-compare-lite": {
@@ -22394,7 +22394,7 @@
     },
     "node_modules/optionator": {
       "version": "0.9.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -24143,7 +24143,7 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -28039,7 +28039,7 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -28058,7 +28058,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.20.2",
-      "dev": true,
+      "devOptional": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -29640,7 +29640,7 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the plugin proxy does not support `urlParam` or `tokenAuth` configuration when used in the context of an App plugin. This PR adds clarification notes to the docs to reflect this.