### PR TITLE
Plugin E2e: Support scenes powered dashboard UI

### DIFF
--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -26,10 +26,6 @@ export default defineConfig<PluginOptions>({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    provisioningRootDir: path.join(
-      process.cwd(),
-      !!process.env.CI ? 'provisioning' : '/packages/plugin-e2e/provisioning'
-    ),
     grafanaAPICredentials: {
       user: 'admin',
       password: 'admin',

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -3,6 +3,7 @@
 import { defineConfig, devices } from '@playwright/test';
 import { PluginOptions } from './src';
 import dotenv from 'dotenv';
+import path from 'path';
 
 dotenv.config();
 
@@ -25,7 +26,10 @@ export default defineConfig<PluginOptions>({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    provisioningRootDir: './packages/plugin-e2e/provisioning',
+    provisioningRootDir: path.join(
+      process.cwd(),
+      process.env.CI ? 'provisioning' : '/packages/plugin-e2e/provisioning'
+    ),
     grafanaAPICredentials: {
       user: 'admin',
       password: 'admin',

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig<PluginOptions>({
     trace: 'on-first-retry',
     provisioningRootDir: path.join(
       process.cwd(),
-      process.env.CI ? 'provisioning' : '/packages/plugin-e2e/provisioning'
+      !!process.env.CI ? 'provisioning' : '/packages/plugin-e2e/provisioning'
     ),
     grafanaAPICredentials: {
       user: 'admin',

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -3,7 +3,6 @@
 import { defineConfig, devices } from '@playwright/test';
 import { PluginOptions } from './src';
 import dotenv from 'dotenv';
-import path from 'path';
 
 dotenv.config();
 

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -25,6 +25,7 @@ export default defineConfig<PluginOptions>({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    provisioningRootDir: './packages/plugin-e2e/provisioning',
     grafanaAPICredentials: {
       user: 'admin',
       password: 'admin',

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -112,6 +112,7 @@ export type Components = {
   NavToolbar: {
     editDashboard: {
       backToDashboardButton: string;
+      editButton: string;
     };
   };
   PageToolbar: {

--- a/packages/plugin-e2e/src/e2e-selectors/types.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/types.ts
@@ -109,6 +109,11 @@ export type Components = {
   Alert: {
     alertV2: (severity: string) => string;
   };
+  NavToolbar: {
+    editDashboard: {
+      backToDashboardButton: string;
+    };
+  };
   PageToolbar: {
     item: (tooltip: string) => string;
     showMoreItems: string;

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -168,7 +168,12 @@ export const versionedComponents = {
   },
   NavToolbar: {
     editDashboard: {
-      backToDashboardButton: { '11.1.0': 'data-testid Back to dashboard button' },
+      editButton: {
+        '11.1.0': 'data-testid Edit dashboard button',
+      },
+      backToDashboardButton: {
+        '11.1.0': 'data-testid Back to dashboard button',
+      },
     },
   },
   PageToolbar: {

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/components.ts
@@ -166,6 +166,11 @@ export const versionedComponents = {
       [MIN_GRAFANA_VERSION]: (severity: string) => `Alert ${severity}`,
     },
   },
+  NavToolbar: {
+    editDashboard: {
+      backToDashboardButton: { '11.1.0': 'data-testid Back to dashboard button' },
+    },
+  },
   PageToolbar: {
     item: {
       [MIN_GRAFANA_VERSION]: (tooltip: string) => `${tooltip}`,

--- a/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
+++ b/packages/plugin-e2e/src/e2e-selectors/versioned/pages.ts
@@ -40,6 +40,7 @@ export const versionedPages = {
       '9.5.0': (title: string) => `data-testid ${title}`,
     },
     addNewPanel: {
+      '11.1.0': 'data-testid Add new panel',
       [MIN_GRAFANA_VERSION]: 'Add new panel',
     },
     itemButtonAddViz: {
@@ -70,8 +71,7 @@ export const versionedPages = {
           url: {
             [MIN_GRAFANA_VERSION]: (variableIndex: string) =>
               `/dashboard/new?orgId=1&editview=templating&editIndex=${variableIndex}`,
-              '11.3.0': (variableIndex: string) =>
-              `/dashboard/new?orgId=1&editview=variables&editIndex=${variableIndex}`,
+            '11.3.0': (variableIndex: string) => `/dashboard/new?orgId=1&editview=variables&editIndex=${variableIndex}`,
           },
         },
       },

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -90,6 +90,9 @@ export class DashboardPage extends GrafanaPage {
       ).click();
       await this.getByGrafanaSelector(pages.AddDashboard.itemButton(pages.AddDashboard.itemButtonAddViz)).click();
     } else {
+      if (this.dashboard?.uid) {
+        await this.getByGrafanaSelector(components.PageToolbar.item('Add panel')).click();
+      }
       await this.getByGrafanaSelector(pages.AddDashboard.addNewPanel).click();
     }
 

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -79,8 +79,8 @@ export class DashboardPage extends GrafanaPage {
   async addPanel(): Promise<PanelEditPage> {
     const { components, pages } = this.ctx.selectors;
 
-    // From Grafana 10.3.0, one needs to click the edit button before adding a new panel in already existing dashboards
-    if (semver.gte(this.ctx.grafanaVersion, '10.3.0') && this.dashboard?.uid) {
+    // From Grafana 11.3.0, one needs to click the edit button before adding a new panel in already existing dashboards
+    if (semver.gte(this.ctx.grafanaVersion, '11.3.0') && this.dashboard?.uid) {
       await this.getByGrafanaSelector(components.NavToolbar.editDashboard.editButton).click();
     }
 

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -78,6 +78,12 @@ export class DashboardPage extends GrafanaPage {
    */
   async addPanel(): Promise<PanelEditPage> {
     const { components, pages } = this.ctx.selectors;
+
+    // From Grafana 10.3.0, one needs to click the edit button before adding a new panel in already existing dashboards
+    if (semver.gte(this.ctx.grafanaVersion, '10.3.0') && this.dashboard?.uid) {
+      await this.getByGrafanaSelector(components.NavToolbar.editDashboard.editButton).click();
+    }
+
     if (semver.gte(this.ctx.grafanaVersion, '10.0.0')) {
       await this.getByGrafanaSelector(
         components.PageToolbar.itemButton(components.PageToolbar.itemButtonTitle)

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -126,8 +126,10 @@ export class PanelEditPage extends GrafanaPage {
       await this.getByGrafanaSelector(
         this.ctx.selectors.components.NavToolbar.editDashboard.backToDashboardButton
       ).click();
-    } else {
+    } else if (semver.gte(this.ctx.grafanaVersion, '9.0.0')) {
       await this.ctx.page.getByTestId(this.ctx.selectors.components.PanelEditor.applyButton).click();
+    } else {
+      await this.ctx.page.getByLabel('panel editor apply').click();
     }
 
     return new DashboardPage(this.ctx, this.args);

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -6,6 +6,7 @@ import { GrafanaPage } from './GrafanaPage';
 import { TimeRange } from '../components/TimeRange';
 import { Panel } from '../components/Panel';
 import { radioButtonSetChecked } from '../utils';
+import { DashboardPage } from './DashboardPage';
 
 export class PanelEditPage extends GrafanaPage {
   datasource: DataSourcePicker;
@@ -117,10 +118,28 @@ export class PanelEditPage extends GrafanaPage {
   }
 
   /**
+   * Clicks the "Back to dashboard" button in the panel editor
+   * In versions prior to 10.3.0, this method clicks the "Apply" button instead
+   */
+  async backToDashboard() {
+    if (semver.gte(this.ctx.grafanaVersion, '10.3.0')) {
+      await this.getByGrafanaSelector(
+        this.ctx.selectors.components.NavToolbar.editDashboard.backToDashboardButton
+      ).click();
+    } else {
+      await this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.applyButton).click();
+    }
+
+    return new DashboardPage(this.ctx, this.args);
+  }
+
+  /**
    * Clicks the "Apply" button in the panel editor
+   *
+   * @deprecated use {@link PanelEditPage.backToDashboard} method instead.
    */
   async apply() {
-    await this.ctx.page.getByTestId(this.ctx.selectors.components.PanelEditor.applyButton).click();
+    return this.backToDashboard();
   }
 
   /**

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -122,7 +122,7 @@ export class PanelEditPage extends GrafanaPage {
    * In versions prior to 10.3.0, this method clicks the "Apply" button instead
    */
   async backToDashboard() {
-    if (semver.gte(this.ctx.grafanaVersion, '10.3.0')) {
+    if (semver.gte(this.ctx.grafanaVersion, '11.3.0')) {
       await this.getByGrafanaSelector(
         this.ctx.selectors.components.NavToolbar.editDashboard.backToDashboardButton
       ).click();

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -119,7 +119,7 @@ export class PanelEditPage extends GrafanaPage {
 
   /**
    * Clicks the "Back to dashboard" button in the panel editor
-   * In versions prior to 10.3.0, this method clicks the "Apply" button instead
+   * In versions prior to 11.3.0, this method clicks the "Apply" button instead
    */
   async backToDashboard() {
     if (semver.gte(this.ctx.grafanaVersion, '11.3.0')) {

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -127,7 +127,7 @@ export class PanelEditPage extends GrafanaPage {
         this.ctx.selectors.components.NavToolbar.editDashboard.backToDashboardButton
       ).click();
     } else {
-      await this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.applyButton).click();
+      await this.ctx.page.getByTestId(this.ctx.selectors.components.PanelEditor.applyButton).click();
     }
 
     return new DashboardPage(this.ctx, this.args);

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/dashboards/dashboard.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/dashboards/dashboard.spec.ts
@@ -4,8 +4,7 @@ import { expect, test } from '../../../../src';
 test('add panel in already existing dashboard', async ({ gotoDashboardPage, readProvisionedDashboard, page }) => {
   const dashboard = await readProvisionedDashboard({ fileName: 'redshift.json' });
   const dashboardPage = await gotoDashboardPage(dashboard);
-  const panelEditPage = await dashboardPage.addPanel();
-  await expect(panelEditPage.panel.locator).toBeVisible();
+  await dashboardPage.addPanel();
   await expect(page.url()).toContain('editPanel');
 });
 

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/dashboards/dashboard.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/dashboards/dashboard.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '../../../../src';
 
 test('add panel in already existing dashboard', async ({ gotoDashboardPage, readProvisionedDashboard, page }) => {
   const dashboard = await readProvisionedDashboard({ fileName: 'redshift.json' });
-  const dashboardPage = await gotoDashboardPage({ uid: 'edediimbjhdz4b' });
+  const dashboardPage = await gotoDashboardPage(dashboard);
   const panelEditPage = await dashboardPage.addPanel();
   await expect(panelEditPage.panel.locator).toBeVisible();
   await expect(page.url()).toContain('editPanel');

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/dashboards/dashboard.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/dashboards/dashboard.spec.ts
@@ -1,0 +1,16 @@
+import exp from 'constants';
+import { expect, test } from '../../../../src';
+
+test('add panel in already existing dashboard', async ({ gotoDashboardPage, readProvisionedDashboard, page }) => {
+  const dashboard = await readProvisionedDashboard({ fileName: 'redshift.json' });
+  const dashboardPage = await gotoDashboardPage({ uid: 'edediimbjhdz4b' });
+  const panelEditPage = await dashboardPage.addPanel();
+  await expect(panelEditPage.panel.locator).toBeVisible();
+  await expect(page.url()).toContain('editPanel');
+});
+
+test('add panel in new dashboard', async ({ dashboardPage, page }) => {
+  const panelEditPage = await dashboardPage.addPanel();
+  await expect(panelEditPage.panel.locator).toBeVisible();
+  await expect(page.url()).toContain('editPanel');
+});

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/dashboards/dashboard.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/dashboards/dashboard.spec.ts
@@ -1,4 +1,3 @@
-import exp from 'constants';
 import { expect, test } from '../../../../src';
 
 test('add panel in already existing dashboard', async ({ gotoDashboardPage, readProvisionedDashboard, page }) => {

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/query-editor/queryEditor.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/query-editor/queryEditor.spec.ts
@@ -54,7 +54,7 @@ test('backToDashboard method should be backwards compatible and navigate to dash
   page,
 }) => {
   const dashboard = await readProvisionedDashboard({ fileName: 'redshift.json' });
-  const panelEditPage = await gotoPanelEditPage({ dashboard, id: '3', waitUntil: 'load' });
+  const panelEditPage = await gotoPanelEditPage({ dashboard, id: '3' });
   await panelEditPage.backToDashboard();
-  await expect(page.url).not.toContain('editPanel');
+  await expect(page.url()).not.toContain('editPanel');
 });

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/query-editor/queryEditor.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/query-editor/queryEditor.spec.ts
@@ -47,3 +47,14 @@ test('should set correct cache time on query passed to the backend', async ({
   await panelEditPage.refreshPanel();
   await expect(await queryReq).toBeTruthy();
 });
+
+test('backToDashboard method should be backwards compatible and navigate to dashboard page', async ({
+  gotoPanelEditPage,
+  readProvisionedDashboard,
+  page,
+}) => {
+  const dashboard = await readProvisionedDashboard({ fileName: 'redshift.json' });
+  const panelEditPage = await gotoPanelEditPage({ dashboard, id: '3', waitUntil: 'load' });
+  await panelEditPage.backToDashboard();
+  await expect(page.url).not.toContain('editPanel');
+});


### PR DESCRIPTION
**What this PR does / why we need it**:

Scenes powered dashboards was [enabled](https://github.com/grafana/grafana/pull/93818) by default in Grafana recently. This included some changes that broke plugin e2e APIs in some certain scenarios:
* Panel edit `Apply` button is renamed to `Back to dashboard` and there was a new e2e selector for the `Back to dashboard` button
* The Add viz button in dashboards only becomes available after first clicking a new `Edit` button 

Unfortunately, these changes were not captured by the [API tests](https://github.com/grafana/grafana/tree/main/e2e/plugin-e2e/plugin-e2e-api-tests) in Grafana (apply method was never tested and addPanel was only tested for new dashboards - not already existing ones). 

**Which issue(s) this PR fixes**:

Fixes #1152

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.4.1-canary.1155.64c8314.0
  npm install @grafana/plugin-e2e@1.8.3-canary.1155.64c8314.0
  # or 
  yarn add @grafana/create-plugin@5.4.1-canary.1155.64c8314.0
  yarn add @grafana/plugin-e2e@1.8.3-canary.1155.64c8314.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
