### PR TITLE
Fix a broken links in the documentation.

### DIFF
--- a/docusaurus/docs/tutorials/build-an-app-plugin.md
+++ b/docusaurus/docs/tutorials/build-an-app-plugin.md
@@ -190,4 +190,4 @@ If you want to let users know that your app requires an existing plugin, you can
 
 - [Sign your plugin](../publish-a-plugin/sign-a-plugin.md)
 - [Publish your plugin](../publish-a-plugin/publish-or-update-a-plugin.md)
-- Write [e2e tests](../e2e-test-a-plugin/get-started.md for your plugin
+- Write [e2e tests](../e2e-test-a-plugin/get-started.md) for your plugin


### PR DESCRIPTION
There's a broken link on the plugin tutorials page.
