### PR TITLE
Create Plugin: Use new JSX transform

### DIFF
--- a/docusaurus/docs/how-to-guides/data-source-plugins/add-features-for-explore-queries.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/add-features-for-explore-queries.md
@@ -22,8 +22,6 @@ To extend Explore functionality for your data source, define an Explore-specific
 1. Create a file `ExploreQueryEditor.tsx` in the `src` directory of your plugin, with content similar to this:
 
    ```tsx title="src/ExploreQueryEditor.tsx"
-   import React from 'react';
-
    import { QueryEditorProps } from '@grafana/data';
    import { QueryField } from '@grafana/ui';
    import { DataSource } from './DataSource';

--- a/docusaurus/docs/how-to-guides/data-source-plugins/add-query-editor-help.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/add-query-editor-help.md
@@ -16,7 +16,6 @@ Query editors support the addition of a help component to display examples of po
 1. In the `src` directory of your plugin, create a file `QueryEditorHelp.tsx` with the following content:
 
    ```ts
-   import React from 'react';
    import { QueryEditorHelpProps } from '@grafana/data';
 
    export default (props: QueryEditorHelpProps) => {
@@ -40,7 +39,6 @@ Query editors support the addition of a help component to display examples of po
 1. Create a few examples of potential queries:
 
    ```tsx
-   import React from 'react';
    import { QueryEditorHelpProps, DataQuery } from '@grafana/data';
 
    const examples = [

--- a/docusaurus/docs/how-to-guides/data-source-plugins/add-support-for-variables.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/add-support-for-variables.md
@@ -133,7 +133,7 @@ Let's create a custom query editor to allow the user to edit the query model.
 1. Create a `VariableQueryEditor` component:
 
    ```tsx title="src/VariableQueryEditor.tsx"
-   import React, { useState } from 'react';
+   import { useState } from 'react';
    import { MyVariableQuery } from './types';
 
    interface VariableQueryProps {

--- a/docusaurus/docs/how-to-guides/data-source-plugins/fetch-data-from-frontend.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/fetch-data-from-frontend.md
@@ -41,7 +41,6 @@ The easiest way to use the data proxy from a data source plugin is using the [`D
 ### Step 1: Use the `DataSourceHttpSettings` component in your data source plugin configuration page
 
 ```typescript title="src/ConfigEditor.tsx"
-import React from 'react';
 import { DataSourceHttpSettings } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 
@@ -160,7 +159,7 @@ You must build your plugin and restart the Grafana server every time you modify 
 ### Step 2: Create your configuration page
 
 ```typescript title="src/ConfigEditor.tsx"
-import React, { ChangeEvent } from 'react';
+import { ChangeEvent } from 'react';
 import { InlineField, Input } from '@grafana/ui';
 
 export function ConfigEditor(props: Props) {

--- a/docusaurus/docs/how-to-guides/panel-plugins/custom-panel-option-editors.md
+++ b/docusaurus/docs/how-to-guides/panel-plugins/custom-panel-option-editors.md
@@ -25,7 +25,6 @@ The simplest editor is a React component that accepts two props:
 The editor in the example below lets the user toggle a boolean value by clicking a button:
 
 ```tsx title="src/SimpleEditor.tsx"
-import React from 'react';
 import { Button } from '@grafana/ui';
 import { StandardEditorProps } from '@grafana/data';
 

--- a/docusaurus/docs/how-to-guides/panel-plugins/subscribe-events.md
+++ b/docusaurus/docs/how-to-guides/panel-plugins/subscribe-events.md
@@ -54,7 +54,7 @@ Here are a few other events you can subscribe to:
 You can access the event bus available from the panel props, and subscribe to events of a certain type using the `getStream()` method. The callback passed to the subscribe method will be called for every new event, as in this example:
 
 ```tsx
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { RefreshEvent } from '@grafana/runtime';
 
 // ...

--- a/docusaurus/docs/tutorials/build-a-panel-plugin-with-d3.md
+++ b/docusaurus/docs/tutorials/build-a-panel-plugin-with-d3.md
@@ -206,7 +206,6 @@ Congrats! You've created a simple and responsive bar chart.
 ## Complete example
 
 ```tsx title="src/components/SimplePanel.tsx"
-import React from 'react';
 import { PanelProps } from '@grafana/data';
 import { SimpleOptions } from 'types';
 import { css, cx } from '@emotion/css';

--- a/docusaurus/docs/tutorials/build-an-app-plugin.md
+++ b/docusaurus/docs/tutorials/build-an-app-plugin.md
@@ -98,7 +98,6 @@ The new page appears in the navigation menu. You can now edit the React router i
 1. Create a new file called `src/pages/NewPage.tsx` and add the following code:
 
    ```tsx title="src/pages/NewPage.tsx"
-   import React from 'react';
    import { PluginPage } from '@grafana/runtime';
 
    export function NewPage() {
@@ -151,7 +150,6 @@ export const updatePluginSettings = async (pluginId: string, data: Partial<Plugi
 The user settings are part of the plugin `meta`. You can retrieve them inside a React component by using the `usePluginContext` hook. For example:
 
 ```tsx
-import React from 'react';
 import usePluginContext from '@grafana/data';
 
 function MyComponent() {

--- a/packages/create-plugin/templates/app/src/components/App/App.test.tsx
+++ b/packages/create-plugin/templates/app/src/components/App/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { AppRootProps, PluginType } from '@grafana/data';
 import { render, screen } from '@testing-library/react';

--- a/packages/create-plugin/templates/app/src/components/App/App.tsx
+++ b/packages/create-plugin/templates/app/src/components/App/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { AppRootProps } from '@grafana/data';
 import { ROUTES } from '../../constants';

--- a/packages/create-plugin/templates/app/src/components/AppConfig/AppConfig.test.tsx
+++ b/packages/create-plugin/templates/app/src/components/AppConfig/AppConfig.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { PluginType } from '@grafana/data';
 import { AppConfig, AppConfigProps } from './AppConfig';

--- a/packages/create-plugin/templates/app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/create-plugin/templates/app/src/components/AppConfig/AppConfig.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { lastValueFrom } from 'rxjs';
 import { css } from '@emotion/css';
 import { AppPluginMeta, GrafanaTheme2, PluginConfigPageProps, PluginMeta } from '@grafana/data';

--- a/packages/create-plugin/templates/app/src/pages/PageFour.tsx
+++ b/packages/create-plugin/templates/app/src/pages/PageFour.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { LinkButton, useStyles2 } from '@grafana/ui';

--- a/packages/create-plugin/templates/app/src/pages/PageOne.tsx
+++ b/packages/create-plugin/templates/app/src/pages/PageOne.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { LinkButton, useStyles2 } from '@grafana/ui';

--- a/packages/create-plugin/templates/app/src/pages/PageThree.tsx
+++ b/packages/create-plugin/templates/app/src/pages/PageThree.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/css';
 import { useParams, Link } from 'react-router-dom';
 import { GrafanaTheme2 } from '@grafana/data';

--- a/packages/create-plugin/templates/app/src/pages/PageTwo.tsx
+++ b/packages/create-plugin/templates/app/src/pages/PageTwo.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { testIds } from '../components/testIds';
 import { PluginPage } from '@grafana/runtime';
 

--- a/packages/create-plugin/templates/common/.config/tsconfig.json
+++ b/packages/create-plugin/templates/common/.config/tsconfig.json
@@ -6,6 +6,7 @@
  */
 {
   "compilerOptions": {
+    "jsx": "react-jsx",
     "alwaysStrict": true,
     "declaration": false,
     "rootDir": "../src",

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -126,6 +126,11 @@ const config = async (env): Promise<Configuration> => {
                   decorators: false,
                   dynamicImport: true,
                 },
+                transform: {
+                  react: {
+                    runtime: 'automatic',
+                  },
+                },
               },
             },
           },

--- a/packages/create-plugin/templates/datasource/src/components/ConfigEditor.tsx
+++ b/packages/create-plugin/templates/datasource/src/components/ConfigEditor.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import { ChangeEvent } from 'react';
 import { InlineField, Input, SecretInput } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { MyDataSourceOptions, MySecureJsonData } from '../types';

--- a/packages/create-plugin/templates/datasource/src/components/QueryEditor.tsx
+++ b/packages/create-plugin/templates/datasource/src/components/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import { ChangeEvent } from 'react';
 import { InlineField, Input, Stack } from '@grafana/ui';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from '../datasource';

--- a/packages/create-plugin/templates/panel/src/components/SimplePanel.tsx
+++ b/packages/create-plugin/templates/panel/src/components/SimplePanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { PanelProps } from '@grafana/data';
 import { SimpleOptions } from 'types';
 import { css, cx } from '@emotion/css';

--- a/packages/create-plugin/templates/scenes-app/src/components/App/App.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/components/App/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppRootProps } from '@grafana/data';
 import { PluginPropsContext } from '../../utils/utils.plugin';
 import { Routes } from '../Routes';

--- a/packages/create-plugin/templates/scenes-app/src/components/AppConfig/AppConfig.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/components/AppConfig/AppConfig.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent } from 'react';
+import { useState, ChangeEvent } from 'react';
 import { Button, Field, Input, useStyles2, FieldSet, SecretInput } from '@grafana/ui';
 import { PluginConfigPageProps, AppPluginMeta, PluginMeta, GrafanaTheme2 } from '@grafana/data';
 import { getBackendSrv, locationService } from '@grafana/runtime';

--- a/packages/create-plugin/templates/scenes-app/src/components/Routes/Routes.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/components/Routes/Routes.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { HomePage } from '../../pages/Home';
 import { PageWithTabs } from '../../pages/WithTabs';

--- a/packages/create-plugin/templates/scenes-app/src/pages/HelloWorld/HelloWorld.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/pages/HelloWorld/HelloWorld.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { getScene } from './helloWorldScene';
 
 export const HelloWorldPluginPage = () => {

--- a/packages/create-plugin/templates/scenes-app/src/pages/Home/CustomSceneObject.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/pages/Home/CustomSceneObject.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SceneComponentProps, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
 import { Input } from '@grafana/ui';
 

--- a/packages/create-plugin/templates/scenes-app/src/pages/Home/Home.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { SceneApp, SceneAppPage } from '@grafana/scenes';
 import { getBasicScene } from './scenes';

--- a/packages/create-plugin/templates/scenes-app/src/pages/WithDrilldown/WithDrilldown.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/pages/WithDrilldown/WithDrilldown.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { prefixRoute } from '../../utils/utils.routing';
 import { DATASOURCE_REF, ROUTES } from '../../constants';
 import {

--- a/packages/create-plugin/templates/scenes-app/src/pages/WithTabs/WithTabs.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/pages/WithTabs/WithTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { SceneApp, SceneAppPage } from '@grafana/scenes';
 import { ROUTES } from '../../constants';
 import { prefixRoute } from '../../utils/utils.routing';

--- a/packages/create-plugin/tsconfig.json
+++ b/packages/create-plugin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "outDir": "./dist"
   },
   "exclude": ["node_modules", "templates"],


### PR DESCRIPTION
**What this PR does / why we need it**:

JSX transform has been enabled for built-in plugins in [this commit](https://github.com/grafana/grafana/commit/47f87171496f675bc44ddf839effaed1846bfa4e). This PR enables it for Create Plugin.
