### PR TITLE
Docs: Update DataSourceWithSupplementaryQueriesSupport instructions

### DIFF
--- a/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-logs-data-source-plugin.md
@@ -403,7 +403,7 @@ These APIs can be used in data sources within the [`grafana/grafana`](https://gi
 
 :::note
 
-This feature is not currently not supported for external plugins outside of Grafana repo. It is implemented in data source by implementing `DataSourceWithXXXSupport` interface.
+It is implemented in data source by implementing `DataSourceWithXXXSupport` interface.
 
 :::
 
@@ -418,7 +418,6 @@ This API must be implemented in data source in typescript code.
 :::
 
 ```ts
-import { queryLogsVolume } from '../features/logs/logsModel'; // This is currently not available for use outside of the Grafana repo
 import {
   DataSourceWithSupplementaryQueriesSupport,
   LogLevel,
@@ -451,19 +450,22 @@ export class ExampleDatasource
     }
   }
 
-  // Returns an observable that will be used to fetch supplementary data based on the provided
-  // supplementary query type and original request.
-  getDataProvider(
+  // It generates a DataQueryRequest for a specific supplementary query type.
+  // @returns A DataQueryRequest for the supplementary queries or undefined if not supported.
+  getSupplementaryRequest(
     type: SupplementaryQueryType,
-    request: DataQueryRequest<ExampleQuery>
-  ): Observable<DataQueryResponse> | undefined {
+    request: DataQueryRequest<ExampleQuery>,
+    options?: SupplementaryQueryOptions
+  ): DataQueryRequest<ExampleQuery> | undefined {
     if (!this.getSupportedSupplementaryQueryTypes().includes(type)) {
       return undefined;
     }
 
     switch (type) {
       case SupplementaryQueryType.LogsVolume:
-        return this.getLogsVolumeDataProvider(request);
+        const logsVolumeOption: LogsVolumeOption =
+          options?.type === SupplementaryQueryType.LogsVolume ? options : { type };
+        return this.getLogsVolumeDataProvider(request, logsVolumeOption);
       default:
         return undefined;
     }
@@ -471,29 +473,19 @@ export class ExampleDatasource
 
   // Be sure to adjust this example based your data source logic.
   private getLogsVolumeDataProvider(
-    request: DataQueryRequest<ExampleQuery>
-  ): Observable<DataQueryResponse> | undefined {
+    request: DataQueryRequest<ExampleQuery>,
+    options: LogsVolumeOption
+  ): DataQueryRequest<ExampleQuery> | undefined {
     const logsVolumeRequest = cloneDeep(request);
     const targets = logsVolumeRequest.targets
-      .map((query) => this.getSupplementaryQuery({ type: SupplementaryQueryType.LogsVolume }, query))
+      .map((query) => this.getSupplementaryQuery(options, query))
       .filter((query): query is ExampleQuery => !!query);
 
     if (!targets.length) {
       return undefined;
     }
 
-    // Use imported queryLogsVolume.
-    return queryLogsVolume(
-      this,
-      { ...logsVolumeRequest, targets },
-      {
-        // Implement extract level to produce color-coded graph.
-        extractLevel: (dataFrame: DataFrame) => LogLevel.unknown,
-        range: request.range,
-        targets: request.targets,
-      }
-    );
-  }
+    return { ...logsVolumeRequest, targets };
 }
 ```
 
@@ -501,7 +493,7 @@ export class ExampleDatasource
 
 :::note
 
-This feature is currently not supported for external plugins outside of the Grafana repo. Implement this API in a data source by implementing the `DataSourceWithXXXSupport` interface.
+Implement this API in a data source by implementing the `DataSourceWithXXXSupport` interface.
 
 :::
 
@@ -510,7 +502,6 @@ The [logs sample](https://grafana.com/docs/grafana/latest/explore/logs-integrati
 To implement the logs sample support in your data source plugin, you can use the `DataSourceWithSupplementaryQueriesSupport` API.
 
 ```ts
-import { queryLogsSample } from '../features/logs/logsModel'; // This is currently not possible to use outside of Grafana repo
 import {
   DataSourceWithSupplementaryQueriesSupport,
   SupplementaryQueryOptions,
@@ -542,37 +533,40 @@ export class ExampleDatasource
     }
   }
 
-  // Returns an observable that will be used to fetch supplementary data based on the provided supplementary query type and original request.
-  getDataProvider(
+  // It generates a DataQueryRequest for a specific supplementary query type.
+  // @returns A DataQueryRequest for the supplementary queries or undefined if not supported.
+  getSupplementaryRequest(
     type: SupplementaryQueryType,
-    request: DataQueryRequest<ExampleQuery>
-  ): Observable<DataQueryResponse> | undefined {
+    request: DataQueryRequest<ExampleQuery>,
+    options?: SupplementaryQueryOptions
+  ): DataQueryRequest<ExampleQuery> | undefined {
     if (!this.getSupportedSupplementaryQueryTypes().includes(type)) {
       return undefined;
     }
 
     switch (type) {
       case SupplementaryQueryType.LogsSample:
-        return this.getLogsSampleDataProvider(request);
+        const logsSampleOption: LogsSampleOptions =
+          options?.type === SupplementaryQueryType.LogsSample ? options : { type };
+        return this.getLogsSampleDataProvider(request, logsSampleOption);
       default:
         return undefined;
     }
   }
-
+  
   private getLogsSampleDataProvider(
-    request: DataQueryRequest<ExampleQuery>
-  ): Observable<DataQueryResponse> | undefined {
+    request: DataQueryRequest<ExampleQuery>,
+    options?: LogsSampleOptions
+  ): DataQueryRequest<ExampleQuery> | undefined {
     const logsSampleRequest = cloneDeep(request);
-    const targets = logsVolumeRequest.targets
-      .map((query) => this.getSupplementaryQuery({ type: SupplementaryQueryType.LogsVolume }, query))
+    const targets = logsSampleRequest.targets
+      .map((query) => this.getSupplementaryQuery({ type: SupplementaryQueryType.LogsSample, limit: 100 }, query))
       .filter((query): query is ExampleQuery => !!query);
 
     if (!targets.length) {
       return undefined;
     }
-
-    // Use imported queryLogsSample
-    return queryLogsSample(this, { ...logsVolumeRequest, targets });
+    return { ...logsSampleRequest, targets };
   }
 }
 ```


### PR DESCRIPTION
We've made updates to DataSourceWithSupplementaryQueriesSupport, allowing support for data sources outside the Grafana core repo. Updating developer docs accordingly.