### PR TITLE
Plugin E2E: Use api client when creating new datasources

### DIFF
--- a/packages/plugin-e2e/src/fixtures/commands/createDataSource.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createDataSource.ts
@@ -15,15 +15,15 @@ export const createDataSourceViaAPI = async (
   const { type, name } = datasource;
   const dsName = name ?? `${type}-${uuidv4()}`;
 
-  const existingDataSource = await grafanaAPIClient.getDataSourceByName(`/api/datasources/name/${dsName}`);
-  if (await existingDataSource.ok()) {
+  const existingDataSource = await grafanaAPIClient.getDataSourceByName(dsName);
+  if (existingDataSource.ok()) {
     const json = await existingDataSource.json();
     await grafanaAPIClient.deleteDataSourceByUID(json.uid);
   }
 
   const createDsReq = await grafanaAPIClient.createDataSource(datasource, dsName);
   const text = await createDsReq.text();
-  const status = await createDsReq.status();
+  const status = createDsReq.status();
   if (status === 200) {
     return createDsReq.json().then((r) => r.datasource);
   }

--- a/packages/plugin-e2e/src/fixtures/commands/createDataSource.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createDataSource.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
-import { APIRequestContext, expect, TestFixture } from '@playwright/test';
+import { expect, TestFixture } from '@playwright/test';
 import { CreateDataSourceArgs, DataSourceSettings, PlaywrightArgs } from '../../types';
+import { GrafanaAPIClient } from '../../models/GrafanaAPIClient';
 
 type CreateDataSourceViaAPIFixture = TestFixture<
   (args: CreateDataSourceArgs) => Promise<DataSourceSettings>,
@@ -8,26 +9,19 @@ type CreateDataSourceViaAPIFixture = TestFixture<
 >;
 
 export const createDataSourceViaAPI = async (
-  request: APIRequestContext,
+  grafanaAPIClient: GrafanaAPIClient,
   datasource: CreateDataSourceArgs
 ): Promise<DataSourceSettings> => {
   const { type, name } = datasource;
   const dsName = name ?? `${type}-${uuidv4()}`;
 
-  const existingDataSource = await request.get(`/api/datasources/name/${dsName}`);
+  const existingDataSource = await grafanaAPIClient.getDataSourceByName(`/api/datasources/name/${dsName}`);
   if (await existingDataSource.ok()) {
     const json = await existingDataSource.json();
-    await request.delete(`/api/datasources/uid/${json.uid}`);
+    await grafanaAPIClient.deleteDataSourceByUID(json.uid);
   }
 
-  const createDsReq = await request.post('/api/datasources', {
-    data: {
-      ...datasource,
-      name: dsName,
-      access: 'proxy',
-      isDefault: false,
-    },
-  });
+  const createDsReq = await grafanaAPIClient.createDataSource(datasource, dsName);
   const text = await createDsReq.text();
   const status = await createDsReq.status();
   if (status === 200) {
@@ -38,8 +32,8 @@ export const createDataSourceViaAPI = async (
   return existingDataSource.json();
 };
 
-export const createDataSource: CreateDataSourceViaAPIFixture = async ({ request }, use) => {
+export const createDataSource: CreateDataSourceViaAPIFixture = async ({ grafanaAPIClient }, use) => {
   await use(async (args) => {
-    return createDataSourceViaAPI(request, args);
+    return createDataSourceViaAPI(grafanaAPIClient, args);
   });
 };

--- a/packages/plugin-e2e/src/fixtures/commands/createDataSourceConfigPage.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/createDataSourceConfigPage.ts
@@ -9,7 +9,7 @@ type CreateDataSourceConfigPageFixture = TestFixture<
 >;
 
 export const createDataSourceConfigPage: CreateDataSourceConfigPageFixture = async (
-  { request, page, selectors, grafanaVersion },
+  { request, page, selectors, grafanaVersion, grafanaAPIClient },
   use,
   testInfo
 ) => {
@@ -17,7 +17,7 @@ export const createDataSourceConfigPage: CreateDataSourceConfigPageFixture = asy
   let deleteDataSource = true;
   await use(async (args) => {
     deleteDataSource = args.deleteDataSourceAfterTest ?? true;
-    const datasource = await createDataSourceViaAPI(request, args);
+    const datasource = await createDataSourceViaAPI(grafanaAPIClient, args);
     datasourceConfigPage = new DataSourceConfigPage({ page, selectors, grafanaVersion, request, testInfo }, datasource);
     await datasourceConfigPage.goto();
     return datasourceConfigPage;

--- a/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
+++ b/packages/plugin-e2e/src/models/GrafanaAPIClient.ts
@@ -1,5 +1,5 @@
 import { APIRequestContext } from '@playwright/test';
-import { DataSourceSettings, User } from '../types';
+import { CreateDataSourceArgs, DataSourceSettings, User } from '../types';
 
 export class GrafanaAPIClient {
   constructor(private request: APIRequestContext) {}
@@ -52,5 +52,24 @@ export class GrafanaAPIClient {
     }
     const settings: DataSourceSettings = await response.json();
     return settings;
+  }
+
+  async createDataSource(datasource: CreateDataSourceArgs, dsName: string) {
+    return this.request.post('/api/datasources', {
+      data: {
+        ...datasource,
+        name: dsName,
+        access: 'proxy',
+        isDefault: false,
+      },
+    });
+  }
+
+  async getDataSourceByName(name: string) {
+    return this.request.get(`/api/datasources/name/${name}`);
+  }
+
+  async deleteDataSourceByUID(uid: string) {
+    return this.request.delete(`/api/datasources/uid/${uid}`);
   }
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

The `createDataSourceConfigPage` fixture uses the grafana api to create a new data source. Currently it's calling the grafana api on behalf of the logged in user, which may not have permissions to create data sources.

This PR changes this so that creating data sources in now made on behalf of the `grafanaAPICredentials` provided in the playwright config. If no credentials have been provided, it will use the default admin:admin so this should not break tests for those who have not specified `grafanaAPICredentials`. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #1202

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.5.4-canary.1201.9d5a0c6.0
  npm install @grafana/plugin-e2e@1.8.4-canary.1201.9d5a0c6.0
  # or 
  yarn add @grafana/create-plugin@5.5.4-canary.1201.9d5a0c6.0
  yarn add @grafana/plugin-e2e@1.8.4-canary.1201.9d5a0c6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
