### PR TITLE
Chore: replace docker-compose with docker compose commands

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Start Grafana
         run: |
           cd packages/plugin-e2e
-          docker-compose pull
-          AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} AWS_ACCESS_KEY_ID=${{secrets.AWS_ACCESS_KEY_ID}} GOOGLE_JWT_FILE=${{secrets.GOOGLE_JWT_FILE}} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} docker-compose up -d
+          docker compose pull
+          AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} AWS_ACCESS_KEY_ID=${{secrets.AWS_ACCESS_KEY_ID}} GOOGLE_JWT_FILE=${{secrets.GOOGLE_JWT_FILE}} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} docker compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -183,7 +183,7 @@ Run the following commands to get started:
     * npm exec playwright install chromium to install e2e test dependencies.
     * npm run dev to build (and watch) the plugin frontend code.
     * mage -v build:backend to build the plugin backend code. Rerun this command every time you edit your backend files.
-    * docker-compose up to start a grafana development server.
+    * docker compose up to start a grafana development server.
     * Open http://localhost:3000 in your browser to create a dashboard to begin developing your plugin.
 
 Note: We strongly recommend creating a new Git repository by running git init in ./org-pluginname-app before continuing.
@@ -255,7 +255,7 @@ mage -l
 To launch the Grafana development server using Docker, run:
 
 ```shell
-docker-compose up --build
+docker compose up --build
 ```
 
 Congratulations! You've just scaffolded your first plugin which you can now access at [http://localhost:3000](http://localhost:3000).

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -83,7 +83,7 @@ services:
         grafana_image: ${GRAFANA_IMAGE:-grafana}
 ```
 
-This example assigns the environment variable `GRAFANA_IMAGE` to the build arg `grafana_image` with a default value of `grafana`. This gives you the option to set the value when running `docker-compose` commands.
+This example assigns the environment variable `GRAFANA_IMAGE` to the build arg `grafana_image` with a default value of `grafana`. This gives you the option to set the value when running `docker compose` commands.
 
 ### Debugging Backend plugin
 

--- a/docusaurus/docs/shared/create-plugin-backend.md
+++ b/docusaurus/docs/shared/create-plugin-backend.md
@@ -33,7 +33,7 @@ The Grafana [create-plugin tool](https://www.npmjs.com/package/@grafana/create-p
 1. Start Grafana:
 
    ```shell
-   docker-compose up
+   docker compose up
    ```
 
 1. <span>Open Grafana, by default <a href="http://localhost:3000/">http://localhost:3000/</a>, and then go to <b>Administration</b> > <b>Plugins</b>. Make sure that your {props.pluginType} plugin is there.</span>

--- a/docusaurus/docs/shared/create-plugin-frontend.md
+++ b/docusaurus/docs/shared/create-plugin-frontend.md
@@ -27,7 +27,7 @@ The Grafana [create-plugin tool](https://www.npmjs.com/package/@grafana/create-p
 1. Start Grafana:
 
    ```shell
-   docker-compose up
+   docker compose up
    ```
 
 1. <span>Open Grafana, by default <a href="http://localhost:3000/">http://localhost:3000/</a>, and then go to <b>Administration</b> > <b>Plugins</b>. Make sure that your {props.pluginType} plugin is there.</span>

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.npm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.npm.md
@@ -57,8 +57,8 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker-compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+          docker compose pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.pnpm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.pnpm.md
@@ -59,8 +59,8 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker-compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+          docker compose pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.yarn.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.yarn.md
@@ -57,8 +57,8 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker-compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+          docker compose pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.npm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.npm.md
@@ -49,8 +49,8 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker-compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+          docker compose pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.pnpm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.pnpm.md
@@ -51,8 +51,8 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker-compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+          docker compose pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.yarn.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.yarn.md
@@ -49,8 +49,8 @@ jobs:
 
       - name: Start Grafana
         run: |
-          docker-compose pull
-          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker-compose up -d
+          docker compose pull
+          GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose up -d
 
       - name: Wait for Grafana to start
         uses: nev7n/wait_for_response@v1

--- a/docusaurus/docs/troubleshooting.md
+++ b/docusaurus/docs/troubleshooting.md
@@ -84,12 +84,12 @@ module.exports = {
 };
 ```
 
-### I get `"image with reference <plugin-name> was found but does not match the specified platform: wanted linux/amd64, actual: linux/arm64/v8"` after running `docker-compose up` or `npm run server`.
+### I get `"image with reference <plugin-name> was found but does not match the specified platform: wanted linux/amd64, actual: linux/arm64/v8"` after running `docker compose up` or `npm run server`.
 
-This error is most likely to impact users of Mac computers with Apple silicon. If you have previously built an image for a plugin scaffolded with `create-plugin` prior to v1.12.2, then running `docker-compose up` may fail with the above message if the old image hasn't been removed.
+This error is most likely to impact users of Mac computers with Apple silicon. If you have previously built an image for a plugin scaffolded with `create-plugin` prior to v1.12.2, then running `docker compose up` may fail with the above message if the old image hasn't been removed.
 
 #### What you can do:
 
-- Run `docker-compose down` to stop and remove the container.
+- Run `docker compose down` to stop and remove the container.
 - Remove the image using `docker rmi <plugin-name>`.
-- Run `docker-compose up` or `npm run server`.
+- Run `docker compose up` or `npm run server`.

--- a/docusaurus/docs/tutorials/build-a-streaming-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-streaming-data-source-plugin.md
@@ -291,13 +291,13 @@ However, there is an easier way of doing all this.
 npm run server
 ```
 
-This command runs a Grafana container using docker-compose and puts the built plugins in the right place.
+This command runs a Grafana container using docker compose and puts the built plugins in the right place.
 
 2. To verify the build, go to Grafana at `https://localhost:3000`.
 
 :::note
 
-You may be using Docker Compose instead of docker-compose. If that is your case, you just need to change the command in the `package.json` in the project's root directory.
+You may be using Docker Compose instead of docker compose. If that is your case, you just need to change the command in the `package.json` in the project's root directory.
 
 :::
 
@@ -305,7 +305,7 @@ You may be using Docker Compose instead of docker-compose. If that is your case,
 
 1. From Grafana at `https://localhost:3000`, use the default credentials: username `admin` and password `admin`. If you're not presented with a login page, click **Sign in** in the top of the page and insert the credentials.
 
-2. Add the data source. Since we are running in our `docker-compose` environment, we don't need to install it, and it will be directly available for usage. Go to **Connections > Data sources**, using the left menu as shown in the following image:
+2. Add the data source. Since we are running in our `docker compose` environment, we don't need to install it, and it will be directly available for usage. Go to **Connections > Data sources**, using the left menu as shown in the following image:
 
 3. A new page opens, and then click **Add data source**. Grafana opens another page where you can search for the data source name that we've just created.
 

--- a/docusaurus/docs/tutorials/build-a-streaming-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-streaming-data-source-plugin.md
@@ -295,12 +295,6 @@ This command runs a Grafana container using docker compose and puts the built pl
 
 2. To verify the build, go to Grafana at `https://localhost:3000`.
 
-:::note
-
-You may be using Docker Compose instead of docker compose. If that is your case, you just need to change the command in the `package.json` in the project's root directory.
-
-:::
-
 ## Step 7: Test the plugin
 
 1. From Grafana at `https://localhost:3000`, use the default credentials: username `admin` and password `admin`. If you're not presented with a login page, click **Sign in** in the top of the page and insert the credentials.

--- a/packages/create-plugin/src/commands/generate/print-success-message.ts
+++ b/packages/create-plugin/src/commands/generate/print-success-message.ts
@@ -18,7 +18,7 @@ export function printGenerateSuccessMessage(answers: TemplateData) {
           `- ${getBackendCmd()} to build the plugin backend code. Rerun this command every time you edit your backend files.`,
         ]
       : []),
-    '- `docker-compose up` to start a grafana development server.',
+    '- `docker compose up` to start a grafana development server.',
     '- Open http://localhost:3000 in your browser to create a dashboard to begin developing your plugin.',
   ];
 

--- a/packages/create-plugin/templates/common/.config/README.md
+++ b/packages/create-plugin/templates/common/.config/README.md
@@ -159,6 +159,6 @@ services:
         grafana_image: ${GRAFANA_IMAGE:-grafana}
 ```
 
-In this example, we assign the environment variable `GRAFANA_IMAGE` to the build arg `grafana_image` with a default value of `grafana`. This will allow you to set the value while running the docker-compose commands, which might be convenient in some scenarios.
+In this example, we assign the environment variable `GRAFANA_IMAGE` to the build arg `grafana_image` with a default value of `grafana`. This will allow you to set the value while running the docker compose commands, which might be convenient in some scenarios.
 
 ---

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -12,7 +12,7 @@
     "e2e": "playwright test",{{/if}}{{#if useCypress}}
     "e2e": "{{ packageManagerName }} exec cypress install && {{ packageManagerName }} exec grafana-e2e run",
     "e2e:update": "{{ packageManagerName }} exec cypress install && {{ packageManagerName }} exec grafana-e2e run --update-screenshots",{{/if}}
-    "server": "docker-compose up --build",
+    "server": "docker compose up --build",
     "sign": "npx --yes @grafana/sign-plugin@latest"
   },
   "author": "{{ sentenceCase orgName }}",

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -23,7 +23,7 @@
     "dev": "nodemon --exec 'tsc'",
     "lint": "eslint --cache --ext .js,.jsx,.ts,.tsx ./src",
     "lint:fix": "npm run lint -- --fix",
-    "server": "docker-compose up --build",
+    "server": "docker compose up --build",
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "test": "vitest",
     "playwright:test": "npx playwright test",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Following this PR https://github.com/grafana/plugin-tools/pull/1046

We should move on to using the `Compose V2` version as V1 was deprecated and stopped receiving updates a year ago.
https://docs.docker.com/compose/migrate/


**Which issue(s) this PR fixes**:
This PR is basically a search and replace from `docker-compose` to `docker compose`

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.3.0-canary.1064.5ba9704.0
  npm install @grafana/plugin-e2e@1.7.0-canary.1064.5ba9704.0
  # or 
  yarn add @grafana/create-plugin@5.3.0-canary.1064.5ba9704.0
  yarn add @grafana/plugin-e2e@1.7.0-canary.1064.5ba9704.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
