### PR TITLE
Support node 22

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: ./.github/actions/check-labels/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .npmrc file for NPM registry
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -74,7 +74,7 @@ jobs:
       - name: Setup .npmrc file for NPM registry
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download packed artifacts
@@ -202,7 +202,7 @@ jobs:
       - name: Setup environment
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Which branch to use?"
-        default: "main"
+        description: 'Which branch to use?'
+        default: 'main'
 jobs:
   deploy:
     name: Deploy docs to Developer Portal Bucket
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
-     
+
       - name: 'Deploy to Developer Portal Bucket'
         run: |
           gsutil -m rsync -r -d -c ./docusaurus/website/build/ gs://staging-developer-portal/plugin-tools

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v2'
-     
+
       - name: 'Deploy to Developer Portal Bucket'
         run: |
           gsutil -m rsync -r -d -c ./docusaurus/website/build/ gs://grafana-developer-portal/plugin-tools

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -27,14 +27,14 @@ jobs:
   build-docs:
     needs: changes
     if: ${{ needs.changes.outputs.docs == 'true' }}
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4        
+        uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - name: Install dependencies

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -62,7 +62,7 @@
     "webpack-virtual-modules": "^0.6.2"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@emotion/css": "11.10.6",

--- a/packages/create-plugin/templates/github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: '{{ packageManagerName }}'
 
       - name: Install dependencies
@@ -161,7 +161,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: '{{ packageManagerName }}'
 
       - name: Install dev dependencies

--- a/packages/create-plugin/templates/github/workflows/is-compatible.yml
+++ b/packages/create-plugin/templates/github/workflows/is-compatible.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: '{{ packageManagerName }}'
       - name: Install dependencies
         run: {{ packageManagerInstallCmd }}

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -32,7 +32,7 @@
     "playwright:all": "npx playwright test"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=18 <=22"
   },
   "peerDependencies": {
     "@playwright/test": "^1.41.2"

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -32,7 +32,7 @@
     "playwright:all": "npx playwright test"
   },
   "engines": {
-    "node": ">=18 <=20"
+    "node": ">=18"
   },
   "peerDependencies": {
     "@playwright/test": "^1.41.2"


### PR DESCRIPTION
**What this PR does / why we need it**:

Node 22 is now LTS. This PR adds support for Node 22 in plugin-e2e (and removes the upper bound) and changes the node engine in scaffolded plugins to 22. Also changing all workflows (local and scaffolded) to use 22. 

We'll remove support for node 18 entirely once it's moved out of maintenance LTS.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

Will add a follow up PR that bumps node version in the examples repo.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.9.0-canary.1298.08bf9c9.0
  npm install @grafana/plugin-e2e@1.12.0-canary.1298.08bf9c9.0
  # or 
  yarn add @grafana/create-plugin@5.9.0-canary.1298.08bf9c9.0
  yarn add @grafana/plugin-e2e@1.12.0-canary.1298.08bf9c9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
