### PR TITLE
Create Plugin: Bundle css as separate files

### DIFF
--- a/packages/create-plugin/templates/common/.config/types/custom.d.ts
+++ b/packages/create-plugin/templates/common/.config/types/custom.d.ts
@@ -35,3 +35,15 @@ declare module '*.woff2';
 declare module '*.eot';
 declare module '*.ttf';
 declare module '*.otf';
+
+// CSS declarations
+declare module '*.module.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}
+
+declare module '*.css' {
+  const content: string;
+  export default content;
+}
+

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -8,6 +8,7 @@
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import ESLintPlugin from 'eslint-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import path from 'path';
 import ReplaceInFileWebpackPlugin from 'replace-in-file-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
@@ -131,12 +132,13 @@ const config = async (env): Promise<Configuration> => {
           },
         },
         {
-          test: /\.css$/,
-          use: ['style-loader', 'css-loader'],
-        },
-        {
-          test: /\.s[ac]ss$/,
-          use: ['style-loader', 'css-loader', 'sass-loader'],
+          test: /\.(sa|sc|c)ss$/,
+          use: [
+            env.development ? "style-loader" : MiniCssExtractPlugin.loader,
+            "css-loader",
+            "postcss-loader",
+            "sass-loader",
+          ],
         },
         {
           test: /\.(png|jpe?g|gif|svg)$/,
@@ -244,7 +246,7 @@ const config = async (env): Promise<Configuration> => {
           extensions: ['.ts', '.tsx'],
           lintDirtyModulesOnly: Boolean(env.development), // don't lint on start, only lint changed files
         }),
-      ] : []),
+      ] : [new MiniCssExtractPlugin()]),
     ],
 
     resolve: {

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -44,6 +44,7 @@
     "imports-loader": "^5.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
+    "mini-css-extract-plugin": "^2.9.1",
     "prettier": "^2.8.7",
     "replace-in-file-webpack-plugin": "^1.0.6",
     "sass": "1.63.2",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR updates the webpack config to use Mini-css-extract plugin during production builds so imported css is extracted into .css files rather than inlined in the javascript bundles. This helps prevent FOUC and aligns with webpacks security warning and recommended approach to loading CSS.

>This loader is primarily meant for development. The default settings are not safe for production environments. See the [recommended example configuration](https://webpack.js.org/loaders/style-loader/#recommend) and the section on [nonces](https://webpack.js.org/loaders/style-loader/#nonce) for details.

>For production builds it's recommended to extract the CSS from your bundle being able to use parallel loading of CSS/JS resources later on. This can be achieved by using the [mini-css-extract-plugin](https://webpack.js.org/plugins/mini-css-extract-plugin/), because it creates separate css files. For development mode (including webpack-dev-server) you can use style-loader, because it injects CSS into the DOM using multiple <style></style> and works faster.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #1150

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.5.0-canary.1153.af88417.0
  # or 
  yarn add @grafana/create-plugin@5.5.0-canary.1153.af88417.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
