### PR TITLE
Create Plugin: Fix CI workflow for E2E tests to successfully run

### DIFF
--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -143,7 +143,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download plugin
-        if: needs.build.outputs.has-backend == 'true'
         uses: actions/download-artifact@v4
         with:
           path: dist

--- a/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/ci/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Execute permissions on binary
         if: needs.build.outputs.has-backend == 'true'
         run: |
-          chmod +x ./dist/gpx_cicd_linux_amd64
+          chmod +x ./dist/gpx_*
 
 {{#if_eq packageManagerName "pnpm"}}
       # pnpm action uses the packageManager field in package.json to
@@ -203,7 +203,7 @@ jobs:
           name: $\{{ matrix.GRAFANA_IMAGE.NAME }}-v$\{{ matrix.GRAFANA_IMAGE.VERSION }}-$\{{github.run_id}}-server-log
           path: grafana-server.log
           retention-days: 5
-  
+
       # Uncomment this step to upload the Playwright report to Github artifacts.
       # If your repository is public, the report will be public on the Internet so beware not to expose sensitive information.
       # - name: Upload artifacts


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR fixes the following issues with a newly scaffolded plugin failing to run e2e tests:

1. The CI workflow currently has a hardcoded backend file name when trying to chmod the files. This PR addresses this by using a wildcard to chmod all files in ./dist that start `gpx_`.
2. The CI workflow currently only downloads the built plugin artefacts if there is a backend component. This PR addresses this by removing the `if` logic in the step.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@4.16.2-canary.1001.ebc5fe7.0
  # or 
  yarn add @grafana/create-plugin@4.16.2-canary.1001.ebc5fe7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
