### PR TITLE
Create Plugin: Support SRI in dynamic imported chunks

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -231,6 +231,9 @@ const config = async (env): Promise<Configuration> => {
           ],
         },
       ]),
+      new SubresourceIntegrityPlugin({
+        hashFuncNames: ["sha256"],
+      }),
       ...(env.development ? [
         new LiveReloadPlugin(),
         new ForkTsCheckerWebpackPlugin({

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -183,6 +183,7 @@ const config = async (env): Promise<Configuration> => {
       path: path.resolve(process.cwd(), DIST_DIR),
       publicPath: `public/plugins/${pluginJson.id}/`,
       uniqueName: pluginJson.id,
+      crossOriginLoading: 'anonymous',
     },
 
     plugins: [

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -11,6 +11,7 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import path from 'path';
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
+import { SubresourceIntegrityPlugin } from "webpack-subresource-integrity";
 import { type Configuration, BannerPlugin } from 'webpack';
 import LiveReloadPlugin from 'webpack-livereload-plugin';
 import VirtualModulesPlugin from 'webpack-virtual-modules';

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -57,6 +57,7 @@
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",
     "webpack-livereload-plugin": "^3.0.2",
+    "webpack-subresource-integrity": "^5.1.0",
     "webpack-virtual-modules": "^0.6.2"
   },
   "engines": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR adds and configures the webpack SRI plugin so any dynamically imported chunks are loaded with hash checks ([subresource-integrity-checks](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)) and crossorigin="anonymous". This adds an extra layer of security when loading plugin assets.

>Subresource Integrity (SRI) is a security feature that enables browsers to verify that resources they fetch (for example, from a [CDN](https://developer.mozilla.org/en-US/docs/Glossary/CDN)) are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match.

Plugin bundles that contain code-split chunks have their hashes set within the module.js file. e.g.

![image](https://github.com/user-attachments/assets/50502e54-95b8-47be-9bdd-8207fc64c6c3)

Combining this PR with the additional work of hashing the module.js, passing that hash to the frontend and then telling SystemJS to use it should give us a more secure loading strategy for plugins.

I've now tested this against the grafana/grafana PR that wires up script loading for cdn assets and can confirm this works as expected. I can load a plugin which has dynamic js chunks as usual and if I tamper with one of the chunks and refresh the page the browser refuses to load it.

| Untouched | Tampered |
| --- | --- |
| <img width="1792" alt="Screenshot 2024-09-06 at 15 50 18" src="https://github.com/user-attachments/assets/63cf356e-fddf-425b-a2a4-d50f05e97ddf"> | <img width="1792" alt="Screenshot 2024-09-06 at 15 49 51" src="https://github.com/user-attachments/assets/1ca82be4-efd9-4e50-9ae3-42afa90df0a3"> | 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related: grafana/grafana-community-team/issues/15

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.5.0-canary.999.0dd2652.0
  # or 
  yarn add @grafana/create-plugin@5.5.0-canary.999.0dd2652.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
