### PR TITLE
Renovate: Restrict selector updates to only plugin-e2e package

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,7 +42,7 @@
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
       "rangeStrategy": "bump",
-      "ignorePaths": ["/packages/create-plugin/templates/common/**"],
+      "matchCategories": ["npm"],
     },
     {
       "groupName": "grafana dependencies",


### PR DESCRIPTION
**What this PR does / why we need it**:

Only the plugin-e2e package needs to follow the `modified` dist-tag of `grafana/e2e-selectors`. However, currently this package rule is affecting also the `_package.json` file for scaffolded plugins (see example in [this](https://github.com/grafana/plugin-tools/pull/1270) pr). By specifying the renovate option [`matchcategories`](`https://docs.renovatebot.com/configuration-options/#matchcategories`) and setting it to `npm`, this update should be restricted to the plugin-e2e workspace only (changes in `_package.json` is managed by the regex manager which has the category name `custom`). 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
