### PR TITLE
Revert "chore(deps): update dependency cookie to v1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11474,6 +11474,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
       "path-to-regexp": "3.3.0"
     },
     "express": {
-      "cookie": "^1.0.0"
+      "cookie": "^0.7.0"
     }
   }
 }


### PR DESCRIPTION
Reverts grafana/plugin-tools#1309

This removed cookie entirely and broke the docusaurus dev command `npm run docs`.

```
[ERROR] Error: Cannot find module 'cookie'
Require stack:
- /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/express/lib/response.js
- /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/express/lib/express.js
- /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/express/index.js
- /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/webpack-dev-server/lib/Server.js
- /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/@docusaurus/core/lib/commands/start/webpack.js
- /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/@docusaurus/core/lib/commands/start/start.js
- /Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/@docusaurus/core/lib/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
    at Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/express/lib/response.js:31:14)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1416:10)
    at Module.load (node:internal/modules/cjs/loader:1208:32)
    at Module._load (node:internal/modules/cjs/loader:1024:12)
    at Module.require (node:internal/modules/cjs/loader:1233:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/express/lib/response.js',
    '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/express/lib/express.js',
    '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/express/index.js',
    '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/webpack-dev-server/lib/Server.js',
    '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/@docusaurus/core/lib/commands/start/webpack.js',
    '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/@docusaurus/core/lib/commands/start/start.js',
    '/Users/jackwestbrook/dev/grafana/plugin-tools/node_modules/@docusaurus/core/lib/index.js'
  ]
}
[INFO] Docusaurus version: 3.6.0
Node version: v20.16.0
npm error Lifecycle script `start` failed with error:
npm error code 1
npm error path /Users/jackwestbrook/dev/grafana/plugin-tools/docusaurus/website
npm error workspace website@3.5.0
npm error location /Users/jackwestbrook/dev/grafana/plugin-tools/docusaurus/website
npm error command failed
npm error command sh -c docusaurus start

—————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Running target start for project website failed

```

