### PR TITLE
Create Plugin: fix absolute path being interpreted by shell

### DIFF
--- a/packages/create-plugin/src/utils/utils.prettifyFiles.ts
+++ b/packages/create-plugin/src/utils/utils.prettifyFiles.ts
@@ -1,10 +1,10 @@
-import { exec as nodeExec } from 'node:child_process';
+import { execFile as nodeExecFile } from 'node:child_process';
 import fs from 'node:fs';
 import { resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { getPackageJson } from './utils.packagejson.js';
 
-const exec = promisify(nodeExec);
+const execFile = promisify(nodeExecFile);
 
 type PrettifyFilesArgs = {
   // The path where we want to prettify files, defaults to the CWD
@@ -30,8 +30,9 @@ export async function prettifyFiles(options: PrettifyFilesArgs) {
   const directoryToWrite = resolve(projectRoot, targetPath);
 
   try {
-    let command = `npx -y prettier@${prettierVersion} ${directoryToWrite} --write`;
-    await exec(command);
+    let command = 'npx';
+    const args = ['-y', `prettier@${prettierVersion}`, directoryToWrite, '--write'];
+    await execFile(command, args);
   } catch (error) {
     throw new Error(
       'There was a problem running prettier on the plugin files. Please run `npx -y prettier@2 . --write` manually in your plugin directory.'


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
CodeQL is complaining about the prettier command when we scaffold. See [code-scanning#20](https://github.com/grafana/plugin-tools/security/code-scanning/20).

From the details in the warning it seems we can fix it by using execFile instead of exec and passing the directory as an argument which prevents it being interpreted by a shell.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.18.1-canary.1560.13431330030.0
  # or 
  yarn add @grafana/create-plugin@5.18.1-canary.1560.13431330030.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
