### PR TITLE
E2E: Added missing APIs while writing tests for panel editor

### DIFF
--- a/packages/plugin-e2e/docker-compose.yaml
+++ b/packages/plugin-e2e/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   grafana:
-    image: grafana/${GRAFANA_IMAGE:-grafana-enterprise}:${GRAFANA_VERSION:-11.4.0}
+    image: grafana/${GRAFANA_IMAGE:-grafana-enterprise}:${GRAFANA_VERSION:-9.2.20}
     environment:
       - GF_INSTALL_PLUGINS=grafana-clock-panel 2.1.3,grafana-googlesheets-datasource 1.2.4,grafana-redshift-datasource 1.13.0,marcusolsson-json-datasource 1.3.12,redis-app 2.2.1
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/packages/plugin-e2e/docker-compose.yaml
+++ b/packages/plugin-e2e/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   grafana:
-    image: grafana/${GRAFANA_IMAGE:-grafana-enterprise}:${GRAFANA_VERSION:-9.2.20}
+    image: grafana/${GRAFANA_IMAGE:-grafana-enterprise}:${GRAFANA_VERSION:-11.4.0}
     environment:
       - GF_INSTALL_PLUGINS=grafana-clock-panel 2.1.3,grafana-googlesheets-datasource 1.2.4,grafana-redshift-datasource 1.13.0,marcusolsson-json-datasource 1.3.12,redis-app 2.2.1
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/packages/plugin-e2e/src/models/components/PanelEditOptionsGroup.ts
+++ b/packages/plugin-e2e/src/models/components/PanelEditOptionsGroup.ts
@@ -9,7 +9,32 @@ import { gte } from 'semver';
 import { RadioGroup } from './RadioGroup';
 
 export class PanelEditOptionsGroup {
-  constructor(private ctx: PluginTestCtx, public readonly element: Locator, private groupLabel: string) {}
+  constructor(
+    private ctx: PluginTestCtx,
+    public readonly element: Locator,
+    private groupLabel: string
+  ) {}
+
+  async collapse(): Promise<void> {
+    const expanded = await this.isExpanded();
+    if (!expanded) {
+      return;
+    }
+    await this.element.click();
+  }
+
+  async expand(): Promise<void> {
+    const expanded = await this.isExpanded();
+    if (expanded) {
+      return;
+    }
+    await this.element.click();
+  }
+
+  private async isExpanded(): Promise<boolean> {
+    const expanded = await this.element.getAttribute('aria-expanded');
+    return expanded === 'true';
+  }
 
   getRadioGroup(label: string): RadioGroup {
     if (gte(this.ctx.grafanaVersion, '10.2.0')) {

--- a/packages/plugin-e2e/src/models/components/PanelEditOptionsGroup.ts
+++ b/packages/plugin-e2e/src/models/components/PanelEditOptionsGroup.ts
@@ -7,6 +7,7 @@ import { MultiSelect } from './MultiSelect';
 import { Switch } from './Switch';
 import { gte } from 'semver';
 import { RadioGroup } from './RadioGroup';
+import { resolveGrafanaSelector } from '../utils';
 
 export class PanelEditOptionsGroup {
   constructor(
@@ -20,7 +21,7 @@ export class PanelEditOptionsGroup {
     if (!expanded) {
       return;
     }
-    await this.element.click();
+    await this.getOptionsGroupToggle().click();
   }
 
   async expand(): Promise<void> {
@@ -28,7 +29,7 @@ export class PanelEditOptionsGroup {
     if (expanded) {
       return;
     }
-    await this.element.click();
+    await this.getOptionsGroupToggle().click();
   }
 
   getRadioGroup(label: string): RadioGroup {
@@ -78,7 +79,12 @@ export class PanelEditOptionsGroup {
   }
 
   private async isExpanded(): Promise<boolean> {
-    const expanded = await this.element.getAttribute('aria-expanded');
+    const expanded = await this.getOptionsGroupToggle().getAttribute('aria-expanded');
     return expanded === 'true';
+  }
+
+  private getOptionsGroupToggle(): Locator {
+    const selector = resolveGrafanaSelector(this.ctx.selectors.components.OptionsGroup.toggle(this.groupLabel));
+    return this.element.locator(selector);
   }
 }

--- a/packages/plugin-e2e/src/models/components/PanelEditOptionsGroup.ts
+++ b/packages/plugin-e2e/src/models/components/PanelEditOptionsGroup.ts
@@ -16,6 +16,11 @@ export class PanelEditOptionsGroup {
     private groupLabel: string
   ) {}
 
+  async isExpanded(): Promise<boolean> {
+    const expanded = await this.getOptionsGroupToggle().getAttribute('aria-expanded');
+    return expanded === 'true';
+  }
+
   async collapse(): Promise<void> {
     const expanded = await this.isExpanded();
     if (!expanded) {
@@ -78,13 +83,13 @@ export class PanelEditOptionsGroup {
     return this.element.getByLabel(`${this.groupLabel} ${optionLabel} field property editor`);
   }
 
-  private async isExpanded(): Promise<boolean> {
-    const expanded = await this.getOptionsGroupToggle().getAttribute('aria-expanded');
-    return expanded === 'true';
-  }
-
   private getOptionsGroupToggle(): Locator {
     const selector = resolveGrafanaSelector(this.ctx.selectors.components.OptionsGroup.toggle(this.groupLabel));
-    return this.element.locator(selector);
+
+    if (gte(this.ctx.grafanaVersion, '10.0.0')) {
+      return this.element.locator(selector);
+    }
+
+    return this.element.locator(selector).getByRole('button');
   }
 }

--- a/packages/plugin-e2e/src/models/components/PanelEditOptionsGroup.ts
+++ b/packages/plugin-e2e/src/models/components/PanelEditOptionsGroup.ts
@@ -31,11 +31,6 @@ export class PanelEditOptionsGroup {
     await this.element.click();
   }
 
-  private async isExpanded(): Promise<boolean> {
-    const expanded = await this.element.getAttribute('aria-expanded');
-    return expanded === 'true';
-  }
-
   getRadioGroup(label: string): RadioGroup {
     if (gte(this.ctx.grafanaVersion, '10.2.0')) {
       return new RadioGroup(this.ctx, this.getByLabel(label).getByRole('radiogroup'));
@@ -80,5 +75,10 @@ export class PanelEditOptionsGroup {
 
   private getByLabel(optionLabel: string): Locator {
     return this.element.getByLabel(`${this.groupLabel} ${optionLabel} field property editor`);
+  }
+
+  private async isExpanded(): Promise<boolean> {
+    const expanded = await this.element.getAttribute('aria-expanded');
+    return expanded === 'true';
   }
 }

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -14,7 +14,10 @@ export class PanelEditPage extends GrafanaPage {
   timeRange: TimeRange;
   panel: Panel;
 
-  constructor(readonly ctx: PluginTestCtx, readonly args: DashboardEditViewArgs<string>) {
+  constructor(
+    readonly ctx: PluginTestCtx,
+    readonly args: DashboardEditViewArgs<string>
+  ) {
     super(ctx, args);
     this.datasource = new DataSourcePicker(ctx);
     this.timeRange = new TimeRange(ctx);
@@ -185,6 +188,10 @@ export class PanelEditPage extends GrafanaPage {
   getCustomOptions(label: string): PanelEditOptionsGroup {
     const locator = this.getOptionsGroupLocator(label);
     return new PanelEditOptionsGroup(this.ctx, locator, label);
+  }
+
+  getPanelOptions(): PanelEditOptionsGroup {
+    return this.getCustomOptions('Panel options');
   }
 
   getStandardOptions(): PanelEditOptionsGroup {

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -103,6 +103,7 @@ export class PanelEditPage extends GrafanaPage {
 
   /**
    * Expands the section for the given category name. If the section is already expanded, this method does nothing.
+   * @deprecated use {@link PanelEditOptionsGroup.expand} method instead.
    */
   async collapseSection(categoryName: string) {
     const section = this.getByGrafanaSelector(this.ctx.selectors.components.OptionsGroup.group(categoryName));

--- a/packages/plugin-e2e/tests/as-admin-user/panel/panelEdit.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/panel/panelEdit.spec.ts
@@ -1,7 +1,5 @@
-import { Locator, Page } from '@playwright/test';
-import { test, expect, PanelEditPage } from '../../../src';
-import { gte, lte } from 'semver';
-import { selectors as E2ESelectors } from '@grafana/e2e-selectors';
+import { test, expect } from '../../../src';
+import { lte } from 'semver';
 
 test('selecting value in radio button group', async ({ gotoPanelEditPage }) => {
   const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'mxb-Jv4Vk' }, id: '5' });
@@ -139,4 +137,30 @@ test('select timezone in timezone picker', async ({ gotoPanelEditPage, grafanaVe
 
   await timeZonePicker.selectOption('Europe/Stockholm');
   await expect(timeZonePicker).toHaveSelected('Europe/Stockholm');
+});
+
+test('collapse expanded options group', async ({ gotoPanelEditPage, selectors }) => {
+  const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'eda84f4d-0b3c-4e4d-815d-7fcb9aa702c2' }, id: '1' });
+  const dataLinksOptions = panelEdit.getCustomOptions('Data links');
+  const optionsGroupButton = panelEdit.getByGrafanaSelector(selectors.components.OptionsGroup.toggle('Data links'), {
+    startsWith: true,
+  });
+
+  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'true');
+  await dataLinksOptions.collapse();
+  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'false');
+});
+
+test('expand collapsed options group', async ({ gotoPanelEditPage, selectors }) => {
+  const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'eda84f4d-0b3c-4e4d-815d-7fcb9aa702c2' }, id: '1' });
+  const dataLinksOptions = panelEdit.getCustomOptions('Data links');
+  const optionsGroupButton = panelEdit.getByGrafanaSelector(selectors.components.OptionsGroup.toggle('Data links'), {
+    startsWith: true,
+  });
+
+  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'true');
+  await dataLinksOptions.collapse();
+  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'false');
+  await dataLinksOptions.expand();
+  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'true');
 });

--- a/packages/plugin-e2e/tests/as-admin-user/panel/panelEdit.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/panel/panelEdit.spec.ts
@@ -1,5 +1,6 @@
-import { test, expect } from '../../../src';
-import { lte } from 'semver';
+import { Locator } from '@playwright/test';
+import { test, expect, PanelEditPage, E2ESelectorGroups } from '../../../src';
+import { gte, lte } from 'semver';
 
 test('selecting value in radio button group', async ({ gotoPanelEditPage }) => {
   const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'mxb-Jv4Vk' }, id: '5' });
@@ -139,28 +140,22 @@ test('select timezone in timezone picker', async ({ gotoPanelEditPage, grafanaVe
   await expect(timeZonePicker).toHaveSelected('Europe/Stockholm');
 });
 
-test('collapse expanded options group', async ({ gotoPanelEditPage, selectors }) => {
+test('collapse expanded options group', async ({ gotoPanelEditPage }) => {
   const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'eda84f4d-0b3c-4e4d-815d-7fcb9aa702c2' }, id: '1' });
   const dataLinksOptions = panelEdit.getCustomOptions('Data links');
-  const optionsGroupButton = panelEdit.getByGrafanaSelector(selectors.components.OptionsGroup.toggle('Data links'), {
-    startsWith: true,
-  });
 
-  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'true');
+  expect(await dataLinksOptions.isExpanded()).toBeTruthy();
   await dataLinksOptions.collapse();
-  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'false');
+  expect(await dataLinksOptions.isExpanded()).toBeFalsy();
 });
 
-test('expand collapsed options group', async ({ gotoPanelEditPage, selectors }) => {
+test('expand collapsed options group', async ({ gotoPanelEditPage }) => {
   const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'eda84f4d-0b3c-4e4d-815d-7fcb9aa702c2' }, id: '1' });
   const dataLinksOptions = panelEdit.getCustomOptions('Data links');
-  const optionsGroupButton = panelEdit.getByGrafanaSelector(selectors.components.OptionsGroup.toggle('Data links'), {
-    startsWith: true,
-  });
 
-  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'true');
+  expect(await dataLinksOptions.isExpanded()).toBeTruthy();
   await dataLinksOptions.collapse();
-  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'false');
+  expect(await dataLinksOptions.isExpanded()).toBeFalsy();
   await dataLinksOptions.expand();
-  await expect(optionsGroupButton).toHaveAttribute('aria-expanded', 'true');
+  expect(await dataLinksOptions.isExpanded()).toBeTruthy();
 });


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
While adding API test for the panel edit APIs I realised that I missed two important APIs. One to being able to toggle a section for a panel edit options group. And also a way to get the standard panel options group.

So they are added in this PR.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@1.16.0-canary.1462.03160e8.0
  npm install @grafana/plugin-meta-extractor@0.1.0-canary.1462.03160e8.0
  # or 
  yarn add @grafana/plugin-e2e@1.16.0-canary.1462.03160e8.0
  yarn add @grafana/plugin-meta-extractor@0.1.0-canary.1462.03160e8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
