### PR TITLE
E2E Workflow: Schedule e2e workflow to run once per day

### DIFF
--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.npm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.npm.md
@@ -2,6 +2,8 @@
 name: E2E tests
 on:
   pull_request:
+  schedule:
+    - cron: '0 11 * * *' #Run e2e tests once a day at 11 UTC
 
 permissions:
   contents: read

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.pnpm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.pnpm.md
@@ -2,6 +2,8 @@
 name: E2E tests
 on:
   pull_request:
+  schedule:
+    - cron: '0 11 * * *' #Run e2e tests once a day at 11 UTC
 
 permissions:
   contents: read

--- a/docusaurus/docs/snippets/plugin-e2e-ds-workflow.yarn.md
+++ b/docusaurus/docs/snippets/plugin-e2e-ds-workflow.yarn.md
@@ -2,6 +2,8 @@
 name: E2E tests
 on:
   pull_request:
+  schedule:
+    - cron: '0 11 * * *' #Run e2e tests once a day at 11 UTC
 
 permissions:
   contents: read

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.npm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.npm.md
@@ -2,6 +2,8 @@
 name: E2E tests
 on:
   pull_request:
+  schedule:
+    - cron: '0 11 * * *' #Run e2e tests once a day at 11 UTC
 
 permissions:
   contents: read

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.pnpm.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.pnpm.md
@@ -2,6 +2,8 @@
 name: E2E tests
 on:
   pull_request:
+  schedule:
+    - cron: '0 11 * * *' #Run e2e tests once a day at 11 UTC
 
 permissions:
   contents: read

--- a/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.yarn.md
+++ b/docusaurus/docs/snippets/plugin-e2e-fe-plugin-workflow.yarn.md
@@ -2,6 +2,8 @@
 name: E2E tests
 on:
   pull_request:
+  schedule:
+    - cron: '0 11 * * *' #Run e2e tests once a day at 11 UTC
 
 permissions:
   contents: read


### PR DESCRIPTION
By scheduling the e2e workflow to run once per day, plugin authors will now weather their plugin is compatible with the next release of Grafana. 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
