### PR TITLE
Types Bundler: Add debugger and process args

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31617,6 +31617,7 @@
         "@grafana/levitate": "^0.15.0",
         "@types/minimist": "^1.2.2",
         "@types/node": "22.8.4",
+        "debug": "^4.3.4",
         "jackw-dts-bundle-gen-test": "^9.5.1",
         "minimist": "^1.2.8"
       },

--- a/packages/plugin-types-bundler/package.json
+++ b/packages/plugin-types-bundler/package.json
@@ -51,6 +51,7 @@
     "@grafana/levitate": "^0.15.0",
     "@types/minimist": "^1.2.2",
     "@types/node": "22.8.4",
+    "debug": "^4.3.4",
     "jackw-dts-bundle-gen-test": "^9.5.1",
     "minimist": "^1.2.8"
   }

--- a/packages/plugin-types-bundler/src/args.ts
+++ b/packages/plugin-types-bundler/src/args.ts
@@ -22,9 +22,10 @@ export const parsedArgs = parseArgs<ParsedArgs>(args, {
     console.error(`Unknown argument: ${arg}`);
     process.exit(1);
   },
-  default: {
-    entryPoint: undefined,
-    tsConfig: resolve(__dirname, '../tsconfig', 'tsconfig.json'),
-    outDir: join(process.cwd(), 'dist'),
-  },
 });
+
+export const DEFAULT_ARGS: ParsedArgs = {
+  entryPoint: undefined,
+  tsConfig: resolve(__dirname, '../tsconfig', 'tsconfig.json'),
+  outDir: join(process.cwd(), 'dist'),
+};

--- a/packages/plugin-types-bundler/src/bin/run.ts
+++ b/packages/plugin-types-bundler/src/bin/run.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import { existsSync } from 'fs';
+import { parsedArgs } from '../args.js';
 import { generateTypes } from '../bundleTypes.js';
-import { parsedArgs } from '../utils.js';
+import { debug } from '../debug.js';
 
-const { entryPoint, tsConfig, outDir } = parsedArgs;
+let { entryPoint, tsConfig, outDir } = parsedArgs;
 
-// Check if the first argument is present
+// Check if the entrypoint argument is present
 if (entryPoint === undefined) {
   console.error('Please provide the path for the entry types file as an argument.');
   console.error('(E.g. "npx @grafana/plugin-types-bundler ./src/types/index.ts")');
@@ -21,6 +22,9 @@ if (!existsSync(entryPoint)) {
 const startTime = Date.now().valueOf();
 try {
   console.log('⚡️ Starting to bundle types for plugin...');
+
+  debug({ entryPoint, tsConfig, outDir });
+
   generateTypes({ entryPoint, tsConfig, outDir });
 } catch (error) {
   console.error('Error while bundling types:', error);

--- a/packages/plugin-types-bundler/src/debug.ts
+++ b/packages/plugin-types-bundler/src/debug.ts
@@ -1,0 +1,3 @@
+import createDebug from 'debug';
+
+export const debug = createDebug('plugin-types-bundler');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds the following to the types-bundler package:

- [x] Split out default args from parseArgs so we have more control over processing args
- [x] add a debugger
- [x] handle cases where empty strings are passed as args and check entry-point file exists

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related grafana/grafana/issues/90171

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-types-bundler@0.0.6-canary.1269.593a35b.0
  # or 
  yarn add @grafana/plugin-types-bundler@0.0.6-canary.1269.593a35b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
