### PR TITLE
Adds announcement bar to promote the use of the grafana community forum for plugin developers

### DIFF
--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -41,8 +41,8 @@ const config = {
       id: 'community_callout',
       content:
         'Learn more and connect with fellow plugin developers in the <a href="https://community.grafana.com/c/plugin-development/30?utm_source=plugin-docs&utm_medium=banner&utm_campaign=community-announcement" target="_blank" rel="noopener">Grafana Community Forum</a>. Ask questions, share knowledge, and get support from the Grafana team and community.',
-      backgroundColor: '#EE6D27',
-      textColor: '#fff',
+      backgroundColor: '#EC7E39',
+      textColor: '#000',
       isCloseable: false,
     },
     navbar: {

--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -40,7 +40,7 @@ const config = {
     announcementBar: {
       id: 'community_callout',
       content:
-        'Learn more and connect with fellow plugin developers in the <a href="https://community.grafana.com/c/plugin-development/30?utm_source=plugin-docs&utm_medium=banner&utm_campaign=community-announcement" target="_blank" rel="noopener">Grafana Community Forum</a>. Ask questions, share knowledge, and get support from the Grafana team and community.',
+        '💬 Learn more and connect with fellow plugin developers in the <a href="https://community.grafana.com/c/plugin-development/30?utm_source=plugin-docs&utm_medium=banner&utm_campaign=community-announcement" target="_blank" rel="noopener">Grafana Community Forum</a>. Ask questions, share knowledge, and get support from the Grafana team and community.',
       backgroundColor: '#EC7E39',
       textColor: '#000',
       isCloseable: false,

--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -37,6 +37,14 @@ const config = {
   ],
 
   themeConfig: {
+    announcementBar: {
+      id: 'community_callout',
+      content:
+        'Learn more and connect with fellow plugin developers in the <a href="https://community.grafana.com/c/plugin-development/30" target="_blank" rel="noopener">Grafana Community Forum</a>. Ask questions, share knowledge, and get support from the Grafana team and community.',
+      backgroundColor: '#EE6D27',
+      textColor: '#fff',
+      isCloseable: false,
+    },
     navbar: {
       ...themeConfigNavbar,
       items: [

--- a/docusaurus/website/docusaurus.config.js
+++ b/docusaurus/website/docusaurus.config.js
@@ -40,7 +40,7 @@ const config = {
     announcementBar: {
       id: 'community_callout',
       content:
-        'Learn more and connect with fellow plugin developers in the <a href="https://community.grafana.com/c/plugin-development/30" target="_blank" rel="noopener">Grafana Community Forum</a>. Ask questions, share knowledge, and get support from the Grafana team and community.',
+        'Learn more and connect with fellow plugin developers in the <a href="https://community.grafana.com/c/plugin-development/30?utm_source=plugin-docs&utm_medium=banner&utm_campaign=community-announcement" target="_blank" rel="noopener">Grafana Community Forum</a>. Ask questions, share knowledge, and get support from the Grafana team and community.',
       backgroundColor: '#EE6D27',
       textColor: '#fff',
       isCloseable: false,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3d56f00a-53df-4a38-9c63-f873a5bc7f36)

As part of a larger effort to encourage plugin developers to be more actively engaged in the community forum, as well as providing an official place for them to get feedback from us, I'd like to promote the community forum within the docs so users are more likely to go there when they have questions or want to share feedback and learnings etc.