### PR TITLE
E2E: Fix so color picker works properly in 11.6.0

### DIFF
--- a/packages/plugin-e2e/src/models/components/ColorPicker.ts
+++ b/packages/plugin-e2e/src/models/components/ColorPicker.ts
@@ -12,11 +12,18 @@ export class ColorPicker extends ComponentBase {
 
   async selectOption(rgbOrHex: string, options?: SelectOptionsType): Promise<void> {
     await this.element.getByRole('button').click(options);
-    await this.getContainer().getByRole('button', { name: 'Custom', exact: true }).click(options);
+    await this.getCustomTab().click(options);
 
     const colorInput = this.getContainer().getByTestId('input-wrapper').getByRole('textbox');
     await colorInput.hover(options);
     await colorInput.fill(rgbOrHex, options);
+  }
+
+  private getCustomTab(): Locator {
+    if (gte(this.ctx.grafanaVersion, '11.6.0')) {
+      return this.getContainer().getByRole('tab', { name: 'Custom', exact: true });
+    }
+    return this.getContainer().getByRole('button', { name: 'Custom', exact: true });
   }
 
   private getContainer(): Locator {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR applies a fix for `11.6.0` where we changed the role of the color picker custom tab.

See this [PR](https://github.com/grafana/grafana/pull/100255) for change in Grafana.
See this [build](https://github.com/grafana/plugin-tools/actions/runs/13269284395/job/37086159996#logs) for failure.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/eslint-plugin-plugins@0.1.1-canary.1540.13286264005.0
  npm install @grafana/plugin-e2e@1.18.1-canary.1540.13286264005.0
  # or 
  yarn add @grafana/eslint-plugin-plugins@0.1.1-canary.1540.13286264005.0
  yarn add @grafana/plugin-e2e@1.18.1-canary.1540.13286264005.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
