### PR TITLE
Renovate: Add release label to e2e-selector updates in the plugin-e2e package

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,7 +38,7 @@
       "automerge": true,
       "groupName": "e2e-selector dependencies",
       "groupSlug": "plugin-e2e-selectors",
-      "labels": ["dependencies", "patch"],
+      "labels": ["dependencies", "patch", "release"],
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
       "rangeStrategy": "bump",


### PR DESCRIPTION

**What this PR does / why we need it**:

Now that the entire flow appears to work, we can attach the release label too. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
