### PR TITLE
Docs: Add notes on 'build targets' on Get Started

### DIFF
--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -232,7 +232,7 @@ To build for production, run:
 
 ### Build the backend
 
-If your plugin includes a [backend](../key-concepts/backend-plugins/index.md) component, you can build using mage:
+If your plugin includes a [backend](../key-concepts/backend-plugins/index.md) component, you can build using Mage:
 
 ```shell
 mage -v build:linux
@@ -243,12 +243,19 @@ mage -v build:linux
 | Option         | Description                                  | Example               |
 | -------------- | -------------------------------------------- | --------------------- |
 | `build:[arch]` | Builds a binary for a specific architecture. | `mage -v build:Linux` |
+| `build:backend` | Builds a production build for the current platform. | `mage -v build:backend` |
 
 List all available Mage targets for additional commands:
 
 ```bash
 mage -l
 ```
+
+:::note
+
+There is a mismatch between AMD, ARM64, and the Docker container which may cause the backend Delve debugger dev env to fail to run on Apple silicon.
+
+:::
 
 ### Run the Grafana server
 


### PR DESCRIPTION
(Draft) Add a note about a problem running builds on Apple silicon to Get Started topic; add a second example to the Mage description.

Fixes https://github.com/grafana/plugin-tools/issues/1012
