### PR TITLE
Types bundler: Add a default TSConfig for bundling types

### DIFF
--- a/packages/plugin-types-bundler/package.json
+++ b/packages/plugin-types-bundler/package.json
@@ -8,8 +8,7 @@
     ".": {
       "import": "./dist/bundleTypes.js"
     },
-    "./package.json": "./package.json",
-    "./tsconfig.json": "./tsconfig/tsconfig.json"
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",

--- a/packages/plugin-types-bundler/package.json
+++ b/packages/plugin-types-bundler/package.json
@@ -11,6 +11,11 @@
     "./package.json": "./package.json",
     "./tsconfig.json": "./tsconfig/tsconfig.json"
   },
+  "files": [
+    "dist",
+    "tsconfig",
+    "CHANGELOG.md"
+  ],
   "scripts": {
     "test": "vitest --passWithNoTests",
     "build": "tsc --project tsconfig.json && chmod +x ./dist/bin/run.js",

--- a/packages/plugin-types-bundler/package.json
+++ b/packages/plugin-types-bundler/package.json
@@ -5,10 +5,11 @@
   "bin": "./dist/bin/run.js",
   "type": "module",
   "exports": {
-    "node": {
+    ".": {
       "import": "./dist/bundleTypes.js"
     },
-    "default": "./dist/bundleTypes.js"
+    "./package.json": "./package.json",
+    "./tsconfig.json": "./tsconfig/tsconfig.json"
   },
   "scripts": {
     "test": "vitest --passWithNoTests",

--- a/packages/plugin-types-bundler/src/bundleTypes.ts
+++ b/packages/plugin-types-bundler/src/bundleTypes.ts
@@ -20,6 +20,7 @@ export const generateTypes = ({ entryPoint, tsConfig, outDir }: ParsedArgs) => {
   const options = {
     preferredConfigPath: tsConfig,
   };
+
   const dts = generateDtsBundle(entryPoints, options);
   const cleanedDts = cleanDTS(dts);
 

--- a/packages/plugin-types-bundler/src/utils.ts
+++ b/packages/plugin-types-bundler/src/utils.ts
@@ -1,7 +1,9 @@
 import parseArgs from 'minimist';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const args = process.argv.slice(2);
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 export type ParsedArgs = {
   entryPoint?: string;
@@ -22,7 +24,7 @@ export const parsedArgs = parseArgs<ParsedArgs>(args, {
   },
   default: {
     entryPoint: undefined,
-    tsConfig: join(process.cwd(), 'tsconfig.json'),
+    tsConfig: resolve(__dirname, '../tsconfig', 'tsconfig.json'),
     outDir: join(process.cwd(), 'dist'),
   },
 });

--- a/packages/plugin-types-bundler/tsconfig/tsconfig.json
+++ b/packages/plugin-types-bundler/tsconfig/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Running the types-bundler package via `npx` brought up types errors which break the bundler. We hadn't seen this when running it from a local build and I still cannot explain 💯 why it is happening. After much rabbit hole... the fix appears to be a separate tsconfig that consists of:

```
{
  "compilerOptions": {
    "declaration": true,
    "esModuleInterop": true,
    "skipLibCheck": true
  }
}
```

This PR introduces the tsconfig as part of the types-bundler package.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-types-bundler@0.0.3-canary.1164.e4bcc0a.0
  # or 
  yarn add @grafana/plugin-types-bundler@0.0.3-canary.1164.e4bcc0a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
