### PR TITLE
Docs: Fix broken links in plugin-types-usage

### DIFF
--- a/docusaurus/docs/key-concepts/plugin-types-usage.md
+++ b/docusaurus/docs/key-concepts/plugin-types-usage.md
@@ -30,7 +30,7 @@ Grafana plugin development allows for many options depending on the type of user
 - **Data-source plugin** - a connection to a new database or other source of data.
 - **App plugin** - an integrated out-of-the-box experience.
 
-Refer to [Get started](../get-started/get-started.mdx) for instructions on how to quickly scaffold [each type](https://grafana.com/developers/plugin-tools/reference/prompts.md/#what-type-of-plugin-would-you-like) of plugin.
+Refer to [Get started](../get-started/get-started.mdx) for instructions on how to quickly scaffold [each type](https://grafana.com/developers/plugin-tools/reference/prompts#select-a-plugin-type) of plugin.
 
 :::note
 
@@ -88,7 +88,7 @@ Note that a plugin of type `datasource` must be installed before it can be provi
 
 ### Bundling of dashboards
 
-Data-source plugins can [include dashboards](https://grafana.com/developers/docs/reference/metadata.md#includes) by referencing dashboard JSON files (including `property` and `type=dashboard`) within the `plugin.json` file. Grafana puts a dashboard in the `General` folder when it is imported.
+Data-source plugins can [include dashboards](https://grafana.com/developers/plugin-tools/reference/plugin-json#includes) by referencing dashboard JSON files (including `property` and `type=dashboard`) within the `plugin.json` file. Grafana puts a dashboard in the `General` folder when it is imported.
 
 ## App plugins
 
@@ -122,7 +122,7 @@ Note that the plugin must be installed before provisioning can succeed with a `p
 
 ### Bundling of apps
 
-The app plugin type allows you to [nest other plugins inside it](../how-to-guides/app-plugins/work-with-nested-plugins); in other words, to bundle or [include](https://grafana.com/developers/docs/reference/metadata.md#includes) multiple plugins in the same package.
+The app plugin type allows you to [nest other plugins inside it](../how-to-guides/app-plugins/work-with-nested-plugins); in other words, to bundle or [include](https://grafana.com/developers/plugin-tools/reference/plugin-json#includes) multiple plugins in the same package.
 
 ### Bundling of dashboards
 

--- a/docusaurus/docs/key-concepts/plugin-types-usage.md
+++ b/docusaurus/docs/key-concepts/plugin-types-usage.md
@@ -30,7 +30,7 @@ Grafana plugin development allows for many options depending on the type of user
 - **Data-source plugin** - a connection to a new database or other source of data.
 - **App plugin** - an integrated out-of-the-box experience.
 
-Refer to [Get started](../get-started/get-started.mdx) for instructions on how to quickly scaffold [each type](https://grafana.com/developers/plugin-tools/reference/prompts#select-a-plugin-type) of plugin.
+Refer to [Get started](../get-started/get-started.mdx) for instructions on how to quickly scaffold [each type](../reference/prompts.md#select-a-plugin-type) of plugin.
 
 :::note
 
@@ -88,7 +88,7 @@ Note that a plugin of type `datasource` must be installed before it can be provi
 
 ### Bundling of dashboards
 
-Data-source plugins can [include dashboards](https://grafana.com/developers/plugin-tools/reference/plugin-json#includes) by referencing dashboard JSON files (including `property` and `type=dashboard`) within the `plugin.json` file. Grafana puts a dashboard in the `General` folder when it is imported.
+Data-source plugins can [include dashboards](../reference/metadata.md#includes) by referencing dashboard JSON files (including `property` and `type=dashboard`) within the `plugin.json` file. Grafana puts a dashboard in the `General` folder when it is imported.
 
 ## App plugins
 
@@ -122,7 +122,7 @@ Note that the plugin must be installed before provisioning can succeed with a `p
 
 ### Bundling of apps
 
-The app plugin type allows you to [nest other plugins inside it](../how-to-guides/app-plugins/work-with-nested-plugins); in other words, to bundle or [include](https://grafana.com/developers/plugin-tools/reference/plugin-json#includes) multiple plugins in the same package.
+The app plugin type allows you to [nest other plugins inside it](../how-to-guides/app-plugins/work-with-nested-plugins); in other words, to bundle or [include](../reference/metadata.md#includes) multiple plugins in the same package.
 
 ### Bundling of dashboards
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes some links which were not working in [plugin-types-usage](https://grafana.com/developers/plugin-tools/key-concepts/plugin-types-usage) page.

**Which issue(s) this PR fixes**:
None that I could find.
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
It feels like full links are mixed with references and there could be a better/more unified way of fixing links, however, this PR should serve as a quick fix to, at least, get those links up again!  