### PR TITLE
Docs: Update references to Grafana 11

### DIFF
--- a/docusaurus/docs/e2e-test-a-plugin/migrate-from-grafana-e2e.md
+++ b/docusaurus/docs/e2e-test-a-plugin/migrate-from-grafana-e2e.md
@@ -20,7 +20,7 @@ import ScaffoldPluginE2EInstallPNPM from '@snippets/plugin-e2e-install.pnpm.md';
 import ScaffoldPluginE2EInstallYarn from '@snippets/plugin-e2e-install.yarn.md';
 
 :::danger
-When Grafana 11.0.0 is released the [`@grafana/e2e`](https://www.npmjs.com/package/@grafana/e2e) will be deprecated and support will be dropped. We recommend all plugin authors to migrate their end-to-end tests to use Playwright and `@grafana/plugin-e2e` instead of Cypress and `@grafana/e2e`.
+With the release of Grafana 11.0.0 the [`@grafana/e2e`](https://www.npmjs.com/package/@grafana/e2e) package has been deprecated and support has been dropped. We recommend all plugin authors to migrate their end-to-end tests to use Playwright and `@grafana/plugin-e2e` instead of Cypress and `@grafana/e2e`.
 :::
 
 In this guide you'll learn:

--- a/docusaurus/docs/key-concepts/data-frames.md
+++ b/docusaurus/docs/key-concepts/data-frames.md
@@ -47,7 +47,7 @@ export interface Field<T = any, V = Vector<T>> {
   /**
    * The raw field values
    * In Grafana 10, this accepts both simple arrays and the Vector interface
-   * In Grafana 11, the Vector interface will be removed
+   * In Grafana 11, the Vector interface has been removed
    */
   values: V | T[];
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
I noticed whilst testing dependency updates to docusaurus there's some references to Grafana 11 that use the future tense. This PR updates them as G11 was released a while back.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
