### PR TITLE
Docs: Add section about provenance attestation for github pipelines

### DIFF
--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -88,7 +88,7 @@ The workflow will generate attestations automatically when building your plugin 
 
 If you encounter errors in the plugin validator or your plugin submission like these:
 
-- `No provenance attestation. This plugin was built without build verification`
+- "No provenance attestation. This plugin was built without build verification."
 - `Cannot verify plugin build`
 
 Follow the steps above to enable provenance attestation in your GitHub Actions workflow.

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -56,9 +56,9 @@ Access the final release zip file directly from the GitHub repository release pa
 
 ## Provenance attestation for plugin builds
 
-Provenance attestation, that is, _a feature that generating verifiable records of the build's origin and process_,  enhances the security of your plugin builds. This feature allows users to confirm that the plugin they are installing was created through your official build pipeline.
+Provenance attestation, that is, _a feature that generating verifiable records of the build's origin and process_, enhances the security of your plugin builds. This feature allows users to confirm that the plugin they are installing was created through your official build pipeline.
 
-Currently, this feature is available only with GitHub Actions. While we recommend using GitHub Actions with provenance attestation for improved security, you can still build and distribute plugins using other CI/CD platforms or manual methods.
+Currently, this feature is available only with GitHub Actions in public repositories. While we recommend using GitHub Actions with provenance attestation for improved security, you can still build and distribute plugins using other CI/CD platforms or manual methods.
 
 ### Enable provenance attestation
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -58,7 +58,7 @@ Access the final release zip file directly from the GitHub repository release pa
 
 Provenance attestation adds a layer of security to your plugin builds by creating verifiable records of where and how your plugin was built. This helps users validate that the plugin they're installing was built through your official build process.
 
-This feature is currently only available when using GitHub Actions. While using GitHub Actions with provenance attestation is recommended for enhanced security, you can still build and distribute plugins using other CI/CD platforms.
+This feature is currently only available when using GitHub Actions. While using GitHub Actions with provenance attestation is recommended for enhanced security, you can still build and distribute plugins using other CI/CD platforms or manual processes.
 
 ### Enable provenance attestation
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -58,7 +58,7 @@ Access the final release zip file directly from the GitHub repository release pa
 
 Provenance attestation, that is, _a feature that generating verifiable records of the build's origin and process_,  enhances the security of your plugin builds. This feature allows users to confirm that the plugin they are installing was created through your official build pipeline.
 
-This feature is currently only available when using GitHub Actions. While using GitHub Actions with provenance attestation is recommended for enhanced security, you can still build and distribute plugins using other CI/CD platforms or manual processes.
+Currently, this feature is available only with GitHub Actions. While we recommend using GitHub Actions with provenance attestation for improved security, you can still build and distribute plugins using other CI/CD platforms or manual methods.
 
 ### Enable provenance attestation
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -54,6 +54,45 @@ After you push the tag, you can create the same tag again.
 
 Access the final release zip file directly from the GitHub repository release path (e.g. https://github.com/org/plugin-id/releases).
 
+## Provenance attestation for plugin builds
+
+Provenance attestation adds a layer of security to your plugin builds by creating verifiable records of where and how your plugin was built. This helps users validate that the plugin they're installing was built through your official build process.
+
+This feature is currently only available when using GitHub Actions. While using GitHub Actions with provenance attestation is recommended for enhanced security, you can still build and distribute plugins using other CI/CD platforms.
+
+### Enable provenance attestation
+
+To enable provenance attestation in your existing GitHub Actions workflow:
+
+1. Add required permissions to your workflow job:
+
+```yaml
+permissions:
+  id-token: write
+  contents: write
+  attestations: write
+```
+
+2. Enable attestation in the build-plugin action:
+
+```yaml
+- uses: grafana/plugin-actions/build-plugin@main
+  with:
+    policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+    attestation: true
+```
+
+The workflow will generate attestations automatically when building your plugin zip file.
+
+### Troubleshooting provenance attestation
+
+If you encounter errors in the plugin validator or your plugin submission like these:
+
+- `No provenance attestation. This plugin was built without build verification`
+- `Cannot verify plugin build`
+
+Follow the steps above to enable provenance attestation in your GitHub Actions workflow.
+
 ## Next steps
 
 When you've packaged your plugin, proceed to [publishing a plugin](./publish-or-update-a-plugin.md) or [installing a packaged plugin](https://grafana.com/docs/grafana/latest/administration/plugin-management/#install-a-packaged-plugin).

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -84,7 +84,7 @@ permissions:
 
 The workflow will generate attestations automatically when building your plugin zip file.
 
-### Troubleshooting provenance attestation
+### Troubleshoot provenance attestation
 
 If you encounter errors in the plugin validator or your plugin submission like these:
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -73,7 +73,7 @@ permissions:
   attestations: write
 ```
 
-2. Enable attestation in the build-plugin action:
+2. Enable attestation in the `build-plugin` action:
 
 ```yaml
 - uses: grafana/plugin-actions/build-plugin@main

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -89,7 +89,7 @@ The workflow will generate attestations automatically when building your plugin 
 If you encounter errors in the plugin validator or your plugin submission like these:
 
 - "No provenance attestation. This plugin was built without build verification."
-- `Cannot verify plugin build`
+- "Cannot verify plugin build."
 
 Follow the steps above to enable provenance attestation in your GitHub Actions workflow.
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -56,7 +56,7 @@ Access the final release zip file directly from the GitHub repository release pa
 
 ## Provenance attestation for plugin builds
 
-Provenance attestation adds a layer of security to your plugin builds by creating verifiable records of where and how your plugin was built. This helps users validate that the plugin they're installing was built through your official build process.
+Provenance attestation, that is, _a feature that generating verifiable records of the build's origin and process_,  enhances the security of your plugin builds. This feature allows users to confirm that the plugin they are installing was created through your official build pipeline.
 
 This feature is currently only available when using GitHub Actions. While using GitHub Actions with provenance attestation is recommended for enhanced security, you can still build and distribute plugins using other CI/CD platforms or manual processes.
 

--- a/docusaurus/docs/publish-a-plugin/build-automation.md
+++ b/docusaurus/docs/publish-a-plugin/build-automation.md
@@ -52,7 +52,7 @@ After you push the tag, you can create the same tag again.
 
 ## Download the release zip file
 
-Access the final release zip file directly from the GitHub repository release path (e.g. https://github.com/org/plugin-id/releases).
+Access the final release zip file directly from the GitHub repository release path (for example, `https://github.com/org/plugin-id/releases`).
 
 ## Provenance attestation for plugin builds
 


### PR DESCRIPTION
Adds documentation about provenance attestation for builds with github actions
