### PR TITLE
Docs: Add info about dependencies for local development

### DIFF
--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -442,7 +442,7 @@ Update the `scripts` in the `package.json` to use the extended Webpack configura
 ```
 ## Add a dependency for local development
 
-Grafana’s plugin development environment is designed to simplify the process of creating and testing plugins. Here’s how it operates:
+Grafana’s plugin development environment is designed to allow for plugins to be dependent upon other plugins if necessary. Here’s how it operates:
 
 Plugin distribution path:
 
@@ -452,7 +452,7 @@ Plugin initialization:
 
 When the Grafana server starts, its plugin loader runs a [Load](https://github.com/grafana/grafana/blob/b53f14ca83eeec6b0f624c2dbbaa417d08bbadbf/pkg/plugins/manager/loader/loader.go#L55-L56) function. This scans the `/var/lib/grafana/` plugins directory for plugins, validates `plugin.json` files, checks signatures and manifests, and initializes valid plugins.
 
-Dependency management:
+Plugin dependency management:
 
 Although some validations occur on the server side, the plugin path itself doesn't include dependency validation. Developers are responsible for ensuring dependencies are correctly managed.
 

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -468,8 +468,6 @@ For example:
 
 tells Grafana to install that the clock panel plugin.
 
-Note that this approach is commonly used during development but requires manual tracking and updates for dependencies.
-
 ### Build and install the plugin via the Grafana CLI
 
 * Use `GF_INSTALL_PLUGINS=your-plugin-zip-via-url` for installation.

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -454,7 +454,7 @@ When the Grafana server starts, its plugin loader runs a [Load](https://github.c
 
 Plugin dependency management:
 
-Although some validations occur on the server side, the plugin path itself doesn't include dependency validation. Developers are responsible for ensuring dependencies are correctly managed.
+Although some validations occur on the server side, the plugin path itself doesn't include validation of other plugins your plugin may be dependent upon. You are responsible for ensuring that your plugin's dependencies are correctly managed.
 
 To manage dependencies during local plugin development, you can use one of the following methods:
 

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -450,7 +450,7 @@ Refer to [Grafana documentation](https://grafana.com/docs/grafana/latest/setup-g
 
 Plugin initialization:
 
-When the Grafana server starts, its plugin loader runs a [Load](https://github.com/grafana/grafana/blob/b53f14ca83eeec6b0f624c2dbbaa417d08bbadbf/pkg/plugins/manager/loader/loader.go#L55-L56) function. This scans the `/var/lib/grafana/` plugins directory for plugins, validates `plugin.json` files, checks signatures and manifests, and initializes valid plugins.
+When the Grafana server starts, its plugin loader runs a [Load](https://github.com/grafana/grafana/blob/b53f14ca83eeec6b0f624c2dbbaa417d08bbadbf/pkg/plugins/manager/loader/loader.go#L55-L56) function. This scans the defined [plugins directory](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#plugins) for plugins, validates `plugin.json` files, checks signatures and manifests, and initializes valid plugins.
 
 Plugin dependency management:
 

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -462,6 +462,12 @@ To manage dependencies during local plugin development, you can use one of the f
 
 * Add dependencies explicitly to your Grafana instance with `GF_INSTALL_PLUGINS=dependency`.
 
+For example:
+
+`GF_INSTALL_PLUGINS=grafana-clock-panel`
+
+tells Grafana to install that the clock panel plugin.
+
 Note that this approach is commonly used during development but requires manual tracking and updates for dependencies.
 
 ### Build and install the plugin via the Grafana CLI

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -12,6 +12,7 @@ description: Set up your development environment with Docker for Grafana plugin 
   - continuous integration
   - automation
   - configuration
+  - dependency
 sidebar_position: 20
 ---
 
@@ -439,3 +440,32 @@ Update the `scripts` in the `package.json` to use the extended Webpack configura
 -"dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
 +"dev": "webpack -w -c ./webpack.config.ts --env development",
 ```
+## Add a dependency for local development
+
+Grafana’s plugin development environment is designed to simplify the process of creating and testing plugins. Here’s how it operates:
+
+Plugin distribution path:
+
+The plugin’s dist folder (built plugin) is linked to `/var/lib/grafana/plugins/{{pluginId}}` in the Grafana server environment.
+
+Plugin initialization:
+
+When the Grafana server starts, its plugin loader runs a [Load](https://github.com/grafana/grafana/blob/b53f14ca83eeec6b0f624c2dbbaa417d08bbadbf/pkg/plugins/manager/loader/loader.go#L55-L56) function. This scans the `/var/lib/grafana/` plugins directory for plugins, validates `plugin.json` files, checks signatures and manifests, and initializes valid plugins.
+
+Dependency management:
+
+Although some validations occur on the server side, the plugin path itself doesn't include dependency validation. Developers are responsible for ensuring dependencies are correctly managed.
+
+To manage dependencies during local plugin development, you can use one of the following methods:
+
+### Use the `GF_INSTALL_PLUGINS` environment variable
+
+* Add dependencies explicitly to your Grafana instance with `GF_INSTALL_PLUGINS=dependency`.
+
+Note that this approach is commonly used during development but requires manual tracking and updates for dependencies.
+
+### Build and install the plugin via the Grafana CLI
+
+* Use `GF_INSTALL_PLUGINS=your-plugin-zip-via-url` for installation.
+
+While effective, this approach can be cumbersome during rapid plugin development.

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -446,7 +446,7 @@ Grafana’s plugin development environment is designed to allow for plugins to b
 
 Plugin distribution path:
 
-The plugin’s dist folder (built plugin) is linked to `/var/lib/grafana/plugins/{{pluginId}}` in the Grafana server environment.
+Refer to [Grafana documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#plugins) for the plugin's location, which can vary depending on your system and development environment.
 
 Plugin initialization:
 

--- a/docusaurus/docs/get-started/set-up-development-environment.mdx
+++ b/docusaurus/docs/get-started/set-up-development-environment.mdx
@@ -468,7 +468,7 @@ For example:
 
 tells Grafana to install that the clock panel plugin.
 
-### Build and install the plugin via the Grafana CLI
+### Build and install the plugin
 
 * Use `GF_INSTALL_PLUGINS=your-plugin-zip-via-url` for installation.
 


### PR DESCRIPTION
Add info about working with dependencies for local development

Note: I'm aware that there are some ambiguities in the text that need to be resolved. 
- First, where are the environment variables added? 
- Second, for GF_INSTALL_PLUGINS=dependency and GF_INSTALL_PLUGINS=your-plugin-zip-via-url can we provide an example? Or use placeholder syntax for placeholders?

Fixes # https://github.com/grafana/plugin-tools/issues/952
