### PR TITLE
Config: check environment for Grafana admin URL, username, and password

### DIFF
--- a/docusaurus/docs/e2e-test-a-plugin/authentication.md
+++ b/docusaurus/docs/e2e-test-a-plugin/authentication.md
@@ -97,7 +97,7 @@ export default defineConfig<PluginOptions>({
 
 ## Managing users
 
-When a `user` is defined in a setup project (like in the RBAC example above) `plugin-e2e` will use the Grafana HTTP API to create the user account. This action requires elevated permissions, so by default the server administrator credentials `admin:admin` will be used. If the end-to-end tests are targeting the [development environment](../get-started/set-up-development-environment.mdx) scaffolded with `create-plugin`, this will work fine. However for other test environments the server administrator password may be different. In that case, we search for GRAFANA_ADMIN_USERNAME and GRAFANA_ADMIN_PASSWORD environment variables. Additionally you can provide the correct credentials by setting `grafanaAPICredentials` in the global options.
+When a `user` is defined in a setup project (like in the RBAC example above) `plugin-e2e` will use the Grafana HTTP API to create the user account. This action requires elevated permissions, so by default the server administrator credentials `admin:admin` will be used. If the end-to-end tests are targeting the [development environment](../get-started/set-up-development-environment.mdx) scaffolded with `create-plugin`, this will work fine. However for other test environments the server administrator password may be different. In that case, we search for GRAFANA_ADMIN_USER and GRAFANA_ADMIN_PASSWORD environment variables. Additionally you can provide the correct credentials by setting `grafanaAPICredentials` in the global options.
 
 ```ts title="playwright.config.ts"
 import { dirname } from 'path';
@@ -110,7 +110,7 @@ export default defineConfig<PluginOptions>({
   use: {
     baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
     grafanaAPICredentials: {
-      user: process.env.GRAFANA_ADMIN_USERNAME || 'admin',
+      user: process.env.GRAFANA_ADMIN_USER || 'admin',
       password: process.env.GRAFANA_ADMIN_PASSWORD || 'admin',
     },
   },

--- a/docusaurus/docs/e2e-test-a-plugin/authentication.md
+++ b/docusaurus/docs/e2e-test-a-plugin/authentication.md
@@ -97,7 +97,7 @@ export default defineConfig<PluginOptions>({
 
 ## Managing users
 
-When a `user` is defined in a setup project (like in the RBAC example above) `plugin-e2e` will use the Grafana HTTP API to create the user account. This action requires elevated permissions, so by default the server administrator credentials `admin:admin` will be used. If the end-to-end tests are targeting the [development environment](../get-started/set-up-development-environment.mdx) scaffolded with `create-plugin`, this will work fine. However for other test environments the server administrator password may be different. In that case, you can provide the correct credentials by setting `grafanaAPICredentials` in the global options.
+When a `user` is defined in a setup project (like in the RBAC example above) `plugin-e2e` will use the Grafana HTTP API to create the user account. This action requires elevated permissions, so by default the server administrator credentials `admin:admin` will be used. If the end-to-end tests are targeting the [development environment](../get-started/set-up-development-environment.mdx) scaffolded with `create-plugin`, this will work fine. However for other test environments the server administrator password may be different. In that case, we search for GRAFANA_USER and GRAFANA_PASSWORD environment variables. Additionally you can provide the correct credentials by setting `grafanaAPICredentials` in the global options.
 
 ```ts title="playwright.config.ts"
 import { dirname } from 'path';

--- a/docusaurus/docs/e2e-test-a-plugin/authentication.md
+++ b/docusaurus/docs/e2e-test-a-plugin/authentication.md
@@ -97,7 +97,7 @@ export default defineConfig<PluginOptions>({
 
 ## Managing users
 
-When a `user` is defined in a setup project (like in the RBAC example above) `plugin-e2e` will use the Grafana HTTP API to create the user account. This action requires elevated permissions, so by default the server administrator credentials `admin:admin` will be used. If the end-to-end tests are targeting the [development environment](../get-started/set-up-development-environment.mdx) scaffolded with `create-plugin`, this will work fine. However for other test environments the server administrator password may be different. In that case, we search for GRAFANA_USER and GRAFANA_PASSWORD environment variables. Additionally you can provide the correct credentials by setting `grafanaAPICredentials` in the global options.
+When a `user` is defined in a setup project (like in the RBAC example above) `plugin-e2e` will use the Grafana HTTP API to create the user account. This action requires elevated permissions, so by default the server administrator credentials `admin:admin` will be used. If the end-to-end tests are targeting the [development environment](../get-started/set-up-development-environment.mdx) scaffolded with `create-plugin`, this will work fine. However for other test environments the server administrator password may be different. In that case, we search for GRAFANA_ADMIN_USERNAME and GRAFANA_ADMIN_PASSWORD environment variables. Additionally you can provide the correct credentials by setting `grafanaAPICredentials` in the global options.
 
 ```ts title="playwright.config.ts"
 import { dirname } from 'path';
@@ -108,10 +108,10 @@ const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 export default defineConfig<PluginOptions>({
   testDir: './tests',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
     grafanaAPICredentials: {
-      user: 'admin',
-      password: process.env.PASSWORD,
+      user: process.env.GRAFANA_ADMIN_USERNAME || 'admin',
+      password: process.env.GRAFANA_ADMIN_PASSWORD || 'admin',
     },
   },
   projects: [

--- a/packages/create-plugin/templates/common/playwright.config
+++ b/packages/create-plugin/templates/common/playwright.config
@@ -28,7 +28,7 @@ export default defineConfig<PluginOptions>({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/packages/plugin-e2e/README.md
+++ b/packages/plugin-e2e/README.md
@@ -47,7 +47,7 @@ export default defineConfig<PluginOptions>({
   testDir: './tests', // change this to the directory that was chosen when installing Playwright
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
   },
   projects: [
     {

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig<PluginOptions>({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
+    baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/packages/plugin-e2e/playwright.config.ts
+++ b/packages/plugin-e2e/playwright.config.ts
@@ -21,7 +21,7 @@ export default defineConfig<PluginOptions>({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -3,7 +3,7 @@ import { Fixtures } from '@playwright/test';
 import { PluginOptions, User } from './types';
 
 export const DEFAULT_ADMIN_USER: User = {
-  user: process.env.GRAFANA_ADMIN_USERNAME || 'admin',
+  user: process.env.GRAFANA_ADMIN_USER || 'admin',
   password: process.env.GRAFANA_ADMIN_PASSWORD || 'admin',
 };
 

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -2,7 +2,10 @@ import path = require('path');
 import { Fixtures } from '@playwright/test';
 import { PluginOptions, User } from './types';
 
-export const DEFAULT_ADMIN_USER: User = { user: 'admin', password: 'admin' };
+export const DEFAULT_ADMIN_USER: User = { 
+  user: process.env.GRAFANA_USER || 'admin', 
+  password: process.env.GRAFANA_PASSWORD || 'admin' 
+};
 
 export const options: Fixtures<{}, PluginOptions> = {
   featureToggles: [{}, { option: true, scope: 'worker' }],

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -2,9 +2,9 @@ import path = require('path');
 import { Fixtures } from '@playwright/test';
 import { PluginOptions, User } from './types';
 
-export const DEFAULT_ADMIN_USER: User = { 
-  user: process.env.GRAFANA_USER || 'admin', 
-  password: process.env.GRAFANA_PASSWORD || 'admin' 
+export const DEFAULT_ADMIN_USER: User = {
+  user: process.env.GRAFANA_ADMIN_USERNAME || 'admin',
+  password: process.env.GRAFANA_ADMIN_PASSWORD || 'admin',
 };
 
 export const options: Fixtures<{}, PluginOptions> = {


### PR DESCRIPTION
**What this PR does**:
This PR adds a check for the GRAFANA_ADMIN_USER, and GRAFANA_ADMIN_PASSWORD environment variables before falling back to defaults following the [conventions for GRAFANA_VERSION](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/src/fixtures/grafanaVersion.ts#L6).

For the baseURL we add a recommendation for the playwright config to use GRAFANA_URL or fallback to localhost:3000.

**Why we need it**:
There are circumstances for testing where we would like to run tests against an instance of Grafana that is not controlled by the test environment. For that we need to pass in the url, username, and password of the grafana instance into the test. Adding support for these environment variables allows us to do this without changing the configuration of the playwright config and makes the tests more portable without intervention from the author


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.7.0-canary.1244.aad8b0e.0
  npm install @grafana/plugin-e2e@1.10.0-canary.1244.aad8b0e.0
  # or 
  yarn add @grafana/create-plugin@5.7.0-canary.1244.aad8b0e.0
  yarn add @grafana/plugin-e2e@1.10.0-canary.1244.aad8b0e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
