### PR TITLE
Renovate: Restrict selector updates to plugin-e2e

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,7 +42,7 @@
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
       "rangeStrategy": "bump",
-      "matchCategories": ["npm"],
+      "matchFileNames": ["packages/plugin-e2e/package.json", "package-lock.json"],
     },
     {
       "groupName": "grafana dependencies",


### PR DESCRIPTION
**What this PR does / why we need it**:

Only the plugin-e2e package needs to follow the `modified` dist-tag of `grafana/e2e-selectors`. However, currently this package rule is affecting also the `_package.json` file for scaffolded plugins.  This PR puts a restriction on the e2e-selector package rule so that it only applies to the package.json in plugin-e2e workspace. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
