### PR TITLE
Create Plugin: Add `buildMode` property to plugin.json asset 

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/BuildModeWebpackPlugin.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/BuildModeWebpackPlugin.ts
@@ -11,17 +11,22 @@ export class BuildModeWebpackPlugin {
           stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
         },
         async () => {
-          const pluginJsonAsset = compilation.getAsset('plugin.json');
-          const pluginJsonString = pluginJsonAsset ? pluginJsonAsset?.source.source().toString() : '{}';
-          const pluginJsonWithBuildMode = JSON.stringify(
-            {
-              ...JSON.parse(pluginJsonString),
-              buildMode: compilation.options.mode,
-            },
-            null,
-            4
-          );
-          compilation.updateAsset('plugin.json', new webpack.sources.RawSource(pluginJsonWithBuildMode));
+          const assets = compilation.getAssets();
+          for (const asset of assets) {
+            if (asset.name.endsWith('plugin.json')) {
+              console.log(asset.name);
+              const pluginJsonString = asset.source.source().toString();
+              const pluginJsonWithBuildMode = JSON.stringify(
+                {
+                  ...JSON.parse(pluginJsonString),
+                  buildMode: compilation.options.mode,
+                },
+                null,
+                4
+              );
+              compilation.updateAsset(asset.name, new webpack.sources.RawSource(pluginJsonWithBuildMode));
+            }
+          }
         }
       );
     });

--- a/packages/create-plugin/templates/common/.config/webpack/BuildModeWebpackPlugin.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/BuildModeWebpackPlugin.ts
@@ -1,0 +1,29 @@
+import * as webpack from 'webpack';
+
+const PLUGIN_NAME = 'BuildModeWebpack';
+
+export class BuildModeWebpackPlugin {
+  apply(compiler: webpack.Compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+        },
+        async () => {
+          const pluginJsonAsset = compilation.getAsset('plugin.json');
+          const pluginJsonString = pluginJsonAsset ? pluginJsonAsset?.source.source().toString() : '{}';
+          const pluginJsonWithBuildMode = JSON.stringify(
+            {
+              ...JSON.parse(pluginJsonString),
+              buildMode: compilation.options.mode,
+            },
+            null,
+            4
+          );
+          compilation.updateAsset('plugin.json', new webpack.sources.RawSource(pluginJsonWithBuildMode));
+        }
+      );
+    });
+  }
+}

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -16,6 +16,7 @@ import { type Configuration, BannerPlugin } from 'webpack';
 import LiveReloadPlugin from 'webpack-livereload-plugin';
 import VirtualModulesPlugin from 'webpack-virtual-modules';
 
+import { BuildModeWebpackPlugin } from './BuildModeWebpackPlugin';
 import { DIST_DIR, SOURCE_DIR } from './constants';
 import { getCPConfigVersion, getEntries, getPackageJson, getPluginJson, hasReadme, isWSL } from './utils';
 
@@ -187,6 +188,7 @@ const config = async (env): Promise<Configuration> => {
     },
 
     plugins: [
+      new BuildModeWebpackPlugin(),
       virtualPublicPath,
       // Insert create plugin version information into the bundle
       new BannerPlugin({


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a simple webpack plugin the inserts a `buildMode` prop to the plugin.json asset. Knowing if the plugin was build for dev or production might be useful in a different scenarios. For example, in the plugin extensions API we put error messages in the dev console in case Grafana is in dev mode. However, most Grafana contributors would consider these errors spam. It would be better if we could only log errors related to a certain plugin in case that specific plugin was built for development. 

Should `buildMode` be added to the plugin.json schema? Note that this is only added to the asset build time.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.8.0-canary.1281.9616e88.0
  # or 
  yarn add @grafana/create-plugin@5.8.0-canary.1281.9616e88.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
