### PR TITLE
Chore: Automerge Grafana dependency updates in create-plugin templates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
   "extends": ["config:base", ":disableDependencyDashboard"],
   "includePaths": ["packages/create-plugin/templates/**"],
   "separateMajorMinor": false,
-  "labels": ["dependencies", "release", "patch"],
   "reviewers": ["team:grafana/plugins-platform-frontend"],
   "enabledManagers": ["regex"],
   "customManagers": [
@@ -23,6 +22,7 @@
   ],
   "packageRules": [
     {
+      "labels": ["dependencies", "patch"],
       "automerge": true,
       "matchCurrentVersion": "!/^0/",
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
@@ -31,6 +31,7 @@
       "groupSlug": "all-grafana-patch"
     },
     {
+      "labels": ["dependencies", "release", "patch"],
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
       "matchUpdateTypes": ["minor", "major"],
       "groupName": "grafana dependencies",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,14 @@
   ],
   "packageRules": [
     {
+      "automerge": true,
+      "matchCurrentVersion": "!/^0/",
+      "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "grafana patch dependencies",
+      "groupSlug": "all-grafana-patch"
+    },
+    {
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
       "matchUpdateTypes": ["minor", "patch", "major"],
       "groupName": "grafana dependencies",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
     },
     {
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
-      "matchUpdateTypes": ["minor", "patch", "major"],
+      "matchUpdateTypes": ["minor", "major"],
       "groupName": "grafana dependencies",
       "groupSlug": "all-grafana"
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables automerging of Renovate generated PRs that bumps dependencies in any of the grafana packages used in the create-plugin templates. Automerging is only applied to patch updates and to those packages that have released the first major. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
