### PR TITLE
Create Plugin: Clean up unused publicPath.ts when updating

### DIFF
--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -1,11 +1,20 @@
 import minimist from 'minimist';
 import chalk from 'chalk';
-import { printRedBox, printBlueBox } from '../utils/utils.console.js';
+import {
+  printRedBox,
+  printBlueBox,
+  confirmPrompt,
+  displayArrayAsList,
+  printMessage,
+  printSuccessMessage,
+} from '../utils/utils.console.js';
 import { updatePackageJson, updateNpmScripts } from '../utils/utils.npm.js';
 import { isGitDirectory, isGitDirectoryClean } from '../utils/utils.git.js';
 import { isPluginDirectory, updateDotConfigFolder } from '../utils/utils.plugin.js';
 import { getVersion, getGrafanaRuntimeVersion } from '../utils/utils.version.js';
 import { getPackageManagerFromUserAgent } from '../utils/utils.packageManager.js';
+import { TEXT, UDPATE_CONFIG } from '../constants.js';
+import { getOnlyExistingInCwd, removeFilesInCwd } from '../utils/utils.files.js';
 
 export const update = async (argv: minimist.ParsedArgs) => {
   const { packageManagerName } = getPackageManagerFromUserAgent();
@@ -53,6 +62,11 @@ In case you want to proceed as is please use the ${chalk.bold('--force')} flag.)
       onlyOutdated: true,
       ignoreGrafanaDependencies: false,
     });
+
+    const filesToRemove = getOnlyExistingInCwd(UDPATE_CONFIG.filesToRemove);
+    if (filesToRemove.length) {
+      removeFilesInCwd(filesToRemove);
+    }
 
     printBlueBox({
       title: 'Update successful ✔',

--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -1,13 +1,6 @@
 import minimist from 'minimist';
 import chalk from 'chalk';
-import {
-  printRedBox,
-  printBlueBox,
-  confirmPrompt,
-  displayArrayAsList,
-  printMessage,
-  printSuccessMessage,
-} from '../utils/utils.console.js';
+import { printRedBox, printBlueBox } from '../utils/utils.console.js';
 import { updatePackageJson, updateNpmScripts } from '../utils/utils.npm.js';
 import { isGitDirectory, isGitDirectoryClean } from '../utils/utils.git.js';
 import { isPluginDirectory, updateDotConfigFolder } from '../utils/utils.plugin.js';

--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -6,7 +6,7 @@ import { isGitDirectory, isGitDirectoryClean } from '../utils/utils.git.js';
 import { isPluginDirectory, updateDotConfigFolder } from '../utils/utils.plugin.js';
 import { getVersion, getGrafanaRuntimeVersion } from '../utils/utils.version.js';
 import { getPackageManagerFromUserAgent } from '../utils/utils.packageManager.js';
-import { TEXT, UDPATE_CONFIG } from '../constants.js';
+import { UDPATE_CONFIG } from '../constants.js';
 import { getOnlyExistingInCwd, removeFilesInCwd } from '../utils/utils.files.js';
 
 export const update = async (argv: minimist.ParsedArgs) => {

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -87,7 +87,7 @@ export const UDPATE_CONFIG = {
   // Files that should be overriden between configuration version updates.
   filesToOverride: ['.config/', '.cprc.json'],
   // Files that are no longer needed for the project and can be removed.
-  filesToRemove: ['./config/webpack/publicPath.ts'],
+  filesToRemove: ['.config/webpack/publicPath.ts'],
 };
 
 // prettier-ignore

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -86,6 +86,8 @@ export const MIGRATION_CONFIG = {
 export const UDPATE_CONFIG = {
   // Files that should be overriden between configuration version updates.
   filesToOverride: ['.config/', '.cprc.json'],
+  // Files that are no longer needed for the project and can be removed.
+  filesToRemove: ['./config/webpack/publicPath.ts'],
 };
 
 // prettier-ignore


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds the ability to remove files from a plugin during update. In this PR we use it to delete the publicPath.ts file that is no longer used by webpack to build plugins.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.0.1-canary.1035.a9f09cb.0
  # or 
  yarn add @grafana/create-plugin@5.0.1-canary.1035.a9f09cb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
