### PR TITLE
Create-Plugin: Add smoke tests to scenes app template

### DIFF
--- a/packages/create-plugin/templates/scenes-app/tests/appConfig.spec.ts
+++ b/packages/create-plugin/templates/scenes-app/tests/appConfig.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from './fixtures';
+
+test('should be possible to save app configuration', async ({ appConfigPage, page }) => {
+  const saveButton = page.getByRole('button', { name: /Save API settings/i });
+
+  // reset the configured secret
+  await page.getByRole('button', { name: /reset/i }).click();
+
+  // enter some valid values
+  await page.getByRole('textbox', { name: 'API Key' }).fill('secret-api-key');
+  await page.getByRole('textbox', { name: 'API Url' }).clear();
+  await page.getByRole('textbox', { name: 'API Url' }).fill('http://www.my-awsome-grafana-app.com/api');
+
+  // listen for the server response on the saved form
+  const saveResponse = appConfigPage.waitForSettingsResponse();
+
+  await saveButton.click();
+  await expect(saveResponse).toBeOK();
+});

--- a/packages/create-plugin/templates/scenes-app/tests/appNavigation.spec.ts
+++ b/packages/create-plugin/templates/scenes-app/tests/appNavigation.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from './fixtures';
+import { ROUTES } from '../src/constants';
+
+test.describe('navigating app', () => {
+  test('page Hello World should render successfully', async ({ gotoPage, page }) => {
+    await gotoPage(`/${ROUTES.HelloWorld}`);
+    await expect(page.getByText('Hello world panel')).toBeVisible();
+  });
+
+  test('page With Tabs should render successfully', async ({ gotoPage, page }) => {
+    await gotoPage(`/${ROUTES.WithTabs}`);
+    await expect(page.getByText('This scene showcases a basic tabs functionality.')).toBeVisible();
+  });
+
+  test('page Home should support an id parameter', async ({ gotoPage, page }) => {
+    await gotoPage(`/${ROUTES.Home}`);
+    await expect(
+      page.getByText(
+        'This scene showcases a basic scene functionality, including query runner, variable and a custom scene object.'
+      )
+    ).toBeVisible();
+  });
+
+  test('page With Drilldown should render sucessfully', async ({ gotoPage, page }) => {
+    // wait for page to successfully render
+    await gotoPage(`/${ROUTES.WithDrilldown}`);
+    await expect(
+      page.getByText(
+        'This scene showcases a basic drilldown functionality. Interact with room to see room details scene.'
+      )
+    ).toBeVisible();
+  });
+});

--- a/packages/create-plugin/templates/scenes-app/tests/fixtures.ts
+++ b/packages/create-plugin/templates/scenes-app/tests/fixtures.ts
@@ -1,0 +1,26 @@
+import { AppConfigPage, AppPage, test as base } from '@grafana/plugin-e2e';
+import pluginJson from '../src/plugin.json';
+
+type AppTestFixture = {
+  appConfigPage: AppConfigPage;
+  gotoPage: (path?: string) => Promise<AppPage>;
+};
+
+export const test = base.extend<AppTestFixture>({
+  appConfigPage: async ({ gotoAppConfigPage }, use) => {
+    const configPage = await gotoAppConfigPage({
+      pluginId: pluginJson.id,
+    });
+    await use(configPage);
+  },
+  gotoPage: async ({ gotoAppPage }, use) => {
+    await use((path) =>
+      gotoAppPage({
+        path,
+        pluginId: pluginJson.id,
+      })
+    );
+  },
+});
+
+export { expect } from '@grafana/plugin-e2e';


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds basic smoke tests to the scenes app template. The tests are copied from the [examples repo](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-scenes) and were recently added by Yulia. Adding these smoke tests should allow us to upgrade the scenes package with more confidence (e2e tests for the scaffolded plugin are executed as part of [ci](https://github.com/grafana/plugin-tools/blob/create-plugin/scenes-template-e2e-tests/.github/workflows/ci.yml/#L147-L151)). 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
