### PR TITLE
Update documentation to use proxyUrl instead of baseUrl

### DIFF
--- a/docusaurus/docs/how-to-guides/data-source-plugins/fetch-data-from-frontend.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/fetch-data-from-frontend.md
@@ -82,20 +82,20 @@ type TODO = {
 };
 
 export class DataSource extends DataSourceApi {
-  baseUrl: string;
+  proxyUrl: string;
   constructor(instanceSettings: DataSourceInstanceSettings) {
     super(instanceSettings);
     // notice we are storing the URL from the instanceSettings
-    this.baseUrl = instanceSettings.url!;
+    this.proxyUrl = instanceSettings.url!;
   }
 
   async query(options: DataQueryRequest): Promise<DataQueryResponse> {
     const response = getBackendSrv().fetch<TODO[]>({
-      // You can see above that `this.baseUrl` is set in the constructor
+      // You can see above that `this.proxyUrl` is set in the constructor
       // in this example we assume the configured url is
       // https://jsonplaceholder.typicode.com
-      /// if you inspect `this.baseUrl` you'll see the Grafana data proxy url
-      url: `${this.baseUrl}/todos`,
+      /// if you inspect `this.proxyUrl` you'll see the Grafana data proxy url
+      url: `${this.proxyUrl}/todos`,
     });
     // backendSrv fetch returns an observable object
     // we should unwrap with rxjs


### PR DESCRIPTION
The code has been updated to use `proxyUrl` instead of `baseUrl` to better reflect its purpose as a proxy URL for the Grafana data source. The documentation should be updated to match this change to maintain consistency and clarity. The changes include updating the variable name in the code examples and related comments.