### PR TITLE
Create Plugin: Stop prettier from writing files outside the target path

### DIFF
--- a/packages/create-plugin/src/utils/utils.prettifyFiles.ts
+++ b/packages/create-plugin/src/utils/utils.prettifyFiles.ts
@@ -1,6 +1,7 @@
 import { exec as nodeExec } from 'node:child_process';
-import { promisify } from 'node:util';
 import fs from 'node:fs';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
 import { getPackageJson } from './utils.packagejson.js';
 
 const exec = promisify(nodeExec);
@@ -26,10 +27,11 @@ export async function prettifyFiles(options: PrettifyFilesArgs) {
   }
 
   const prettierVersion = getPrettierVersion(projectRoot);
+  const directoryToWrite = resolve(projectRoot, targetPath);
 
   try {
-    let command = `npx -y prettier@${prettierVersion} . --write`;
-    await exec(command, { cwd: targetPath });
+    let command = `npx -y prettier@${prettierVersion} ${directoryToWrite} --write`;
+    await exec(command);
   } catch (error) {
     throw new Error(
       'There was a problem running prettier on the plugin files. Please run `npx -y prettier@2 . --write` manually in your plugin directory.'


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR removes the exec working directory option in favour of passing an absolute path to prettier when writing files. It seems passing a `.` to prettier doesn't resolve correctly when inside the `.config` directory and _I think_ it walks up the tree to find the project root (package.json) then executes. This can cause noise for developers that have plugins in repos in a nested directory or in a mono-repo when running the `update` command.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #1131 

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.5.2-canary.1166.7d9aa46.0
  # or 
  yarn add @grafana/create-plugin@5.5.2-canary.1166.7d9aa46.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
