### PR TITLE
Renovate: Don't group prod major minor bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
   "reviewers": ["team:grafana/plugins-platform-frontend"],
   "enabledManagers": ["regex", "npm", "github-actions"],
   "postUpdateOptions": ["npmDedupe"],
+  "labels": ["dependencies", "javascript", "patch"],
   // These custom managers are used to bump dependencies in create-plugin template files
   "customManagers": [
     {
@@ -71,16 +72,6 @@
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"]
-    },
-    // minor and major will touch package.json files so we apply the patch label here to ensure changelog entries
-    {
-      "excludePackagePatterns": ["^@?docusaurus", "@grafana/*"],
-      "groupName": "dependencies",
-      "groupSlug": "prod-dependencies",
-      "labels": ["dependencies", "javascript", "patch"],
-      "matchCurrentVersion": "!/^0/",
-      "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["minor", "major"]
     },
     {
       "automerge": true,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR removes the minor, major grouped prod dependency bumps and instead sets default labels for any remaining dependency bump PRs. This should result in individual PRs for prod major and minor bumps that include `dependencies`, `javascript`, and `patch` labels.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
