### PR TITLE
Docs: Add note about paid plugins to homepage

### DIFF
--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -1,7 +1,7 @@
 ---
 id: get-started
 title: Get started
-description: Get started with Grafana plugin developing with the create-plugin tool.
+description: Get started with Grafana plugin development with the create-plugin tool.
 keywords:
   - grafana
   - plugins
@@ -32,7 +32,7 @@ Welcome to the world of Grafana plugin creation, where you can enhance Grafana's
 
 **Watch our introductory video** to see a step-by-step guide on getting started with your first Grafana plugin. This visual tutorial complements the detailed instructions below and provides practical insights to help you along the way.
 
-## Quick Start
+## Quick start
 
 Scaffold a new plugin with a single command! Run the following and answer the prompts:
 
@@ -51,14 +51,14 @@ Scaffold a new plugin with a single command! Run the following and answer the pr
 Grafana plugin development allows you to create many different types of user experiences. For example, you can make:
 
 - **Panel plugins** - new ways of visualizing data
-- **Data-source plugins** - connections to a new database or other source of data
+- **Data source plugins** - connections to a new database or other source of data
 - **App plugins** - integrated out-of-the-box experiences
 
-:::tip
+## Classifications of Grafana plugins
 
-If this is your first time creating a plugin, we recommend that you familiarize yourself with the fundamentals of plugin types, backend plugins, data frames, and other essentials. We commend that you familiarize yourself with the [key concepts of Grafana plugin development](/key-concepts/).
+If this is your first time creating a plugin, we recommend that you familiarize yourself with the fundamentals of plugin types, backend plugins, data frames, and other essentials. Learn more about the [key concepts of Grafana plugin development](/key-concepts/).
 
-:::
+Additionally, we recommend that you familiarize yourself with the signature classifications of Grafana plugins, such as private and public plugins. Note that if you are a commercial entity wanting to publish to the official Grafana catalog, a paid subscription is required. Learn more about [our plugins policy](https://grafana.com/legal/plugins/).
 
 ## Use plugin tools to develop your plugins faster
 

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -54,11 +54,15 @@ Grafana plugin development allows you to create many different types of user exp
 - **Data source plugins** - connections to a new database or other source of data
 - **App plugins** - integrated out-of-the-box experiences
 
-## Classifications of Grafana plugins
+:::tip
 
 If this is your first time creating a plugin, we recommend that you familiarize yourself with the fundamentals of plugin types, backend plugins, data frames, and other essentials. Learn more about the [key concepts of Grafana plugin development](/key-concepts/).
 
-Additionally, we recommend that you familiarize yourself with the signature classifications of Grafana plugins, such as private and public plugins. Note that if you are a commercial entity wanting to publish to the official Grafana catalog, a paid subscription is required. Learn more about [our plugins policy](https://grafana.com/legal/plugins/).
+:::
+
+## Classifications of Grafana plugins
+
+We recommend that you familiarize yourself with the signature classifications of Grafana plugins, such as the distinction between private and public plugins. Note that if you are a commercial entity wanting to publish to the official Grafana catalog, a paid subscription is typically required. Learn more about [our plugins policy](https://grafana.com/legal/plugins/).
 
 ## Use plugin tools to develop your plugins faster
 

--- a/docusaurus/docs/get-started/get-started.mdx
+++ b/docusaurus/docs/get-started/get-started.mdx
@@ -62,7 +62,7 @@ If this is your first time creating a plugin, we recommend that you familiarize 
 
 ## Classifications of Grafana plugins
 
-We recommend that you familiarize yourself with the signature classifications of Grafana plugins, such as the distinction between private and public plugins. Note that if you are a commercial entity wanting to publish to the official Grafana catalog, a paid subscription is typically required. Learn more about [our plugins policy](https://grafana.com/legal/plugins/).
+We recommend that you familiarize yourself with the signature classifications of Grafana plugins, such as the distinction between private and public plugins. Note that if you want to publish a plugin which is associated with a commercial offering to the official Grafana catalog, a paid subscription is typically required. Learn more about [our plugins policy](https://grafana.com/legal/plugins/).
 
 ## Use plugin tools to develop your plugins faster
 


### PR DESCRIPTION
Add prominent note to advise developers that if they want to publish their plugin in the catalog as a commercial entity, then they will have to pay a fee. 

Fixes https://github.com/grafana/plugin-tools/issues/1225


