### PR TITLE
Renovate: Prevent capturing template expression in version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
     {
       "customType": "regex",
       "fileMatch": ["_package.json"],
-      "matchStrings": ["\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\""],
+      "matchStrings": ["\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","],
       "datasourceTemplate": "npm"
     },
     {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Create plugin update doesn't bump grafana/schema leaving packages out of sync.

![image](https://github.com/user-attachments/assets/a18ab8ed-3015-458d-b2b2-3941c1035af9)

From what I can tell Renovate doesn't update `@grafana/schema` [in PRs](https://github.com/grafana/plugin-tools/pull/1156). I can't be 💯 sure on this but the regex is capturing the trailing template expression on that line as part of the version which I think throws renovate off somewhere. By adding the trailing `,` we capture just the version information.

**Before**
![image](https://github.com/user-attachments/assets/c2a35117-9c82-4b74-b658-0bbfc305790e)

**After**
![image](https://github.com/user-attachments/assets/aaf4f1f7-02a9-4688-9578-a006af2af65f)

[regex101 link](https://regex101.com/r/FXmhZe/1) for those that want to play around.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
