### PR TITLE
Create Plugin: Fix support yarn pnp with virtual modules

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -22,7 +22,7 @@ const pluginJson = getPluginJson();
 const cpVersion = getCPConfigVersion();
 
 const virtualPublicPath = new VirtualModulesPlugin({
-  'node_modules/grafana-public-path.js': `
+  'virtual_modules/grafana-public-path.js': `
 import amdMetaModule from 'amd-module';
 
 __webpack_public_path__ =
@@ -247,7 +247,7 @@ const config = async (env): Promise<Configuration> => {
     resolve: {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
       // handle resolving "rootDir" paths
-      modules: [path.resolve(process.cwd(), 'src'), 'node_modules'],
+      modules: [path.resolve(process.cwd(), 'src'), 'node_modules', 'virtual_modules'],
       unsafeCache: true,
     },
   };

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -51,6 +51,7 @@
     "sass-loader": "13.3.1",
     "style-loader": "3.3.3",
     "swc-loader": "^0.2.3",
+    "terser-webpack-plugin": "^5.3.10",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "4.8.4",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It looks like yarn pnp's resolution hijacking causes the current virtual public path setup to fail as it redirects everything to it's zipped dependencies which causes the virtual module to fail to be found. This PR addresses it by moving the file to a virtual_modules directory and including this directory in module resolution webpack settings.

Supporting yarn pnp is a bit of a thorny issue, won't merge this until we reach some consensus.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.3.3-canary.1069.afa1a66.0
  # or 
  yarn add @grafana/create-plugin@5.3.3-canary.1069.afa1a66.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
