### PR TITLE
CI: Fix failing docker-compose down command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Stop grafana docker
         if: ${{ matrix.workingDir != 'myorg-nobackend-scenesapp' }}
-        run: docker-compose down
+        run: docker compose down
         working-directory: ./${{ matrix.workingDir }}
 
       - name: Archive E2E output


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR fixes failing CI runs due to something changing in the gh runner (most likely a docker update) where we're seeing errors in CI like:

```
/home/runner/work/_temp/a9afad24-300e-4563-a656-456f6bebcbc1.sh: line 1: docker-compose: command not found
```


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
