### PR TITLE
Renovate: Add packageRule for minor and major dep bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -72,6 +72,16 @@
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"]
     },
+    // minor and major will touch package.json files so we apply the patch label here to ensure changelog entries
+    {
+      "excludePackagePatterns": ["^@?docusaurus", "@grafana/*"],
+      "groupName": "dependencies",
+      "groupSlug": "prod-dependencies",
+      "labels": ["dependencies", "javascript", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "major"]
+    },
     {
       "automerge": true,
       "groupName": "auto-merged gitHub actions",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Renovate is now opening minor and major prod dependency PRs without labels. This bumps will touch package.json and potentially require code changes to work meaning they should make their way into changelogs and create releases.

I've opted for `patch` as the default as these shouldn't create breaking changes for consumers.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
