### PR TITLE
Update dashboard variables settings URL

### DIFF
--- a/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
@@ -63,12 +63,15 @@ export const versionedPages = {
         List: {
           url: {
             [MIN_GRAFANA_VERSION]: '/dashboard/new?orgId=1&editview=templating',
+            '11.3.0': '/dashboard/new?orgId=1&editview=variables',
           },
         },
         Edit: {
           url: {
-            [MIN_GRAFANA_VERSION]: (annotationIndex: string) =>
-              `/dashboard/new?orgId=1&editview=templating&editIndex=${annotationIndex}`,
+            [MIN_GRAFANA_VERSION]: (variableIndex: string) =>
+              `/dashboard/new?orgId=1&editview=templating&editIndex=${variableIndex}`,
+              '11.3.0': (variableIndex: string) =>
+              `/dashboard/new?orgId=1&editview=variables&editIndex=${variableIndex}`,
           },
         },
       },
@@ -107,6 +110,7 @@ export const versionedPages = {
         List: {
           url: {
             [MIN_GRAFANA_VERSION]: (dashboardUid: string) => `/d/${dashboardUid}?editview=templating`,
+            '11.3.0': (dashboardUid: string) => `/d/${dashboardUid}?editview=variables`,
           },
           newButton: {
             [MIN_GRAFANA_VERSION]: 'Variable editor New variable button',
@@ -125,6 +129,8 @@ export const versionedPages = {
           url: {
             [MIN_GRAFANA_VERSION]: (dashboardUid: string, editIndex: string) =>
               `/d/${dashboardUid}?editview=templating&editIndex=${editIndex}`,
+            '11.3.0': (dashboardUid: string, editIndex: string) =>
+              `/d/${dashboardUid}?editview=variables&editIndex=${editIndex}`,
           },
           General: {
             generalTypeSelectV2: {


### PR DESCRIPTION
Because Scenes will be enabled by default, it needs to use a different selector

https://github.com/grafana/grafana/pull/93818
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.3.12-canary.1144.5e4319e.0
  npm install @grafana/plugin-e2e@1.8.2-canary.1144.5e4319e.0
  # or 
  yarn add @grafana/create-plugin@5.3.12-canary.1144.5e4319e.0
  yarn add @grafana/plugin-e2e@1.8.2-canary.1144.5e4319e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
