### PR TITLE
chore: bump go version to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21'
+          go-version: '~1.22'
           check-latest: true
           cache-dependency-path: ./${{ matrix.workingDir }}/go.sum
         if: ${{ matrix.hasBackend == true }}

--- a/packages/create-plugin/templates/backend-app/go.mod
+++ b/packages/create-plugin/templates/backend-app/go.mod
@@ -1,6 +1,6 @@
 module github.com/{{ kebabCase orgName }}/{{ kebabCase pluginName }}
 
-go 1.21
+go 1.22
 
 require github.com/grafana/grafana-plugin-sdk-go v0.156.0
 

--- a/packages/create-plugin/templates/backend/go.mod
+++ b/packages/create-plugin/templates/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/{{ kebabCase orgName }}/{{ kebabCase pluginName }}
 
-go 1.21
+go 1.22
 
 require github.com/grafana/grafana-plugin-sdk-go v0.156.0
 

--- a/packages/create-plugin/templates/github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
 
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Dropping support for 1.21 to allow otel dependency updates (which dropped support for Go 1.21), see https://github.com/grafana/grafana-plugin-sdk-go/pull/1092, https://github.com/grafana/grafana-plugin-sdk-go/pull/1086, https://github.com/grafana/grafana-plugin-sdk-go/pull/1084 and https://github.com/grafana/grafana-plugin-sdk-go/pull/1083

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/grafana-plugin-sdk-go/issues/1107

**Special notes for your reviewer**:
