### PR TITLE
Renovate: Update rules for es-lint config and selectors

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,14 +42,14 @@
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
       "rangeStrategy": "bump",
-      "enabledManagers": ["npm"],
+      "ignorePaths": ["/packages/create-plugin/templates/common/**"],
     },
     {
       "groupName": "grafana dependencies",
       "groupSlug": "all-grafana",
       "labels": ["dependencies", "release", "patch"],
       "matchPackagePatterns": ["@grafana/*", "grafana/grafana-enterprise"],
-      "excludePackageNames": ["@grafana/e2e-selectors"],
+      "excludePackageNames": ["@grafana/e2e-selectors", "@grafana/eslint-config"],
       "matchUpdateTypes": ["minor", "major"]
     },
     // Docusaurus dependencies have to be grouped together otherwise error out when building website.


### PR DESCRIPTION
**What this PR does / why we need it**:

Temporarily ignoring major updates of the `grafana/eslint-config` as 8.0 is not compatible with yarn. Also change the e2e-selectors package rule so that changes doesn't update the package json in scaffolded plugins. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
