### PR TITLE
Fix: Dont default navigation page permissions to admin

### DIFF
--- a/docusaurus/docs/tutorials/build-an-app-plugin.md
+++ b/docusaurus/docs/tutorials/build-an-app-plugin.md
@@ -77,7 +77,6 @@ Let's add a new page to the navigation menu:
            "type": "page",
            "name": "New Page",
            "path": "/a/%PLUGIN_ID%/new-page",
-           "roles": "Admin",
            "addToNav": true,
            "defaultNav": false
        }
@@ -119,6 +118,12 @@ The new page appears in the navigation menu. You can now edit the React router i
 1. Reload Grafana to see the new page in place.
 
 You don't need to register all your pages inside `includes` in your `plugin.json`. Register only pages that you want to add to the navigation menu.
+
+:::tip
+
+You can limit which users have access to pages in the navigation menu by using the [`role`](/reference/plugin-json#properties-7) property.
+
+:::
 
 :::note
 

--- a/packages/create-plugin/templates/app/src/plugin.json
+++ b/packages/create-plugin/templates/app/src/plugin.json
@@ -53,6 +53,7 @@
       "icon": "cog",
       "name": "Configuration",
       "path": "/plugins/%PLUGIN_ID%",
+      "role": "Admin",
       "addToNav": true
     }
   ],

--- a/packages/create-plugin/templates/app/src/plugin.json
+++ b/packages/create-plugin/templates/app/src/plugin.json
@@ -24,7 +24,6 @@
       "type": "page",
       "name": "Page One",
       "path": "/a/%PLUGIN_ID%/one",
-      "role": "Admin",
       "addToNav": true,
       "defaultNav": true
     },
@@ -32,7 +31,6 @@
       "type": "page",
       "name": "Page Two",
       "path": "/a/%PLUGIN_ID%/two",
-      "role": "Admin",
       "addToNav": true,
       "defaultNav": false
     },
@@ -40,7 +38,6 @@
       "type": "page",
       "name": "Page Three",
       "path": "/a/%PLUGIN_ID%/three",
-      "role": "Admin",
       "addToNav": true,
       "defaultNav": false
     },
@@ -48,7 +45,6 @@
       "type": "page",
       "name": "Page Four",
       "path": "/a/%PLUGIN_ID%/four",
-      "role": "Admin",
       "addToNav": true,
       "defaultNav": false
     },
@@ -57,7 +53,6 @@
       "icon": "cog",
       "name": "Configuration",
       "path": "/plugins/%PLUGIN_ID%",
-      "role": "Admin",
       "addToNav": true
     }
   ],

--- a/packages/create-plugin/templates/scenes-app/src/plugin.json
+++ b/packages/create-plugin/templates/scenes-app/src/plugin.json
@@ -26,7 +26,6 @@
       "type": "page",
       "name": "Home",
       "path": "/a/%PLUGIN_ID%/home",
-      "role": "Admin",
       "addToNav": true,
       "defaultNav": true
     },
@@ -34,7 +33,6 @@
       "type": "page",
       "name": "Page with tabs",
       "path": "/a/%PLUGIN_ID%/page-with-tabs",
-      "role": "Admin",
       "addToNav": true,
       "defaultNav": false
     },
@@ -42,7 +40,6 @@
       "type": "page",
       "name": "Page with drilldown",
       "path": "/a/%PLUGIN_ID%/page-with-drilldown",
-      "role": "Admin",
       "addToNav": true,
       "defaultNav": false
     },
@@ -50,7 +47,6 @@
       "type": "page",
       "name": "Hello world",
       "path": "/a/%PLUGIN_ID%/hello-world",
-      "role": "Admin",
       "addToNav": true,
       "defaultNav": false
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
There have been a [recent bug report](https://raintank-corp.slack.com/archives/C04FRQ2S0AV/p1728381252390489) that scenes apps can only be accessed by admin users. After some back and forth with the developers it was confirmed that the plugin.json contained `role: Admin` which limits page access to only Admin users.

This PR removes these role properties from the plugin.json templates for apps and apps with scenes leaving it for a plugin developer to "buy in" to limiting custom page access to certain roles. It also cleans up the build an app tutorial which has an incorrect `roles` property and adds a tip admonition explaining how to limit access to pages.

I've intentionally left the app config page with role access as admin as I believe anything else would likely cause errors if viewers or editors attempted to access / edit the app configs.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #1207

**Special notes for your reviewer**:
If / when this PR is ready to merge will likely need to carry across whatever changes we make here to the plugin-examples repo app examples.