### PR TITLE
Plugin Types Bundler: Update the .tsconfig

### DIFF
--- a/packages/plugin-types-bundler/tsconfig/tsconfig.json
+++ b/packages/plugin-types-bundler/tsconfig/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "jsx": "react",
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
### What changed?

This PR extending the default `.tsconfig.json` that is used by the underlying `dts-bundle-gen` package.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.18.2-canary.1561.13437202877.0
  npm install @grafana/plugin-types-bundler@0.2.5-canary.1561.13437202877.0
  # or 
  yarn add @grafana/create-plugin@5.18.2-canary.1561.13437202877.0
  yarn add @grafana/plugin-types-bundler@0.2.5-canary.1561.13437202877.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
