### PR TITLE
Chore: Let depedabot handle plugin-e2e dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,12 @@ updates:
         patterns:
           - '@auto-it/*'
           - 'auto'
+  - package-ecosystem: 'npm'
+    directory: '/packages/plugin-e2e'
+    schedule:
+      interval: 'monthly'
+    # Specify labels for npm pull requests
+    labels:
+      - 'javascript'
+      - 'dependencies'
+      - 'no stalebot'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR lets dependabot manage dependency updates in the plugin-e2e package.

According to plugin-e2e peer deps, the package is compatible with `>=1.41.2 <2.0.0` of Playwright. For that reason, it makes sense to always use latest version of Playwright internally when testing plugin-e2e. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
