### PR TITLE
Create-Plugin: Prevent defaulting values causing prompts to bypass

### DIFF
--- a/packages/create-plugin/src/utils/utils.cli.ts
+++ b/packages/create-plugin/src/utils/utils.cli.ts
@@ -12,8 +12,6 @@ export const argv = minimist(args, {
     pluginName: 'plugin-name',
     orgName: 'org-name',
   },
-  boolean: ['force', 'hasBackend'],
-  string: ['pluginType', 'pluginName', 'orgName', 'feature-flags'],
   unknown: (arg) => {
     printWarning(`Ignoring unknown option: ${arg}.`);
     return false;

--- a/packages/create-plugin/src/utils/utils.cli.ts
+++ b/packages/create-plugin/src/utils/utils.cli.ts
@@ -1,5 +1,4 @@
 import minimist from 'minimist';
-import { printWarning } from './utils.console.js';
 
 export const args = process.argv.slice(2);
 
@@ -11,10 +10,6 @@ export const argv = minimist(args, {
     hasBackend: 'backend',
     pluginName: 'plugin-name',
     orgName: 'org-name',
-  },
-  unknown: (arg) => {
-    printWarning(`Ignoring unknown option: ${arg}.`);
-    return false;
   },
 });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes the issue of not being able to run `update` command and not being able to scaffold backend plugins due to incorrectly set minimist options that recognise "unknown" args and set defaults for booleans.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #1036

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.1.1-canary.1037.06345188962221d.0
  # or 
  yarn add @grafana/create-plugin@5.1.1-canary.1037.06345188962221d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
