### PR TITLE
Dependencies: Follow e2e-selectors modified tag

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,7 +36,7 @@
     },
     {
       "automerge": true,
-      "groupName": "e2e-selector dependencies in scaffolded plugin ",
+      "groupName": "e2e-selector dependencies in scaffolded plugin",
       "groupSlug": "scaffolded-plugin-e2e-selectors",
       "labels": ["dependencies", "patch", "release"],
       "matchPackageNames": ["@grafana/e2e-selectors"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -80,7 +80,8 @@
       "groupSlug": "dev-dependencies-automerge",
       "labels": ["dependencies", "javascript", "no-changelog"],
       "matchCurrentVersion": "!/^0/",
-      "matchDepTypes": ["devDependencies"]
+      "matchDepTypes": ["devDependencies"],
+      "excludePackageNames": ["@grafana/e2e-selectors"],
     },
     // patches will only touch the repo lock file so we apply no-changelog to prevent entries in the changelog
     // which would be misleading to consumers.

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,13 +31,34 @@
       "labels": ["dependencies", "patch"],
       "matchCurrentVersion": "!/^0/",
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
-      "matchUpdateTypes": ["patch"]
+      "excludePackageNames": ["@grafana/e2e-selectors"],
+      "matchUpdateTypes": ["patch"],
+    },
+    {
+      "automerge": true,
+      "groupName": "e2e-selector dependencies in scaffolded plugin ",
+      "groupSlug": "scaffolded-plugin-e2e-selectors",
+      "labels": ["dependencies", "patch", "release"],
+      "matchPackageNames": ["@grafana/e2e-selectors"],
+      "matchUpdateTypes": ["patch"],
+      "followTag": "modified",
+      "matchManagers": ["regex"],
+    },
+    {
+      "automerge": true,
+      "groupName": "e2e-selector dependencies in plugin-e2e",
+      "groupSlug": "plugin-e2e-selectors",
+      "labels": ["dependencies", "no-changelog"],
+      "matchPackageNames": ["@grafana/e2e-selectors"],
+      "followTag": "modified",
+      "matchManagers": ["npm"],
     },
     {
       "groupName": "grafana dependencies",
       "groupSlug": "all-grafana",
       "labels": ["dependencies", "release", "patch"],
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
+      "excludePackageNames": ["@grafana/e2e-selectors"],
       "matchUpdateTypes": ["minor", "major"]
     },
     // Docusaurus dependencies have to be grouped together otherwise error out when building website.

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -19,12 +19,12 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "^7.21.4",{{#if useCypress}}
-    "@grafana/e2e": "^11.0.7",
-    "@grafana/e2e-selectors": "^11.2.2",{{/if}}
+    "@grafana/e2e": "^11.0.7",{{/if}}
     "@grafana/eslint-config": "^7.0.0",{{#if usePlaywright}}
     "@grafana/plugin-e2e": "^1.8.3",{{/if}}
     "@grafana/tsconfig": "^2.0.0",{{#if usePlaywright}}
     "@playwright/test": "^1.41.2",{{/if}}
+    "@grafana/e2e-selectors": "11.2.2",
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",


### PR DESCRIPTION
**What this PR does / why we need it**:

In this PR, we follow the `grafana/e2e-selectors@modified` tag in scaffolded plugin and in the plugin-e2e package. I put them in two different package rules since they needs two different set of labels - plugin-e2e needs to be released immediately and create-plugin can probably wait. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
