### PR TITLE
Plugin E2E: Support advanced query mode in alert rules

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
-          limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
+          # limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
 
   playwright-tests:
     needs: resolve-versions

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
-          # limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
+          limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
 
   playwright-tests:
     needs: resolve-versions

--- a/docusaurus/docs/e2e-test-a-plugin/test-a-data-source-plugin/alert-queries.md
+++ b/docusaurus/docs/e2e-test-a-plugin/test-a-data-source-plugin/alert-queries.md
@@ -27,7 +27,7 @@ The following example uses the `alertRulePage` fixture. With this fixture, the t
 
 ```ts
 test('should evaluate to true if query is valid', async ({ page, alertRuleEditPage, selectors }) => {
-  const queryA = alertRuleEditPage.getAlertRuleQueryRow('A');
+  const queryA = alertRuleEditPage.getQueryRow();
   await queryA.datasource.set('gdev-prometheus');
   await queryA.locator.getByLabel('Code').click();
   await page.waitForFunction(() => window.monaco);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5588,9 +5588,9 @@
       "link": true
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-11.5.0.tgz",
-      "integrity": "sha512-PlCpnt1ivTwlwjA04juosWmOMq3487kxGsxNrBoceyH520ELPbgvnT7VO8eCXIDamHbpRdmFOAZgVK6STUut3A==",
+      "version": "11.5.0-220285",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-11.5.0-220285.tgz",
+      "integrity": "sha512-/HHdiFjU0E0sA95tBedMZDjU2KH7IewSQs6pZ0wJix8pGcCtnmB1N6khhtebX1e4daCh15YKwVp1Gn0J2G0YMg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grafana/tsconfig": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35087,7 +35087,7 @@
         "marked": "^15.0.0",
         "marked-terminal": "^7.2.0",
         "minimist": "^1.2.8",
-        "semver": "^7.7.0",
+        "semver": "^7.3.5",
         "title-case": "^4.3.0",
         "which": "^5.0.0"
       },
@@ -35125,7 +35125,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@grafana/e2e-selectors": "^11.5.0-220285",
-        "semver": "^7.7.0",
+        "semver": "^7.5.4",
         "uuid": "^11.0.2",
         "yaml": "^2.3.4"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5587,24 +5587,6 @@
       "resolved": "packages/create-plugin",
       "link": true
     },
-    "node_modules/@grafana/e2e-selectors": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-11.5.0.tgz",
-      "integrity": "sha512-PlCpnt1ivTwlwjA04juosWmOMq3487kxGsxNrBoceyH520ELPbgvnT7VO8eCXIDamHbpRdmFOAZgVK6STUut3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grafana/tsconfig": "^2.0.0",
-        "semver": "7.6.3",
-        "tslib": "2.8.1",
-        "typescript": "5.7.3"
-      }
-    },
-    "node_modules/@grafana/e2e-selectors/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/@grafana/eslint-config": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@grafana/eslint-config/-/eslint-config-8.0.0.tgz",
@@ -35128,6 +35110,36 @@
       "peerDependencies": {
         "@playwright/test": "^1.41.2"
       }
+    },
+    "packages/plugin-e2e/node_modules/@grafana/e2e-selectors": {
+      "version": "11.5.0-221187",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-11.5.0-221187.tgz",
+      "integrity": "sha512-sOL49ovXIV+MkwNM/KpvREVmbgY4eMYidlztn6k/kY7WihvBEv9EebX/gQgDAm1UrPwViz9aAYbl7iiD4XFohg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grafana/tsconfig": "^2.0.0",
+        "semver": "7.7.0",
+        "tslib": "2.8.1",
+        "typescript": "5.7.3"
+      }
+    },
+    "packages/plugin-e2e/node_modules/semver": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/plugin-e2e/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "packages/plugin-meta-extractor": {
       "name": "@grafana/plugin-meta-extractor",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35087,7 +35087,7 @@
         "marked": "^15.0.0",
         "marked-terminal": "^7.2.0",
         "minimist": "^1.2.8",
-        "semver": "^7.3.5",
+        "semver": "^7.7.0",
         "title-case": "^4.3.0",
         "which": "^5.0.0"
       },
@@ -35125,7 +35125,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@grafana/e2e-selectors": "^11.5.0-220285",
-        "semver": "^7.5.4",
+        "semver": "^7.7.0",
         "uuid": "^11.0.2",
         "yaml": "^2.3.4"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5588,9 +5588,9 @@
       "link": true
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "11.5.0-220285",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-11.5.0-220285.tgz",
-      "integrity": "sha512-/HHdiFjU0E0sA95tBedMZDjU2KH7IewSQs6pZ0wJix8pGcCtnmB1N6khhtebX1e4daCh15YKwVp1Gn0J2G0YMg==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-11.5.0.tgz",
+      "integrity": "sha512-PlCpnt1ivTwlwjA04juosWmOMq3487kxGsxNrBoceyH520ELPbgvnT7VO8eCXIDamHbpRdmFOAZgVK6STUut3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grafana/tsconfig": "^2.0.0",

--- a/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
@@ -54,7 +54,8 @@ export class AlertRuleEditPage extends GrafanaPage {
    * Only available in Grafana 11.5.0 and later. If advanced mode is not supported, this method will do nothing.
    */
   async enableAdvancedQueryMode() {
-    if (!this.isAdvancedModeSupported()) {
+    const advancedModeSupported = await this.isAdvancedModeSupported();
+    if (!advancedModeSupported) {
       console.log('Advanced query mode is not supported in this Grafana version. Ignoring the request.');
       return;
     }
@@ -69,7 +70,8 @@ export class AlertRuleEditPage extends GrafanaPage {
    * Advanced mode is enabled by default in Grafana 11.5.0 and later.
    */
   async disableAdvancedQueryMode() {
-    if (!this.isAdvancedModeSupported()) {
+    const advancedModeSupported = await this.isAdvancedModeSupported();
+    if (!advancedModeSupported) {
       console.log('Advanced query mode is not supported in this Grafana version. Ignoring the request.');
       return;
     }
@@ -117,7 +119,8 @@ export class AlertRuleEditPage extends GrafanaPage {
    * Since Grafana 11.5, this method is only available if advanced mode is enabled. Use enableQueryAdvancedMode() method to enable it.
    */
   async clickAddQueryRow(): Promise<AlertRuleQuery> {
-    if ((await this.isAdvancedModeSupported()) && !(await this.advancedModeSwitch.isChecked())) {
+    const advancedModeSupported = await this.isAdvancedModeSupported();
+    if (advancedModeSupported && !(await this.advancedModeSwitch.isChecked())) {
       throw new Error(
         'Since Grafana 11.5, you need to enable advanced mode to add queries. Use enableQueryAdvancedMode() method to enable it.'
       );

--- a/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
@@ -51,7 +51,7 @@ export class AlertRuleEditPage extends GrafanaPage {
 
   /*
    * Enables the advanced mode for the query and expression step.
-   * Only available in Grafana 11.5.0 and later. If advanced mode is not supported, this method will do nothing.
+   * Only available in Grafana 11.6.0 and later. If advanced mode is not supported, this method will do nothing.
    */
   async enableAdvancedQueryMode() {
     const advancedModeSupported = await this.isAdvancedModeSupported();
@@ -67,7 +67,7 @@ export class AlertRuleEditPage extends GrafanaPage {
 
   /*
    * Disabled the advanced mode for the query and expression step.
-   * Advanced mode is enabled by default in Grafana 11.5.0 and later.
+   * Advanced mode is enabled by default in Grafana 11.6.0 and later.
    */
   async disableAdvancedQueryMode() {
     const advancedModeSupported = await this.isAdvancedModeSupported();
@@ -101,8 +101,8 @@ export class AlertRuleEditPage extends GrafanaPage {
    * @deprecated Use getQueryRow instead
    * Returns an instance of the {@link AlertRuleQuery} class for a query in the query and expression step (step 2)
    *
-   * @param refId is optional. If not provided, it will return query row with refId 'A' in Grafana versions <11.5.
-   * In Grafana versions >=11.5 where advanced mode is supported, it will return the default query if advanced mode
+   * @param refId is optional. If not provided, it will return query row with refId 'A' in Grafana versions <11.6.
+   * In Grafana versions >=11.6 where advanced mode is supported, it will return the default query if advanced mode
    * is not enabled. If advanced mode is enabled, it will return the a query by refId.
    */
   getAlertRuleQueryRow(refId = 'A'): AlertRuleQuery {
@@ -116,13 +116,13 @@ export class AlertRuleEditPage extends GrafanaPage {
   /**
    * Clicks the "Add query" button and returns an instance of the {@link AlertRuleQuery} class for the new query row.
    *
-   * Since Grafana 11.5, this method is only available if advanced mode is enabled. Use enableQueryAdvancedMode() method to enable it.
+   * Since Grafana 11.6, this method is only available if advanced mode is enabled. Use enableQueryAdvancedMode() method to enable it.
    */
   async clickAddQueryRow(): Promise<AlertRuleQuery> {
     const advancedModeSupported = await this.isAdvancedModeSupported();
     if (advancedModeSupported && !(await this.advancedModeSwitch.isChecked())) {
       throw new Error(
-        'Since Grafana 11.5, you need to enable advanced mode to add queries. Use enableQueryAdvancedMode() method to enable it.'
+        'Since Grafana 11.6, you need to enable advanced mode to add queries. Use enableQueryAdvancedMode() method to enable it.'
       );
     }
 

--- a/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
@@ -3,8 +3,13 @@ import { AlertRuleArgs, NavigateOptions, PluginTestCtx, RequestOptions } from '.
 import { GrafanaPage } from './GrafanaPage';
 import { AlertRuleQuery } from '../components/AlertRuleQuery';
 
+const QUERY_AND_EXPRESSION_STEP_ID = '2';
+
 export class AlertRuleEditPage extends GrafanaPage {
-  constructor(readonly ctx: PluginTestCtx, readonly args?: AlertRuleArgs) {
+  constructor(
+    readonly ctx: PluginTestCtx,
+    readonly args?: AlertRuleArgs
+  ) {
     super(ctx, args);
   }
 
@@ -29,10 +34,76 @@ export class AlertRuleEditPage extends GrafanaPage {
     return this.ctx.page.getByPlaceholder('Give your alert rule a name');
   }
 
-  /**
-   * Returns an instance of the {@link AlertRuleQuery} class for the query row with the provided refId.
+  get advancedModeSwitch() {
+    return this.getByGrafanaSelector(
+      this.ctx.selectors.components.AlertRules.stepAdvancedModeSwitch(QUERY_AND_EXPRESSION_STEP_ID)
+    );
+  }
+
+  async isAdvancedModeSupported() {
+    // why not check if alertingQueryAndExpressionsStepMode feature is enabled? then we'd have to update the code when the toggle is removed.
+    const count = await this.getByGrafanaSelector(
+      this.ctx.selectors.components.AlertRules.stepAdvancedModeSwitch(QUERY_AND_EXPRESSION_STEP_ID)
+    ).count();
+
+    return count > 0;
+  }
+
+  /*
+   * Enables the advanced mode for the query and expression step.
+   * Only available in Grafana 11.5.0 and later. If advanced mode is not supported, this method will do nothing.
    */
-  getAlertRuleQueryRow(refId: string): AlertRuleQuery {
+  async enableAdvancedQueryMode() {
+    if (!this.isAdvancedModeSupported()) {
+      console.log('Advanced query mode is not supported in this Grafana version. Ignoring the request.');
+      return;
+    }
+
+    await this.getByGrafanaSelector(
+      this.ctx.selectors.components.AlertRules.stepAdvancedModeSwitch(QUERY_AND_EXPRESSION_STEP_ID)
+    ).check({ force: true });
+  }
+
+  /*
+   * Disabled the advanced mode for the query and expression step.
+   * Advanced mode is enabled by default in Grafana 11.5.0 and later.
+   */
+  async disableAdvancedQueryMode() {
+    if (!this.isAdvancedModeSupported()) {
+      console.log('Advanced query mode is not supported in this Grafana version. Ignoring the request.');
+      return;
+    }
+
+    await this.getByGrafanaSelector(
+      this.ctx.selectors.components.AlertRules.stepAdvancedModeSwitch(QUERY_AND_EXPRESSION_STEP_ID)
+    ).uncheck({ force: true });
+  }
+
+  async getQueryRow(refId = 'A'): Promise<AlertRuleQuery> {
+    const advancedModeSupported = await this.isAdvancedModeSupported();
+
+    if (advancedModeSupported && !(await this.advancedModeSwitch.isChecked()) && refId === 'A') {
+      // return the default query row
+      return new AlertRuleQuery(this.ctx, this.ctx.page.getByTestId('query-editor-row'));
+    }
+
+    // return query by refId
+    const locator = this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRows.rows).filter({
+      has: this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRow.title(refId)),
+    });
+
+    return new AlertRuleQuery(this.ctx, locator);
+  }
+
+  /**
+   * @deprecated Use getQueryRow instead
+   * Returns an instance of the {@link AlertRuleQuery} class for a query in the query and expression step (step 2)
+   *
+   * @param refId is optional. If not provided, it will return query row with refId 'A' in Grafana versions <11.5.
+   * In Grafana versions >=11.5 where advanced mode is supported, it will return the default query if advanced mode
+   * is not enabled. If advanced mode is enabled, it will return the a query by refId.
+   */
+  getAlertRuleQueryRow(refId = 'A'): AlertRuleQuery {
     const locator = this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRows.rows).filter({
       has: this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRow.title(refId)),
     });
@@ -42,8 +113,16 @@ export class AlertRuleEditPage extends GrafanaPage {
 
   /**
    * Clicks the "Add query" button and returns an instance of the {@link AlertRuleQuery} class for the new query row.
+   *
+   * Since Grafana 11.5, this method is only available if advanced mode is enabled. Use enableQueryAdvancedMode() method to enable it.
    */
   async clickAddQueryRow(): Promise<AlertRuleQuery> {
+    if ((await this.isAdvancedModeSupported()) && !(await this.advancedModeSwitch.isChecked())) {
+      throw new Error(
+        'Since Grafana 11.5, you need to enable advanced mode to add queries. Use enableQueryAdvancedMode() method to enable it.'
+      );
+    }
+
     await this.getByGrafanaSelector(this.ctx.selectors.components.QueryTab.addQuery).click();
     const locator = this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRows.rows).last();
 

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.advancedMode.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.advancedMode.spec.ts
@@ -5,19 +5,19 @@ const skipMsg = 'Alerting rule test API are only compatible with Grafana 9.5.0 a
 
 test.describe('Test alert rule APIs', () => {
   test('advanced mode should be enabled', async ({ grafanaVersion, alertRuleEditPage }) => {
-    test.skip(semver.lt(grafanaVersion, '11.5.0'), 'Advanced mode is not supported in Grafana versions < 11.5.0');
+    test.skip(semver.lt(grafanaVersion, '11.6.0'), 'Advanced mode is not supported in Grafana versions < 11.6.0');
     expect(await alertRuleEditPage.isAdvancedModeSupported()).toBe(true);
   });
 
   test('should be possible to enable advanced mode', async ({ grafanaVersion, alertRuleEditPage }) => {
-    test.skip(semver.lt(grafanaVersion, '11.5.0'), 'Advanced mode is not supported in Grafana versions < 11.5.0');
+    test.skip(semver.lt(grafanaVersion, '11.6.0'), 'Advanced mode is not supported in Grafana versions < 11.6.0');
     await expect(alertRuleEditPage.advancedModeSwitch).not.toBeChecked();
     await alertRuleEditPage.enableAdvancedQueryMode();
     await expect(alertRuleEditPage.advancedModeSwitch).toBeChecked();
   });
 
   test('should be possible to disable advanced mode', async ({ grafanaVersion, alertRuleEditPage }) => {
-    test.skip(semver.lt(grafanaVersion, '11.5.0'), 'Advanced mode is not supported in Grafana versions < 11.5.0');
+    test.skip(semver.lt(grafanaVersion, '11.6.0'), 'Advanced mode is not supported in Grafana versions < 11.6.0');
     await alertRuleEditPage.enableAdvancedQueryMode();
     await expect(alertRuleEditPage.advancedModeSwitch).toBeChecked();
     await alertRuleEditPage.disableAdvancedQueryMode();

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.advancedMode.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.advancedMode.spec.ts
@@ -5,19 +5,19 @@ const skipMsg = 'Alerting rule test API are only compatible with Grafana 9.5.0 a
 
 test.describe('Test alert rule APIs', () => {
   test('advanced mode should be enabled', async ({ grafanaVersion, alertRuleEditPage }) => {
-    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    test.skip(semver.lt(grafanaVersion, '11.5.0'), 'Advanced mode is not supported in Grafana versions < 11.5.0');
     expect(await alertRuleEditPage.isAdvancedModeSupported()).toBe(true);
   });
 
   test('should be possible to enable advanced mode', async ({ grafanaVersion, alertRuleEditPage }) => {
-    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    test.skip(semver.lt(grafanaVersion, '11.5.0'), 'Advanced mode is not supported in Grafana versions < 11.5.0');
     await expect(alertRuleEditPage.advancedModeSwitch).not.toBeChecked();
     await alertRuleEditPage.enableAdvancedQueryMode();
     await expect(alertRuleEditPage.advancedModeSwitch).toBeChecked();
   });
 
   test('should be possible to disable advanced mode', async ({ grafanaVersion, alertRuleEditPage }) => {
-    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    test.skip(semver.lt(grafanaVersion, '11.5.0'), 'Advanced mode is not supported in Grafana versions < 11.5.0');
     await alertRuleEditPage.enableAdvancedQueryMode();
     await expect(alertRuleEditPage.advancedModeSwitch).toBeChecked();
     await alertRuleEditPage.disableAdvancedQueryMode();

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.basicMode.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.basicMode.spec.ts
@@ -1,0 +1,87 @@
+import * as semver from 'semver';
+import { test, expect } from '../../../../src';
+
+const skipMsg = 'Alerting rule test API are only compatible with Grafana 9.5.0 and later';
+test.use({ featureToggles: { alertingQueryAndExpressionsStepMode: false, alertingNotificationsStepMode: false } });
+test.describe('Test alert rule APIs', () => {
+  test('advanced mode should be disabled', async ({ grafanaVersion, alertRuleEditPage }) => {
+    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    expect(await alertRuleEditPage.isAdvancedModeSupported()).toBe(false);
+  });
+});
+
+test.describe('Test new alert rules', () => {
+  test('should evaluate to true if query is valid', async ({
+    grafanaVersion,
+    page,
+    alertRuleEditPage,
+    readProvisionedDataSource,
+  }) => {
+    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    const ds = await readProvisionedDataSource({ fileName: 'testdatasource.yaml' });
+    const queryA = await alertRuleEditPage.getQueryRow('A');
+    await queryA.datasource.set(ds.name);
+    await page.getByRole('textbox', { name: 'Query Text' }).fill('some query');
+    await expect(alertRuleEditPage.evaluate()).toBeOK();
+  });
+
+  test('should evaluate to false if query is invalid', async ({
+    grafanaVersion,
+    page,
+    alertRuleEditPage,
+    readProvisionedDataSource,
+  }) => {
+    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    const ds = await readProvisionedDataSource({ fileName: 'testdatasource.yaml' });
+    const queryA = await alertRuleEditPage.getQueryRow('A');
+    await queryA.datasource.set(ds.name);
+    await page.getByRole('textbox', { name: 'Query Text' }).fill('error');
+    await expect(alertRuleEditPage.evaluate()).not.toBeOK();
+  });
+
+  test('should be possible to add multiple rows', async ({
+    grafanaVersion,
+    alertRuleEditPage,
+    selectors,
+    readProvisionedDataSource,
+    page,
+  }) => {
+    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    const { rows } = selectors.components.QueryEditorRows;
+    const ds = await readProvisionedDataSource({ fileName: 'testdatasource.yaml' });
+    const queryA = await alertRuleEditPage.getQueryRow();
+    await queryA.datasource.set(ds.name);
+    const rowCount = await alertRuleEditPage.getByGrafanaSelector(rows).count();
+    await alertRuleEditPage.clickAddQueryRow();
+    await expect(alertRuleEditPage.getByGrafanaSelector(rows)).toHaveCount(rowCount + 1);
+    await alertRuleEditPage.clickAddQueryRow();
+    await expect(alertRuleEditPage.getByGrafanaSelector(rows)).toHaveCount(rowCount + 2);
+  });
+});
+
+test.describe('Tests existing alert rules', () => {
+  test('should evaluate to true when loading a provisioned query that is valid', async ({
+    grafanaVersion,
+    gotoAlertRuleEditPage,
+    readProvisionedAlertRule,
+  }) => {
+    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    const alertRule = await readProvisionedAlertRule({
+      fileName: 'testdatasource.yml',
+      ruleTitle: 'successful-alert',
+    });
+    const alertRuleEditPage = await gotoAlertRuleEditPage(alertRule);
+    await expect(alertRuleEditPage.evaluate()).toBeOK();
+  });
+
+  test('should evaluate to false when loading a provisioned query that is invalid', async ({
+    grafanaVersion,
+    gotoAlertRuleEditPage,
+    readProvisionedAlertRule,
+  }) => {
+    test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);
+    const alertRule = await readProvisionedAlertRule({ fileName: 'testdatasource.yml', ruleTitle: 'broken-alert' });
+    const alertRuleEditPage = await gotoAlertRuleEditPage(alertRule);
+    await expect(alertRuleEditPage.evaluate()).not.toBeOK();
+  });
+});


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR adds support for advanced query mode in alert rules. This was introduced in G11.3 and enabled by default in G11.5. With the change, the plugin-e2e methods `clickAddQueryRow` and `getAlertRuleQueryRow` stopped working because these features were hidden in basic mode (which is default starting from 11.5). 

This PR introduces a few new methods and properties to facilitate for advanced query mode. The `getAlertRuleQueryRow` is now deprecated in favour of `getQueryRow`. The `getQueryRow` is backwards compatible. Calling it without a refId will be equivalent to calling it with refId `A` in versions before 11.5, and will return the default query in +11.5

### Examples
#### Retrieving the first query row
Instead of:
```tsx
const queryA = alertRuleEditPage.getAlertRuleQueryRow('A');
```
Use:
```tsx
const queryA = await alertRuleEditPage.getQueryRow();
```

### Adding more rows and accessing them specifically
Instead of: 
```tsx
await alertRuleEditPage.clickAddQueryRow();
const queryB =alertRuleEditPage.getAlertRuleQueryRow('B');
```
Use:
```tsx
await alertRuleEditPage.enableAdvancedQueryMode(); //this method will do nothing in <G11.5
await alertRuleEditPage.clickAddQueryRow();
const queryB = await alertRuleEditPage.getQueryRow('B');
```


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/plugin-tools/issues/1480

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.15.0-canary.1490.92a0669.0
  npm install @grafana/plugin-e2e@1.18.0-canary.1490.92a0669.0
  # or 
  yarn add @grafana/create-plugin@5.15.0-canary.1490.92a0669.0
  yarn add @grafana/plugin-e2e@1.18.0-canary.1490.92a0669.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
