### PR TITLE
Renovate: Adjust e2e-selectors dependency management

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,7 @@
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
       "rangeStrategy": "bump",
+      "enabledManagers": ["npm"],
     },
     {
       "groupName": "grafana dependencies",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,9 +38,10 @@
       "automerge": true,
       "groupName": "e2e-selector dependencies",
       "groupSlug": "plugin-e2e-selectors",
-      "labels": ["dependencies", "patch", "release"],
+      "labels": ["dependencies", "patch"],
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
+      "rangeStrategy": "bump",
     },
     {
       "groupName": "grafana dependencies",

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -19,12 +19,12 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "^7.21.4",{{#if useCypress}}
-    "@grafana/e2e": "^11.0.7",{{/if}}
+    "@grafana/e2e": "^11.0.7",
+    "@grafana/e2e-selectors": "^11.2.2",{{/if}}
     "@grafana/eslint-config": "^7.0.0",{{#if usePlaywright}}
     "@grafana/plugin-e2e": "^1.8.3",{{/if}}
     "@grafana/tsconfig": "^2.0.0",{{#if usePlaywright}}
     "@playwright/test": "^1.41.2",{{/if}}
-    "@grafana/e2e-selectors": "^11.4.0-204289",
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -24,7 +24,7 @@
     "@grafana/plugin-e2e": "^1.8.3",{{/if}}
     "@grafana/tsconfig": "^2.0.0",{{#if usePlaywright}}
     "@playwright/test": "^1.41.2",{{/if}}
-    "@grafana/e2e-selectors": "11.2.2",
+    "@grafana/e2e-selectors": "^11.4.0-204289",
     "@swc/core": "^1.3.90",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes a few changes to the package rule for the `e2e-selector` package:
* adds a `^` range to the package.json for scaffolded plugins (the regex manager did not pickup this change due to missing range)
* removes the `release` label as it will be added automatically by the labelling Action
* since the new version of the `e2e-selectors` package satisfies the range, Renovate will only update the lockfile and not the package.json. By specifying rangeStrategy to `bump`, I _think_ renovate will update the package.json version too. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
