### PR TITLE
Plugin E2E: Fix datasource picker root locator

### DIFF
--- a/packages/plugin-e2e/src/models/components/DataSourcePicker.ts
+++ b/packages/plugin-e2e/src/models/components/DataSourcePicker.ts
@@ -15,7 +15,9 @@ export class DataSourcePicker extends GrafanaPage {
    * Sets the data source picker to the provided name
    */
   async set(name: string) {
-    let datasourcePicker = this.ctx.page.getByTestId(this.ctx.selectors.components.DataSourcePicker.inputV2);
+    let datasourcePicker = (this.root || this.ctx.page).getByTestId(
+      this.ctx.selectors.components.DataSourcePicker.inputV2
+    );
 
     if (semver.lt(this.ctx.grafanaVersion, '10.1.0')) {
       datasourcePicker = this.getByGrafanaSelector(this.ctx.selectors.components.DataSourcePicker.container, {

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.spec.ts
@@ -48,7 +48,6 @@ test.describe('Test new alert rules', () => {
     const queryA = alertRuleEditPage.getAlertRuleQueryRow('A');
     await queryA.datasource.set(ds.name);
     const rowCount = await alertRuleEditPage.getByGrafanaSelector(rows).count();
-    semver.gte(grafanaVersion, '11.5.0') && (await page.getByLabel('Advanced options').nth(1).check());
     await alertRuleEditPage.clickAddQueryRow();
     await expect(alertRuleEditPage.getByGrafanaSelector(rows)).toHaveCount(rowCount + 1);
     await alertRuleEditPage.clickAddQueryRow();

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.spec.ts
@@ -3,6 +3,8 @@ import { test, expect } from '../../../../src';
 
 const skipMsg = 'Alerting rule test API are only compatible with Grafana 9.5.0 and later';
 
+test.use({ featureToggles: { alertingQueryAndExpressionsStepMode: false, alertingNotificationsStepMode: false } });
+
 test.describe('Test new alert rules', () => {
   test('should evaluate to true if query is valid', async ({
     grafanaVersion,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR correctly sets the root locator for the datasource picker component. With this fix, we can properly solve [this](https://github.com/grafana/grafana/pull/99492) issue. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@1.16.3-canary.1483.bbe402c.0
  # or 
  yarn add @grafana/plugin-e2e@1.16.3-canary.1483.bbe402c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
