### PR TITLE
Docs: Fix warnings about nested link tags in build logs

### DIFF
--- a/docusaurus/docs/shared/create-plugin-backend.md
+++ b/docusaurus/docs/shared/create-plugin-backend.md
@@ -1,42 +1,42 @@
 The Grafana [create-plugin tool](https://www.npmjs.com/package/@grafana/create-plugin) is a CLI application that simplifies Grafana plugin development, so that you can focus on code. The tool scaffolds a starter plugin, all the required configuration, and a development environment using [Docker Compose](https://docs.docker.com/compose/) for you.
 
-1. <span>In a new directory, create a plugin from a template using the create-plugin tool. When prompted for the kind of plugin, select {props.pluginType}</span> and answer yes to "Do you want a backend part of your plugin?":
+1. In a new directory, create a plugin from a template using the create-plugin tool. When prompted for the kind of plugin, select {props.pluginType} and answer yes to "Do you want a backend part of your plugin?":
 
    ```shell
    npx @grafana/create-plugin@latest
    ```
 
-1. Go to the directory of your newly created plugin:
+2. Go to the directory of your newly created plugin:
 
    ```shell
    cd <your-plugin>
    ```
 
-1. Install the dependencies:
+3. Install the dependencies:
 
    ```shell
    npm install
    ```
 
-1. Build the plugin frontend:
+4. Build the plugin frontend:
 
    ```shell
    npm run dev
    ```
 
-1. In a new terminal window, build the plugin backend:
+5. In a new terminal window, build the plugin backend:
 
    ```shell
    mage -v build:linux
    ```
 
-1. Start Grafana:
+6. Start Grafana:
 
    ```shell
    docker compose up
    ```
 
-1. <span>Open Grafana, by default <a href="http://localhost:3000/">http://localhost:3000/</a>, and then go to <b>Administration</b> > <b>Plugins</b>. Make sure that your {props.pluginType} plugin is there.</span>
+7. Open Grafana, by default [http://localhost:3000](http://localhost:3000), and then go to **Administration** > **Plugins**. Make sure that your {props.pluginType} plugin is there.
 
 You can also verify that Grafana has discovered the plugin by checking the logs:
 

--- a/docusaurus/docs/shared/create-plugin-frontend.md
+++ b/docusaurus/docs/shared/create-plugin-frontend.md
@@ -1,36 +1,36 @@
 The Grafana [create-plugin tool](https://www.npmjs.com/package/@grafana/create-plugin) is a CLI application that simplifies Grafana plugin development, so that you can focus on code. The tool scaffolds a starter plugin, all the required configuration, and a development environment using [Docker Compose](https://docs.docker.com/compose/) for you.
 
-1. <span>In a new directory, create a plugin from a template using the create-plugin tool. When prompted for the kind of plugin, select {props.pluginType}</span>:
+1. In a new directory, create a plugin from a template using the create-plugin tool. When prompted for the kind of plugin, select {props.pluginType}:
 
    ```shell
    npx @grafana/create-plugin@latest
    ```
 
-1. Go to the directory of your newly created plugin:
+2. Go to the directory of your newly created plugin:
 
    ```shell
    cd <your-plugin>
    ```
 
-1. Install the dependencies:
+3. Install the dependencies:
 
    ```shell
    npm install
    ```
 
-1. Build the plugin:
+4. Build the plugin:
 
    ```shell
    npm run dev
    ```
 
-1. Start Grafana:
+5. Start Grafana:
 
    ```shell
    docker compose up
    ```
 
-1. <span>Open Grafana, by default <a href="http://localhost:3000/">http://localhost:3000/</a>, and then go to <b>Administration</b> > <b>Plugins</b>. Make sure that your {props.pluginType} plugin is there.</span>
+6. Open Grafana, by default [http://localhost:3000](http://localhost:3000), and then go to **Administration** > **Plugins**. Make sure that your {props.pluginType} plugin is there.
 
 You can also verify that Grafana has discovered your plugin by checking the logs:
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR fixes the current docs prod build warnings:

```
- "/developers/plugin-tools/how-to-guides/app-plugins/add-backend-component":
  - [HTML minifier diagnostic - error] Start tag "a" seen but an element of the same type was already open - {"primary_spans":[{"end":28545,"start":28470}],"span_labels":[]}
  - [HTML minifier diagnostic - error] Stray end tag "a" - {"primary_spans":[{"end":28575,"start":28571}],"span_labels":[]}

- "/developers/plugin-tools/tutorials/build-a-data-source-backend-plugin":
  - [HTML minifier diagnostic - error] Start tag "a" seen but an element of the same type was already open - {"primary_spans":[{"end":25796,"start":257[21](https://github.com/grafana/plugin-tools/actions/runs/12651392479/job/35251903872?pr=1435#step:5:22)}],"span_labels":[]}
  - [HTML minifier diagnostic - error] Stray end tag "a" - {"primary_spans":[{"end":25826,"start":258[22](https://github.com/grafana/plugin-tools/actions/runs/12651392479/job/35251903872?pr=1435#step:5:23)}],"span_labels":[]}

- "/developers/plugin-tools/tutorials/build-a-data-source-plugin":
  - [HTML minifier diagnostic - error] Start tag "a" seen but an element of the same type was already open - {"primary_spans":[{"end":[23](https://github.com/grafana/plugin-tools/actions/runs/12651392479/job/35251903872?pr=1435#step:5:24)610,"start":23535}],"span_labels":[]}
  - [HTML minifier diagnostic - error] Stray end tag "a" - {"primary_spans":[{"end":23640,"start":23636}],"span_labels":[]}

- "/developers/plugin-tools/tutorials/build-a-panel-plugin":
  - [HTML minifier diagnostic - error] Start tag "a" seen but an element of the same type was already open - {"primary_spans":[{"end":23747,"start":23672}],"span_labels":[]}
  - [HTML minifier diagnostic - error] Stray end tag "a" - {"primary_spans":[{"end":23777,"start":23773}],"span_labels":[]}

- "/developers/plugin-tools/tutorials/build-an-app-plugin":
  - [HTML minifier diagnostic - error] Start tag "a" seen but an element of the same type was already open - {"primary_spans":[{"end":23576,"start":23501}],"span_labels":[]}
  - [HTML minifier diagnostic - error] Stray end tag "a" - {"primary_spans":[{"end":23606,"start":23602}],"span_labels":[]}
```

They appear to come from the HTML inside the shared create-plugin backend and frontend files. This PR converts it to markdown to fix the Docusaurus warnings.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
