### PR TITLE
Docs: Add app backend component how-to-guide

### DIFF
--- a/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
@@ -18,15 +18,16 @@ import TroubleshootPluginLoad from '@shared/troubleshoot-plugin-doesnt-load.md';
 
 A backend component for an app plugin allows you to extend the app plugin for additional functionality such as custom authentication methods and integration with other services.
 
-# Use cases for backend components in app plugins
+The following are typical use cases for backend components in app plugins:
 
-- Use custom authentication methods and/or authorization checks that aren't supported in Grafana.
-- Running workloads in the server side
+- Use custom authentication methods that aren't supported in Grafana
+- Use authorization checks that aren't supported in Grafana
+- Run workloads on the server side
 - Connect to non-HTTP services that normally can't be connected to from a browser
 
-# Add a backend component to an app plugin
+## Before you begin
 
-## Prerequisites
+Install the following prerequisites before adding a backend component:
 
 - Go ([Version](https://github.com/grafana/plugin-tools/blob/main/packages/create-plugin/templates/backend/go.mod#L3))
 - [Mage](https://magefile.org/)
@@ -41,17 +42,13 @@ A backend component for an app plugin allows you to extend the app plugin for ad
 
 <BackendPluginAnatomy pluginType="app" />
 
-## Troubleshooting
-
-<TroubleshootPluginLoad />
-
 ## Add authentication to your app plugin
 
-To learn more about adding authentication to your app plugin (e.g. to call a custom backend or third-party API) and handling secrets, refer to [Add authentication for app plugins](./add-authentication-for-app-plugins.md).
+To learn more about adding authentication to your app plugin (for example, to call a custom backend or third-party API) and handling secrets, refer to [Add authentication for app plugins](./add-authentication-for-app-plugins.md).
 
-## Access App settings
+## Access app settings
 
-Settings are part of the `AppInstanceSettings` struct. They are passed to the app plugin constructor as the second argument.
+Settings are part of the `AppInstanceSettings` struct. They are passed to the app plugin constructor as the second argument. For example:
 
 ```go title="src/app.go"
 func NewApp(ctx context.Context, settings backend.AppInstanceSettings) (instancemgmt.Instance, error) {
@@ -60,7 +57,7 @@ func NewApp(ctx context.Context, settings backend.AppInstanceSettings) (instance
 }
 ```
 
-You can also get the settings from a request `Context`
+You can also get the settings from a request `Context`:
 
 ```go title="src/resources.go"
 func (a *App) handleMyRequest(w http.ResponseWriter, req *http.Request) {
@@ -71,9 +68,11 @@ func (a *App) handleMyRequest(w http.ResponseWriter, req *http.Request) {
 
 ## Add a custom endpoint to your app plugin
 
+Here's how to add a `ServeMux` or `CallResource` endpoint to your app plugin.
+
 ### ServeMux (recommended)
 
-Your scaffoled app plugin already has a default CallResource that uses [ServeMux](https://pkg.go.dev/net/http#ServeMux). It looks like this:
+Your scaffolded app plugin already has a default `CallResource` that uses [`ServeMux`](https://pkg.go.dev/net/http#ServeMux). It looks like this:
 
 ```go title="app.go"
 type App struct {
@@ -84,7 +83,7 @@ type App struct {
 func NewApp(_ context.Context, _ backend.AppInstanceSettings) (instancemgmt.Instance, error) {
 	var app App
 
-	// Use a httpadapter (provided by the SDK) for resource calls. This allows us
+	// Use an httpadapter (provided by the SDK) for resource calls. This allows us
 	// to use a *http.ServeMux for resource calls, so we can map multiple routes
 	// to CallResource without having to implement extra logic.
 	mux := http.NewServeMux()
@@ -116,7 +115,7 @@ func (a *App) handleMyCustomEndpoint(w http.ResponseWriter, r *http.Request) {
 
 ### CallResource
 
-You can also add custom endpoints to your app plugin by adding a CallResource handler to your backend component directly. You will have to implement the logic to handle multiple requests.
+You can also add custom endpoints to your app plugin by adding a `CallResource` handler to your backend component directly. You must implement the logic to handle multiple requests.
 
 ```go title="app.go"
 func (a *App) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
@@ -137,9 +136,9 @@ func (a *App) CallResource(ctx context.Context, req *backend.CallResourceRequest
 
 You can also see the data sources [documentation on resource handler](../data-source-plugins/add-resource-handler.md) which you can also apply to your app plugin.
 
-### Calling your custom endpoint from frontend code
+### Call your custom endpoint from frontend code
 
-To call your custom endpoint from frontend code, you can use the `fetch` function from `getBackendSrv`. E.g.:
+To call your custom endpoint from frontend code, you can use the `fetch` function from `getBackendSrv`. For example:
 
 ```ts
 import { getBackendSrv } from '@grafana/runtime';
@@ -154,6 +153,10 @@ function getMyCustomEndpoint() {
 }
 ```
 
-### Next steps
+## Troubleshooting
 
-Take a look at our [example app plugin with backend](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-backend) for a complete example.
+<TroubleshootPluginLoad />
+
+## Example
+
+Refer to our [example app plugin with backend](https://github.com/grafana/grafana-plugin-examples/tree/main/examples/app-with-backend) for a complete example.

--- a/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
@@ -58,6 +58,26 @@ By default, Grafana requires backend plugins to be signed. To load unsigned back
 configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#allow-unsigned-plugins).
 For more information, refer to [https://www.action.com/nl-nl/p/1325690/c-c-autowax-en-polijstmiddel/Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).
 
+## Access App settings
+
+Settings are part of the `AppInstanceSettings` struct. They are passed to the app plugin constructor as the second argument.
+
+```go title="src/app.go"
+func NewApp(ctx context.Context, settings backend.AppInstanceSettings) (instancemgmt.Instance, error) {
+  jsonData := settings.JSONData // json.RawMessage
+  secureJsonData := settings.DecryptedSecureJSONData // map[string]string
+}
+```
+
+You can also get the settings from a request `Context`
+
+```go title="src/resources.go"
+func (a *App) handleMyRequest(w http.ResponseWriter, req *http.Request) {
+  pluginConfig := backend.PluginConfigFromContext(req.Context())
+  jsonData := pluginConfig.AppInstanceSettings.JSONData // json.RawMessage
+}
+```
+
 ## Add a custom endpoint to your app plugin
 
 ### ServeMux (recommended)

--- a/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
@@ -1,0 +1,59 @@
+---
+id: add-backend-component
+title: Add a backend component to an app plugin
+description: How to add a backend component to an app plugin
+keywords:
+  - grafana
+  - plugins
+  - plugin
+  - app
+  - backend
+---
+
+import CreatePlugin from '@shared/create-plugin-backend.md';
+import BackendPluginAnatomy from '@shared/backend-plugin-anatomy.md';
+
+Grafana app plugins allow you bundle panels and data sources. Apps also allow you to create custom pages in Grafana with complex functionality.
+
+A backend component for an app plugin allows you to extend the app plugin for additional functionality such as custom authentication methods and integration with other services.
+
+# Use cases for backend components in app plugins
+
+- Use custom authentication methods and/or authorization checks that aren't supported in Grafana.
+- Running workloads in the background
+- Connect to non-HTTP services that normally can't be connected to from a browser
+
+# Add a backend component to an app plugin
+
+## Prerequisites
+
+- Go ([Version](https://github.com/grafana/plugin-tools/blob/main/packages/create-plugin/templates/backend/go.mod#L3))
+- [Mage](https://magefile.org/)
+- [LTS](https://nodejs.dev/en/about/releases/) version of Node.js
+- [Docker](https://docs.docker.com/get-docker/)
+
+## Create a new app plugin
+
+<CreatePlugin pluginType="app" />
+
+## Anatomy of a backend plugin
+
+<BackendPluginAnatomy pluginType="app" />
+
+## Troubleshooting
+
+### Grafana doesn't load my plugin
+
+Ensure that Grafana has been started in development mode. If you are running Grafana from source, you'll need to add the following line to your `conf/custom.ini` file (if you don't have one already, go ahead and create this file before proceeding):
+
+```ini
+app_mode = development
+```
+
+You can then start Grafana in development mode by running `make run & make run-frontend` in the Grafana repository root.
+
+If you are running Grafana from a binary or inside a Docker container, you can start it in development mode by setting the environment variable `GF_DEFAULT_APP_MODE` to `development`.
+
+By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
+configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#allow-unsigned-plugins).
+For more information, refer to [Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).

--- a/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
@@ -13,7 +13,7 @@ keywords:
 import CreatePlugin from '@shared/create-plugin-backend.md';
 import BackendPluginAnatomy from '@shared/backend-plugin-anatomy.md';
 
-Grafana app plugins allow you bundle panels and data sources. Apps also allow you to create custom pages in Grafana with complex functionality.
+# Add a backend component to an app plugin
 
 A backend component for an app plugin allows you to extend the app plugin for additional functionality such as custom authentication methods and integration with other services.
 
@@ -56,4 +56,70 @@ If you are running Grafana from a binary or inside a Docker container, you can s
 
 By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
 configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#allow-unsigned-plugins).
-For more information, refer to [Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).
+For more information, refer to [https://www.action.com/nl-nl/p/1325690/c-c-autowax-en-polijstmiddel/Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).
+
+## Add a custom endpoint to your app plugin
+
+### ServeMux (recommended)
+
+Your scaffoled app plugin already has a default CallResource that uses [ServeMux](https://pkg.go.dev/net/http#ServeMux).
+
+You can add custom endpoints to your app plugin in the `resources.go` file. E.g.:
+
+```go title="resources.go"
+// this function already exists in the scaffolded app plugin
+func (a *App) registerRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/myCustomEndpoint", a.handleMyCustomEndpoint)
+}
+
+func (a *App) handleMyCustomEndpoint(w http.ResponseWriter, r *http.Request) {
+  // handle the request
+  // e.g. call a third-party API
+  w.Write([]byte("my custom response"))
+  w.WriteHeader(http.StatusOK)
+}
+```
+
+### CallResource
+
+You can also add custom endpoints to your app plugin by adding a CallResource handler to your backend component directly. You will have to implement the logic to handle multiple requests.
+
+```go title="app.go"
+func (a *App) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+	switch req.Path {
+	case "myCustomEndpoint":
+		sender.Send(&backend.CallResourceResponse{
+			Status: http.StatusOK,
+			Body:   []byte("my custom response"),
+		})
+	default:
+		return sender.Send(&backend.CallResourceResponse{
+			Status: http.StatusNotFound,
+		})
+	}
+	return nil
+}
+```
+
+You can also see the data sources [documentation on resource handler](../data-source-plugins/add-resource-handler.md) which you can also apply to your app plugin.
+
+### Calling your custom endpoint from frontend code
+
+To call your custom endpoint from frontend code, you can use the `fetch` function from `getBackendSrv`. E.g.:
+
+```ts
+import { getBackendSrv } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
+
+function getMyCustomEndpoint() {
+  const response = await getBackendSrv().fetch({
+    // replace ${PLUGIN_ID} with your plugin id
+    url: '/api/plugins/${PLUGIN_ID}/myCustomEndpoint',
+  });
+  return await lastValueFrom(response);
+}
+```
+
+## Add authentication to your app plugin
+
+To learn more about adding authentication to your app plugin and handling secrets, refer to [Add authentication for app plugins](./add-authentication-for-app-plugins.md).

--- a/docusaurus/docs/shared/backend-plugin-anatomy.md
+++ b/docusaurus/docs/shared/backend-plugin-anatomy.md
@@ -1,0 +1,18 @@
+The folders and files used to build the backend for the {props.pluginType} are:
+
+| file/folder        | description                                                                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Magefile.go`      | It’s not a requirement to use mage build files, but we strongly recommend using it so that you can use the build targets provided by the plugin SDK. |
+| `/go.mod `         | Go [modules dependencies](https://golang.org/cmd/go/#hdr-The_go_mod_file)                                                                            |
+| `/src/plugin.json` | A JSON file describing the plugin                                                                                                                    |
+| `/pkg/main.go`     | Starting point of the plugin binary.                                                                                                                 |
+
+#### plugin.json
+
+The [plugin.json](../reference/metadata.md) file is required for all plugins. When building a backend plugin these properties are important:
+
+| property   | description                                                                                                                          |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| backend    | Set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin.                         |
+| executable | This is the name of the executable that Grafana expects to start, see [plugin.json reference](../reference/metadata.md) for details. |
+| alerting   | If your backend data source supports alerting, set to `true`. Requires `backend` to be set to `true`.                                |

--- a/docusaurus/docs/shared/backend-plugin-anatomy.md
+++ b/docusaurus/docs/shared/backend-plugin-anatomy.md
@@ -1,18 +1,18 @@
 The folders and files used to build the backend for the {props.pluginType} are:
 
-| file/folder        | description                                                                                                                                          |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Magefile.go`      | It’s not a requirement to use mage build files, but we strongly recommend using it so that you can use the build targets provided by the plugin SDK. |
-| `/go.mod `         | Go [modules dependencies](https://golang.org/cmd/go/#hdr-The_go_mod_file)                                                                            |
-| `/src/plugin.json` | A JSON file describing the plugin                                                                                                                    |
-| `/pkg/main.go`     | Starting point of the plugin binary.                                                                                                                 |
+| file/folder        | description                                                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Magefile.go`      | It’s not a requirement to use mage build files, but we strongly recommend using them so that you can use the build targets provided by the plugin SDK. |
+| `/go.mod `         | Go [modules dependencies](https://golang.org/cmd/go/#hdr-The_go_mod_file).                                                                             |
+| `/src/plugin.json` | A JSON file describing the plugin.                                                                                                                     |
+| `/pkg/main.go`     | Starting point of the plugin binary.                                                                                                                   |
 
-#### plugin.json
+#### The plugin.json file
 
-The [plugin.json](../reference/metadata.md) file is required for all plugins. When building a backend plugin these properties are important:
+The [`plugin.json`](../reference/metadata.md) file is required for all plugins. When building a backend plugin, pay attention especially to these properties:
 
-| property   | description                                                                                                                          |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| backend    | Set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin.                         |
-| executable | This is the name of the executable that Grafana expects to start, see [plugin.json reference](../reference/metadata.md) for details. |
-| alerting   | If your backend data source supports alerting, set to `true`. Requires `backend` to be set to `true`.                                |
+| property     | description                                                                                                                               |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `backend`    | Set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin.                              |
+| `executable` | This is the name of the executable that Grafana expects to start. Refer to [plugin.json reference](../reference/metadata.md) for details. |
+| `alerting`   | If your backend data source supports alerting, set to `true`. Requires `backend` to be set to `true`.                                     |

--- a/docusaurus/docs/shared/troubleshoot-plugin-doesnt-load.md
+++ b/docusaurus/docs/shared/troubleshoot-plugin-doesnt-load.md
@@ -12,4 +12,4 @@ If you are running Grafana from a binary or inside a Docker container, you can s
 
 By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
 configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#allow-unsigned-plugins).
-For more information, refer to [https://www.action.com/nl-nl/p/1325690/c-c-autowax-en-polijstmiddel/Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).
+For more information, refer to [Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).

--- a/docusaurus/docs/shared/troubleshoot-plugin-doesnt-load.md
+++ b/docusaurus/docs/shared/troubleshoot-plugin-doesnt-load.md
@@ -1,15 +1,23 @@
-#### Grafana doesn't load my plugin
+### Grafana doesn't load my plugin
 
-Ensure that Grafana has been started in development mode. If you are running Grafana from source, you'll need to add the following line to your `conf/custom.ini` file (if you don't have one already, go ahead and create this file before proceeding):
+Ensure that Grafana has been started in development mode. If you are running Grafana from source, add the following line to your `conf/custom.ini` file:
 
 ```ini
 app_mode = development
 ```
 
+:::note
+
+If you don't have a `conf/custom.ini` file already, create it before proceeding.
+
+:::
+
 You can then start Grafana in development mode by running `make run & make run-frontend` in the Grafana repository root.
 
 If you are running Grafana from a binary or inside a Docker container, you can start it in development mode by setting the environment variable `GF_DEFAULT_APP_MODE` to `development`.
 
-By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
-configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#allow-unsigned-plugins).
-For more information, refer to [Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).
+:::note
+
+By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#allow-unsigned-plugins). For more information, refer to [Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).
+
+:::

--- a/docusaurus/docs/shared/troubleshoot-plugin-doesnt-load.md
+++ b/docusaurus/docs/shared/troubleshoot-plugin-doesnt-load.md
@@ -1,0 +1,15 @@
+#### Grafana doesn't load my plugin
+
+Ensure that Grafana has been started in development mode. If you are running Grafana from source, you'll need to add the following line to your `conf/custom.ini` file (if you don't have one already, go ahead and create this file before proceeding):
+
+```ini
+app_mode = development
+```
+
+You can then start Grafana in development mode by running `make run & make run-frontend` in the Grafana repository root.
+
+If you are running Grafana from a binary or inside a Docker container, you can start it in development mode by setting the environment variable `GF_DEFAULT_APP_MODE` to `development`.
+
+By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
+configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#allow-unsigned-plugins).
+For more information, refer to [https://www.action.com/nl-nl/p/1325690/c-c-autowax-en-polijstmiddel/Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).

--- a/docusaurus/docs/tutorials/build-a-data-source-backend-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-backend-plugin.md
@@ -14,6 +14,7 @@ keywords:
 
 import CreatePlugin from '@shared/create-plugin-backend.md';
 import BackendPluginAnatomy from '@shared/backend-plugin-anatomy.md';
+import TroubleshootPluginLoad from '@shared/troubleshoot-plugin-doesnt-load.md';
 
 ## Introduction
 
@@ -56,21 +57,7 @@ To add the data source to the dashboard:
 
 ### Troubleshooting
 
-#### Grafana doesn't load my plugin
-
-Ensure that Grafana has been started in development mode. If you are running Grafana from source, you'll need to add the following line to your `conf/custom.ini` file (if you don't have one already, go ahead and create this file before proceeding):
-
-```ini
-app_mode = development
-```
-
-You can then start Grafana in development mode by running `make run & make run-frontend` in the Grafana repository root.
-
-If you are running Grafana from a binary or inside a Docker container, you can start it in development mode by setting the environment variable `GF_DEFAULT_APP_MODE` to `development`.
-
-By default, Grafana requires backend plugins to be signed. To load unsigned backend plugins, you need to
-configure Grafana to [allow unsigned plugins](https://grafana.com/docs/grafana/latest/administration/plugin-management/#allow-unsigned-plugins).
-For more information, refer to [Plugin signature verification](https://grafana.com/docs/grafana/latest/administration/plugin-management/#backend-plugins).
+<TroubleshootPluginLoad />
 
 ## Anatomy of a backend plugin
 

--- a/docusaurus/docs/tutorials/build-a-data-source-backend-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-backend-plugin.md
@@ -13,6 +13,7 @@ keywords:
 ---
 
 import CreatePlugin from '@shared/create-plugin-backend.md';
+import BackendPluginAnatomy from '@shared/backend-plugin-anatomy.md';
 
 ## Introduction
 
@@ -72,24 +73,7 @@ For more information, refer to [Plugin signature verification](https://grafana.c
 
 ## Anatomy of a backend plugin
 
-The folders and files used to build the backend for the data source are:
-
-| file/folder        | description                                                                                                                                          |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Magefile.go`      | It’s not a requirement to use mage build files, but we strongly recommend using it so that you can use the build targets provided by the plugin SDK. |
-| `/go.mod `         | Go [modules dependencies](https://golang.org/cmd/go/#hdr-The_go_mod_file)                                                                            |
-| `/src/plugin.json` | A JSON file describing the backend plugin                                                                                                            |
-| `/pkg/main.go`     | Starting point of the plugin binary.                                                                                                                 |
-
-#### plugin.json
-
-The [plugin.json](../reference/metadata.md) file is required for all plugins. When building a backend plugin these properties are important:
-
-| property   | description                                                                                                                          |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| backend    | Set to `true` for backend plugins. This tells Grafana that it should start a binary when loading the plugin.                         |
-| executable | This is the name of the executable that Grafana expects to start, see [plugin.json reference](../reference/metadata.md) for details. |
-| alerting   | If your backend data source supports alerting, set to `true`. Requires `backend` to be set to `true`.                                |
+<BackendPluginAnatomy pluginType="data source" />
 
 In the next step we will look at the query endpoint!
 


### PR DESCRIPTION
Adds a new documentation page on how to add a backend component to app plugins.

Closes https://github.com/grafana/plugin-tools/issues/1031
