### PR TITLE
Renovate: Fix update config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,12 +41,12 @@
     {
       "groupName": "docusaurus dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
-      "matchPackageNames": ["@?docusaurus/*"]
+      "matchPackageNames": ["@?docusaurus"]
     },
     {
       "groupName": "auto dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
-      "matchPackageNames": ["^@auto-it/**", "^auto"]
+      "matchPackageNames": ["^@auto-it", "^auto"]
     },
     {
       "automerge": true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
   "reviewers": ["team:grafana/plugins-platform-frontend"],
   "enabledManagers": ["regex", "npm", "github-actions"],
   "postUpdateOptions": ["npmDedupe"],
+  // These custom managers are used to bump dependencies in create-plugin template files
   "customManagers": [
     {
       "customType": "regex",
@@ -38,11 +39,13 @@
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
       "matchUpdateTypes": ["minor", "major"]
     },
+    // Docusaurus dependencies have to be grouped together otherwise error out when building website.
     {
       "groupName": "docusaurus dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
       "matchPackageNames": ["@?docusaurus"]
     },
+    // Auto dependencies should be grouped together to avoid issues
     {
       "groupName": "auto dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
@@ -57,12 +60,14 @@
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["devDependencies"]
     },
+    // patches will only touch the repo lock file so we apply no-changelog to prevent entries in the changelog
+    // which would be misleading to consumers.
     {
       "automerge": true,
       "excludePackagePatterns": ["^@?docusaurus", "@grafana/*"],
       "groupName": "auto-merged patch dependencies",
       "groupSlug": "prod-dependencies-automerge",
-      "labels": ["dependencies", "javascript", "patch"],
+      "labels": ["dependencies", "javascript", "no-changelog"],
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR addresses the following:

Renovate has opened a PR for a single auto-it dependency but we want it to group all auto-it dependencies into a single PR. This leads me to think these regex patterns I've moved over from dependabot config don't work the same with renovate.

Additionally we don't want entries in our changelogs for patch dependency bumps which will only affect the repos lock file.

Changed the renovate config file type to json5 so we can add comments.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
