### PR TITLE
Create Plugin: Use `module.tsx` in is-compatible workflow for apps

### DIFF
--- a/packages/create-plugin/templates/github/workflows/is-compatible.yml
+++ b/packages/create-plugin/templates/github/workflows/is-compatible.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Build plugin
         run: {{ packageManagerName }} run build
       - name: Compatibility check
-        run: npx --yes @grafana/levitate@latest is-compatible --path src/module.{{#if isAppType}}tsx{{else}}ts{{/if}} --target @grafana/data,@grafana/ui,@grafana/runtime
+        run: npx --yes @grafana/levitate@latest is-compatible --path $(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \)) --target @grafana/data,@grafana/ui,@grafana/runtime

--- a/packages/create-plugin/templates/github/workflows/is-compatible.yml
+++ b/packages/create-plugin/templates/github/workflows/is-compatible.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Build plugin
         run: {{ packageManagerName }} run build
       - name: Compatibility check
-        run: npx --yes @grafana/levitate@latest is-compatible --path src/module.ts --target @grafana/data,@grafana/ui,@grafana/runtime
+        run: npx --yes @grafana/levitate@latest is-compatible --path src/module.{{#if isAppType}}tsx{{else}}ts{{/if}} --target @grafana/data,@grafana/ui,@grafana/runtime


### PR DESCRIPTION
### What changed?
The is-compatible workflow template always used the `.ts` extension for `module.ts`, although app plugins are now scaffolded with `module.tsx`, which causing issues in new app plugin scaffolds ([for example in the cmab-app](https://github.com/grafana/cmab-app/actions/runs/12177001679/job/33963896415)) This PR updates the is-compatible workflow template to use `module.tsx` in case we are scaffolding an app plugin.

Thanks @gubjanos for flagging this 🙏  
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@3.5.2-canary.1384.e2b8c3c.0
  npm install @grafana/create-plugin@5.12.4-canary.1384.e2b8c3c.0
  npm install @grafana/plugin-e2e@1.14.2-canary.1384.e2b8c3c.0
  npm install @grafana/plugin-meta-extractor@0.0.10-canary.1384.e2b8c3c.0
  npm install @grafana/plugin-types-bundler@0.2.1-canary.1384.e2b8c3c.0
  npm install @grafana/sign-plugin@3.0.6-canary.1384.e2b8c3c.0
  # or 
  yarn add website@3.5.2-canary.1384.e2b8c3c.0
  yarn add @grafana/create-plugin@5.12.4-canary.1384.e2b8c3c.0
  yarn add @grafana/plugin-e2e@1.14.2-canary.1384.e2b8c3c.0
  yarn add @grafana/plugin-meta-extractor@0.0.10-canary.1384.e2b8c3c.0
  yarn add @grafana/plugin-types-bundler@0.2.1-canary.1384.e2b8c3c.0
  yarn add @grafana/sign-plugin@3.0.6-canary.1384.e2b8c3c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
