### PR TITLE
Renovate: Add gomod manger and package rule for plugin sdk

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
   "separateMajorMinor": false,
   "labels": ["dependencies", "release", "patch"],
   "reviewers": ["team:grafana/plugins-platform-frontend"],
-  "enabledManagers": ["regex"],
+  "enabledManagers": ["regex", "gomod"],
   "customManagers": [
     {
       "customType": "regex",
@@ -23,10 +23,17 @@
   ],
   "packageRules": [
     {
+      "matchManagers": ["regex"],
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
       "matchUpdateTypes": ["minor", "patch", "major"],
       "groupName": "grafana dependencies",
       "groupSlug": "all-grafana"
+    },
+    {
+      "reviewers": ["team:grafana/plugins-platform-backend"],
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["grafana-plugin-sdk-go"],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables Renovate to manage updates to the grafana-plugin-sdk-go. As soon as there's a new minor or patch release available for the sdk, Renovate will raise a PR that bumps its version in the gomod file for create-plugin backend templates.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
