### PR TITLE
Plugin E2E: Fix typings for the toHaveAlert matcher

### DIFF
--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -134,7 +134,7 @@ declare global {
       /**
        * Asserts that a GrafanaPage contains an alert with the specified severity. Use the options to specify the timeout and to filter the alerts.
        */
-      toHaveAlert(this: Matchers<unknown, GrafanaPage>, severity: AlertVariant, options?: AlertPageOptions): R;
+      toHaveAlert(this: Matchers<unknown, GrafanaPage>, severity: AlertVariant, options?: AlertPageOptions): Promise<R>;
     }
   }
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

 Fix typings for the toHaveAlert expect matcher.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/plugin-tools/issues/1010

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.3.0-canary.1070.82881c3.0
  npm install @grafana/plugin-e2e@1.7.0-canary.1070.82881c3.0
  # or 
  yarn add @grafana/create-plugin@5.3.0-canary.1070.82881c3.0
  yarn add @grafana/plugin-e2e@1.7.0-canary.1070.82881c3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
