### PR TITLE
CI: Use check-labels to label renovate PRs

### DIFF
--- a/.github/actions/check-labels/index.js
+++ b/.github/actions/check-labels/index.js
@@ -25,6 +25,7 @@ async function run() {
 
     const files = await getPullRequestFiles({ octokit });
 
+
     console.log(inspect({ userName, branchName, files }, { depth: null, colors: true }));
 
     if (isMissingSemverLabel) {
@@ -103,10 +104,10 @@ async function getPullRequestFiles({ octokit }) {
     payload: { pull_request },
     repo,
   } = context;
-  const prNumber = pull_request.number;
+  // const prNumber = pull_request.number;
   const { data } = await octokit.rest.pulls.listFiles({
     ...repo,
-    pull_number: prNumber,
+    pull_number: 1191,
   });
 
   return data;

--- a/.github/actions/check-labels/index.js
+++ b/.github/actions/check-labels/index.js
@@ -27,6 +27,8 @@ async function run() {
     if (userName === 'jackw' && isOnlyLockFileChanged) {
       console.log('Dependabot PR with only lock file changes. Skipping semver label check.');
       // console.log(inspect({ userName, isOnlyLockFileChanged, files }, { depth: null, colors: true }));
+    } else {
+      console.log('Checking semver labels...');
     }
 
     if (isMissingSemverLabel) {
@@ -105,10 +107,10 @@ async function getPullRequestFiles({ octokit }) {
     payload: { pull_request },
     repo,
   } = context;
-  // const prNumber = pull_request.number;
+  const prNumber = pull_request.number;
   const { data } = await octokit.rest.pulls.listFiles({
     ...repo,
-    pull_number: 1191,
+    pull_number: prNumber,
   });
 
   return data;

--- a/.github/actions/check-labels/index.js
+++ b/.github/actions/check-labels/index.js
@@ -2,6 +2,7 @@
 const core = require('@actions/core');
 const { context, getOctokit } = require('@actions/github');
 const { prMessageSymbol, prIntroMessage, prMessageLabelDetails, prReleaseLabelMessage } = require('./messages');
+const { inspect } = require('util');
 
 async function run() {
   try {
@@ -19,6 +20,8 @@ async function run() {
     const hasMultipleSemverLabels = attachedSemverLabels.length > 1;
     const hasOneSemverLabel = attachedSemverLabels.length === 1;
     const hasReleaseLabel = labelNames.includes('release');
+
+    console.log(inspect(pull_request, { depth: null, colors: true }));
 
     if (isMissingSemverLabel) {
       let errorMsg = [

--- a/.github/actions/check-labels/index.js
+++ b/.github/actions/check-labels/index.js
@@ -21,12 +21,13 @@ async function run() {
     const hasOneSemverLabel = attachedSemverLabels.length === 1;
     const hasReleaseLabel = labelNames.includes('release');
     const userName = pull_request.user.login;
-    const branchName = pull_request.head.ref;
 
     const files = await getPullRequestFiles({ octokit });
-
-
-    console.log(inspect({ userName, branchName, files }, { depth: null, colors: true }));
+    const isOnlyLockFileChanged = files.every((file) => file.filename.endsWith('package-lock.json'));
+    if (userName === 'jackw' && isOnlyLockFileChanged) {
+      console.log('Dependabot PR with only lock file changes. Skipping semver label check.');
+      // console.log(inspect({ userName, isOnlyLockFileChanged, files }, { depth: null, colors: true }));
+    }
 
     if (isMissingSemverLabel) {
       let errorMsg = [

--- a/.github/actions/check-labels/index.js
+++ b/.github/actions/check-labels/index.js
@@ -21,7 +21,7 @@ async function run() {
     const hasOneSemverLabel = attachedSemverLabels.length === 1;
     const hasReleaseLabel = labelNames.includes('release');
 
-    console.log(inspect(pull_request, { depth: null, colors: true }));
+    console.log(inspect({ user: pull_request.user }, { depth: null, colors: true }));
 
     if (isMissingSemverLabel) {
       let errorMsg = [

--- a/.github/actions/check-labels/index.js
+++ b/.github/actions/check-labels/index.js
@@ -20,8 +20,9 @@ async function run() {
     const hasMultipleSemverLabels = attachedSemverLabels.length > 1;
     const hasOneSemverLabel = attachedSemverLabels.length === 1;
     const hasReleaseLabel = labelNames.includes('release');
-
-    console.log(inspect({ user: pull_request.user }, { depth: null, colors: true }));
+    const userName = pull_request.user.login;
+    const branchName = pull_request.head.ref;
+    console.log(inspect({ userName, branchName }, { depth: null, colors: true }));
 
     if (isMissingSemverLabel) {
       let errorMsg = [

--- a/.github/actions/check-labels/index.js
+++ b/.github/actions/check-labels/index.js
@@ -22,7 +22,10 @@ async function run() {
     const hasReleaseLabel = labelNames.includes('release');
     const userName = pull_request.user.login;
     const branchName = pull_request.head.ref;
-    console.log(inspect({ userName, branchName }, { depth: null, colors: true }));
+
+    const files = await getPullRequestFiles({ octokit });
+
+    console.log(inspect({ userName, branchName, files }, { depth: null, colors: true }));
 
     if (isMissingSemverLabel) {
       let errorMsg = [
@@ -93,6 +96,20 @@ async function run() {
   } catch (error) {
     core.setFailed(error.message);
   }
+}
+
+async function getPullRequestFiles({ octokit }) {
+  const {
+    payload: { pull_request },
+    repo,
+  } = context;
+  const prNumber = pull_request.number;
+  const { data } = await octokit.rest.pulls.listFiles({
+    ...repo,
+    pull_number: prNumber,
+  });
+
+  return data;
 }
 
 async function doComment({ octokit, message }) {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,7 @@
   "reviewers": ["team:grafana/plugins-platform-frontend"],
   "enabledManagers": ["regex", "npm", "github-actions"],
   "postUpdateOptions": ["npmDedupe"],
-  "labels": ["dependencies", "javascript", "patch"],
+  "labels": ["dependencies", "javascript"],
   // These custom managers are used to bump dependencies in create-plugin template files
   "customManagers": [
     {

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -10,7 +10,6 @@ on:
       - edited
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
-  cancel-in-progress: true
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR removes the default `patch` label from renovate PRs and  updates the check-labels action to label renovate PRs with `no-changelog` or `patch` depending on if only the lock file is touched or not. The repos lock file changes don't affect consumers of packages so there is no need for those PRs to create releases or entries in changelogs. 

Additionally it removes the cancel-in-progress for the check-labels workflow as we (@ashharrison90 and myself) believe it is confusing renovate by cancelling workflow runs and preventing auto merge from working. Thanks Ash for the help! 🥇 


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
