### PR TITLE
Create Plugin: Wrap app config fields with `<form>`

### DIFF
--- a/packages/create-plugin/templates/app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/create-plugin/templates/app/src/components/AppConfig/AppConfig.tsx
@@ -30,6 +30,8 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
     isApiKeySet: Boolean(secureJsonFields?.apiKey),
   });
 
+  const isSubmitDisabled = Boolean(!state.apiUrl || (!state.isApiKeySet && !state.apiKey));
+
   const onResetApiKey = () =>
     setState({
       ...state,
@@ -44,8 +46,30 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
     });
   };
 
+  const onSubmit = () => {
+    if (isSubmitDisabled) {
+      return;
+    }
+
+    updatePluginAndReload(plugin.meta.id, {
+      enabled,
+      pinned,
+      jsonData: {
+        apiUrl: state.apiUrl,
+      },
+      // This cannot be queried later by the frontend.
+      // We don't want to override it in case it was set previously and left untouched now.
+      secureJsonData: state.isApiKeySet
+        ? undefined
+        : {
+            apiKey: state.apiKey,
+          },
+    });
+  };
+
   return (
     <div data-testid={testIds.appConfig.container}>
+    <form onSubmit={onSubmit}>
       <FieldSet label="API Settings">
         <Field label="API Key" description="A secret key for authenticating to our custom API">
           <SecretInput
@@ -77,28 +101,13 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
           <Button
             type="submit"
             data-testid={testIds.appConfig.submit}
-            onClick={() =>
-              updatePluginAndReload(plugin.meta.id, {
-                enabled,
-                pinned,
-                jsonData: {
-                  apiUrl: state.apiUrl,
-                },
-                // This cannot be queried later by the frontend.
-                // We don't want to override it in case it was set previously and left untouched now.
-                secureJsonData: state.isApiKeySet
-                  ? undefined
-                  : {
-                      apiKey: state.apiKey,
-                    },
-              })
-            }
-            disabled={Boolean(!state.apiUrl || (!state.isApiKeySet && !state.apiKey))}
+            disabled={isSubmitDisabled}
           >
             Save API settings
           </Button>
         </div>
       </FieldSet>
+      </form>
     </div>
   );
 };

--- a/packages/create-plugin/templates/app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/create-plugin/templates/app/src/components/AppConfig/AppConfig.tsx
@@ -68,7 +68,6 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
   };
 
   return (
-    <div data-testid={testIds.appConfig.container}>
     <form onSubmit={onSubmit}>
       <FieldSet label="API Settings">
         <Field label="API Key" description="A secret key for authenticating to our custom API">
@@ -108,7 +107,6 @@ export const AppConfig = ({ plugin }: AppConfigProps) => {
         </div>
       </FieldSet>
       </form>
-    </div>
   );
 };
 

--- a/packages/create-plugin/templates/app/src/components/testIds.ts
+++ b/packages/create-plugin/templates/app/src/components/testIds.ts
@@ -1,6 +1,5 @@
 export const testIds = {
   appConfig: {
-    container: 'data-testid ac-container',
     apiKey: 'data-testid ac-api-key',
     apiUrl: 'data-testid ac-api-url',
     submit: 'data-testid ac-submit-form',

--- a/packages/create-plugin/templates/scenes-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/components/AppConfig/AppConfig.tsx
@@ -75,44 +75,42 @@ export const AppConfig = ({ plugin }: Props) => {
   };
 
   return (
-    <div data-testid={testIds.appConfig.container}>
-      <form onSubmit={onSubmit}>
-        <FieldSet label="API Settings" className={s.marginTopXl}>
-          {/* API Key */}
-          <Field label="API Key" description="A secret key for authenticating to our custom API">
-            <SecretInput
-              width={60}
-              data-testid={testIds.appConfig.apiKey}
-              id="api-key"
-              value={state?.apiKey}
-              isConfigured={state.isApiKeySet}
-              placeholder={'Your secret API key'}
-              onChange={onChangeApiKey}
-              onReset={onResetApiKey}
-            />
-          </Field>
+    <form onSubmit={onSubmit}>
+      <FieldSet label="API Settings" className={s.marginTopXl}>
+        {/* API Key */}
+        <Field label="API Key" description="A secret key for authenticating to our custom API">
+          <SecretInput
+            width={60}
+            data-testid={testIds.appConfig.apiKey}
+            id="api-key"
+            value={state?.apiKey}
+            isConfigured={state.isApiKeySet}
+            placeholder={'Your secret API key'}
+            onChange={onChangeApiKey}
+            onReset={onResetApiKey}
+          />
+        </Field>
 
-          {/* API Url */}
-          <Field label="API Url" description="" className={s.marginTop}>
-            <Input
-              width={60}
-              id="api-url"
-              data-testid={testIds.appConfig.apiUrl}
-              label={`API Url`}
-              value={state?.apiUrl}
-              placeholder={`E.g.: http://mywebsite.com/api/v1`}
-              onChange={onChangeApiUrl}
-            />
-          </Field>
+        {/* API Url */}
+        <Field label="API Url" description="" className={s.marginTop}>
+          <Input
+            width={60}
+            id="api-url"
+            data-testid={testIds.appConfig.apiUrl}
+            label={`API Url`}
+            value={state?.apiUrl}
+            placeholder={`E.g.: http://mywebsite.com/api/v1`}
+            onChange={onChangeApiUrl}
+          />
+        </Field>
 
-          <div className={s.marginTop}>
-            <Button type="submit" data-testid={testIds.appConfig.submit} disabled={isSubmitDisabled}>
-              Save API settings
-            </Button>
-          </div>
-        </FieldSet>
-      </form>
-    </div>
+        <div className={s.marginTop}>
+          <Button type="submit" data-testid={testIds.appConfig.submit} disabled={isSubmitDisabled}>
+            Save API settings
+          </Button>
+        </div>
+      </FieldSet>
+    </form>
   );
 };
 

--- a/packages/create-plugin/templates/scenes-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/components/AppConfig/AppConfig.tsx
@@ -33,6 +33,8 @@ export const AppConfig = ({ plugin }: Props) => {
     isApiKeySet: Boolean(jsonData?.isApiKeySet),
   });
 
+  const isSubmitDisabled = Boolean(!state.apiUrl || (!state.isApiKeySet && !state.apiKey));
+
   const onResetApiKey = () =>
     setState({
       ...state,
@@ -54,106 +56,62 @@ export const AppConfig = ({ plugin }: Props) => {
     });
   };
 
+  const onSubmit = () => {
+    updatePluginAndReload(plugin.meta.id, {
+      enabled,
+      pinned,
+      jsonData: {
+        apiUrl: state.apiUrl,
+        isApiKeySet: true,
+      },
+      // This cannot be queried later by the frontend.
+      // We don't want to override it in case it was set previously and left untouched now.
+      secureJsonData: state.isApiKeySet
+        ? undefined
+        : {
+            apiKey: state.apiKey,
+          },
+    });
+  };
+
   return (
     <div data-testid={testIds.appConfig.container}>
-      {/* ENABLE / DISABLE PLUGIN */}
-      <FieldSet label="Enable / Disable">
-        {!enabled && (
-          <>
-            <div className={s.colorWeak}>The plugin is currently not enabled.</div>
-            <Button
-              className={s.marginTop}
-              variant="primary"
-              onClick={() =>
-                updatePluginAndReload(plugin.meta.id, {
-                  enabled: true,
-                  pinned: true,
-                  jsonData,
-                })
-              }
-            >
-              Enable plugin
+      <form onSubmit={onSubmit}>
+        <FieldSet label="API Settings" className={s.marginTopXl}>
+          {/* API Key */}
+          <Field label="API Key" description="A secret key for authenticating to our custom API">
+            <SecretInput
+              width={60}
+              data-testid={testIds.appConfig.apiKey}
+              id="api-key"
+              value={state?.apiKey}
+              isConfigured={state.isApiKeySet}
+              placeholder={'Your secret API key'}
+              onChange={onChangeApiKey}
+              onReset={onResetApiKey}
+            />
+          </Field>
+
+          {/* API Url */}
+          <Field label="API Url" description="" className={s.marginTop}>
+            <Input
+              width={60}
+              id="api-url"
+              data-testid={testIds.appConfig.apiUrl}
+              label={`API Url`}
+              value={state?.apiUrl}
+              placeholder={`E.g.: http://mywebsite.com/api/v1`}
+              onChange={onChangeApiUrl}
+            />
+          </Field>
+
+          <div className={s.marginTop}>
+            <Button type="submit" data-testid={testIds.appConfig.submit} disabled={isSubmitDisabled}>
+              Save API settings
             </Button>
-          </>
-        )}
-
-        {/* Disable the plugin */}
-        {enabled && (
-          <>
-            <div className={s.colorWeak}>The plugin is currently enabled.</div>
-            <Button
-              className={s.marginTop}
-              variant="destructive"
-              onClick={() =>
-                updatePluginAndReload(plugin.meta.id, {
-                  enabled: false,
-                  pinned: false,
-                  jsonData,
-                })
-              }
-            >
-              Disable plugin
-            </Button>
-          </>
-        )}
-      </FieldSet>
-
-      {/* CUSTOM SETTINGS */}
-      <FieldSet label="API Settings" className={s.marginTopXl}>
-        {/* API Key */}
-        <Field label="API Key" description="A secret key for authenticating to our custom API">
-          <SecretInput
-            width={60}
-            data-testid={testIds.appConfig.apiKey}
-            id="api-key"
-            value={state?.apiKey}
-            isConfigured={state.isApiKeySet}
-            placeholder={'Your secret API key'}
-            onChange={onChangeApiKey}
-            onReset={onResetApiKey}
-          />
-        </Field>
-
-        {/* API Url */}
-        <Field label="API Url" description="" className={s.marginTop}>
-          <Input
-            width={60}
-            id="api-url"
-            data-testid={testIds.appConfig.apiUrl}
-            label={`API Url`}
-            value={state?.apiUrl}
-            placeholder={`E.g.: http://mywebsite.com/api/v1`}
-            onChange={onChangeApiUrl}
-          />
-        </Field>
-
-        <div className={s.marginTop}>
-          <Button
-            type="submit"
-            data-testid={testIds.appConfig.submit}
-            onClick={() =>
-              updatePluginAndReload(plugin.meta.id, {
-                enabled,
-                pinned,
-                jsonData: {
-                  apiUrl: state.apiUrl,
-                  isApiKeySet: true,
-                },
-                // This cannot be queried later by the frontend.
-                // We don't want to override it in case it was set previously and left untouched now.
-                secureJsonData: state.isApiKeySet
-                  ? undefined
-                  : {
-                      apiKey: state.apiKey,
-                    },
-              })
-            }
-            disabled={Boolean(!state.apiUrl || (!state.isApiKeySet && !state.apiKey))}
-          >
-            Save API settings
-          </Button>
-        </div>
-      </FieldSet>
+          </div>
+        </FieldSet>
+      </form>
     </div>
   );
 };


### PR DESCRIPTION
### What changed?
- **app templates:** wrapped the config fields with a `<form>` element
- **scenes app templates:**
  - wrapped the config fields with a `<form>` element
  - removed the obsolete enable/disable logic (already part of the header)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.3.3-canary.1041.1ab47f9.0
  # or 
  yarn add @grafana/create-plugin@5.3.3-canary.1041.1ab47f9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
