### PR TITLE
Create Plugin: Fix missing module.ts in sourcemaps

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -98,6 +98,18 @@ const config = async (env): Promise<Configuration> => {
 
     module: {
       rules: [
+        // This must come first in the rules array otherwise it breaks sourcemaps.
+        {
+          test: /src\/(?:.*\/)?module\.tsx?$/,
+          use: [
+            {
+              loader: 'imports-loader',
+              options: {
+                imports: `side-effects grafana-public-path`,
+              },
+            },
+          ],
+        },
         {
           exclude: /(node_modules)/,
           test: /\.[tj]sx?$/,
@@ -117,17 +129,6 @@ const config = async (env): Promise<Configuration> => {
               },
             },
           },
-        },
-        {
-          test: /src\/(?:.*\/)?module\.tsx?$/,
-          use: [
-            {
-              loader: 'imports-loader',
-              options: {
-                imports: `side-effects grafana-public-path`,
-              },
-            },
-          ],
         },
         {
           test: /\.css$/,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Whilst working on stripping console statements from production builds I noticed sourcemaps didn't contain the module.ts entrypoint. Placing the imports-loader first in the list of module.rules appears to fix this. Below are screenshots of me attempting to place breakpoints in devtools that should resolve to the module.ts file.

### Before
<img width="1792" alt="Screenshot 2024-08-21 at 12 37 22" src="https://github.com/user-attachments/assets/182ac1b8-6d3b-403a-8d01-92238a38e935">

### After
<img width="1792" alt="Screenshot 2024-08-21 at 12 35 53" src="https://github.com/user-attachments/assets/78c28dd6-ce66-459c-897d-51b4479393ac">

Additionally it appears to work fine with plugin validator:

![image](https://github.com/user-attachments/assets/a25f34e7-9b8c-4ae3-a8f2-abb67a3b36b6)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.3.1-canary.1071.d689f04.0
  # or 
  yarn add @grafana/create-plugin@5.3.1-canary.1071.d689f04.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
