### PR TITLE
[e2e-plugins] - Export PageFixture type

### DIFF
--- a/packages/plugin-e2e/src/fixtures/page.ts
+++ b/packages/plugin-e2e/src/fixtures/page.ts
@@ -1,8 +1,5 @@
-import { TestFixture, Page } from '@playwright/test';
-import { PlaywrightArgs } from '../types';
+import { PageFixture } from '../types';
 import { overrideFeatureToggles } from './scripts/overrideFeatureToggles';
-
-type PageFixture = TestFixture<Page, PlaywrightArgs>;
 
 /**
  * This fixture ensures the feature toggles defined in the Playwright config are being used in Grafana frontend.

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -6,6 +6,8 @@ import {
   PlaywrightWorkerOptions,
   Response,
   TestInfo,
+  TestFixture,
+  Page,
 } from '@playwright/test';
 
 import { E2ESelectors } from './e2e-selectors/types';
@@ -40,7 +42,7 @@ export type PluginOptions = {
    * The feature toggles you specify here will only work in the frontend. If you need a feature toggle to work across the entire stack, you
    * need to need to enable the feature in the Grafana config. Also see https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/feature-toggles
    *
-   * To override feature toggles globally in the playwright.config.ts file: 
+   * To override feature toggles globally in the playwright.config.ts file:
    * export default defineConfig({
       use: {
         featureToggles: {
@@ -49,7 +51,7 @@ export type PluginOptions = {
         },
       },
     });
-   * 
+   *
    * To override feature toggles for tests in a certain file:
      test.use({
       featureToggles: {
@@ -107,9 +109,9 @@ export type PluginFixture = {
   /**
    * Fixture command that login to Grafana using the Grafana API and stores the cookie state on disk.
    * The file name for the storage state will be `playwright/.auth/<username>.json`, so it's important that the username is unique.
-   * 
-   * If you have not specified a user, the default admin/admin credentials will be used. 
-   * 
+   *
+   * If you have not specified a user, the default admin/admin credentials will be used.
+   *
    * e.g
    * projects: [
       {
@@ -128,7 +130,7 @@ export type PluginFixture = {
       }
     }
    *
-   * If your plugin supports RBAC, you may want to use different projects for different roles. 
+   * If your plugin supports RBAC, you may want to use different projects for different roles.
    * In the following example, a new user with the role `Viewer` gets created and authenticated in a `createUserAndAuthenticate` project.
    * In the `viewer` project, authentication state from the previous project is used in all tests in the ./tests/viewer folder.
    * projects: [
@@ -333,6 +335,8 @@ export type PlaywrightArgs = PluginFixture &
   PlaywrightTestOptions &
   PlaywrightWorkerArgs &
   PlaywrightWorkerOptions;
+
+export type PageFixture = TestFixture<Page, PlaywrightArgs>;
 
 /**
  * The data source settings


### PR DESCRIPTION
this is useful when writing interfaces that might use the page component, since currently we'd have to use the `Page` type from playwright, but in reality the type should be PageFixture which is currentlty unexported.

This PR fixes that

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.4.0-canary.1140.8d70b63.0
  npm install @grafana/plugin-e2e@1.9.0-canary.1140.8d70b63.0
  # or 
  yarn add @grafana/create-plugin@5.4.0-canary.1140.8d70b63.0
  yarn add @grafana/plugin-e2e@1.9.0-canary.1140.8d70b63.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
