### PR TITLE
Create plugin: Update release workflow template to include attestation by default

### DIFF
--- a/packages/create-plugin/templates/github/workflows/release.yml
+++ b/packages/create-plugin/templates/github/workflows/release.yml
@@ -13,14 +13,17 @@ permissions: read-all
 jobs:
   release:
     permissions:
+      id-token: write
       contents: write
+      attestations: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: grafana/plugin-actions/build-plugin@main
-        # Uncomment to enable plugin signing
-        # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
-        #with:
+        with:
+          attestation: true
+          # Uncomment to enable plugin signing
+          # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
           # Make sure to save the token in your repository secrets
           #policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
           # Usage of GRAFANA_API_KEY is deprecated, prefer `policy_token` option above


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the release default template to create attestations by default

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.17.0-canary.1539.13304384862.0
  # or 
  yarn add @grafana/create-plugin@5.17.0-canary.1539.13304384862.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
