### PR TITLE
Create Plugin: Add error-handling for JSON parsing in utils

### DIFF
--- a/packages/create-plugin/src/utils/utils.goSdk.ts
+++ b/packages/create-plugin/src/utils/utils.goSdk.ts
@@ -71,8 +71,14 @@ function getLatestSdkVersion(exportPath: string): Promise<string> {
         debug(error);
         reject();
       }
-      const version = JSON.parse(stdout).Version;
-      resolve(version);
+
+      try {
+        const version = JSON.parse(stdout).Version;
+        resolve(version);
+      } catch (e) {
+        debug(e);
+        reject();
+      }
     });
   });
 }


### PR DESCRIPTION
### What's the problem?
We [received an error](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1731522412055029?thread_ts=1731517592.993479&cid=C01C4K8DETW) that happens when the return value of the go sdk version check command cannot be parsed as a JSON: 
```
› npx @grafana/create-plugin@latest update
undefined:1


SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at file:///Users/l2d2/.npm/_npx/c8ca622b04c0c218/node_modules/@grafana/create-plugin/dist/utils/utils.goSdk.js:58:34
    at ChildProcess.exithandler (node:child_process:430:5)
    at ChildProcess.emit (node:events:514:28)
    at maybeClose (node:internal/child_process:1105:16)
    at Socket.<anonymous> (node:internal/child_process:457:11)
    at Socket.emit (node:events:514:28)
    at Pipe.<anonymous> (node:net:337:12)
```

### What changed?
This PR adds a simple error handling for the JSON parsing, so it fails gracefully in case the return value is not a valid JSON.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.9.2-canary.1323.45d3ff8.0
  # or 
  yarn add @grafana/create-plugin@5.9.2-canary.1323.45d3ff8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
