### PR TITLE
Build: force installation of optional peer dependencies for CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,12 @@
         "packages/plugin-types-bundler",
         "packages/eslint-plugin-plugins"
       ],
+      "dependencies": {
+        "@rollup/rollup-linux-x64-gnu": "*",
+        "@rspack/binding-linux-x64-gnu": "*",
+        "@swc/html-linux-x64-gnu": "*",
+        "lightningcss-linux-x64-gnu": "*"
+      },
       "devDependencies": {
         "@auto-it/all-contributors": "11.3.0",
         "@auto-it/first-time-contributor": "11.3.0",
@@ -45,6 +51,12 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.34.9",
+        "@rspack/binding-linux-x64-gnu": "^1.2.7",
+        "@swc/html-linux-x64-gnu": "^1.11.7",
+        "lightningcss-linux-x64-gnu": "^1.29.2"
       }
     },
     "docusaurus/website": {
@@ -8660,13 +8672,12 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
-      "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
+      "version": "4.34.9",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.9.tgz",
+      "integrity": "sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8727,6 +8738,19 @@
       "optional": true,
       "os": [
         "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-lUOAUq0YSsofCXsP6XnlgfH0ZRDZ2X2XqXLXYjqf4xkSxCl5eBmE0EQYjAHF4zjUvU5rVx4a4bDLWv7+t3bOHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ]
     },
     "node_modules/@rspack/lite-tapable": {
@@ -9541,13 +9565,12 @@
       }
     },
     "node_modules/@swc/html-linux-x64-gnu": {
-      "version": "1.10.14",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.10.14.tgz",
-      "integrity": "sha512-iXHZ07fJqLPE6HX/NMtdc3GtVI1df//wn4EgVn49lRm9GiEZFhWtJrbvujBbaZF/g6KPt4GyQbXLm5ZFXOyayA==",
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.11.7.tgz",
+      "integrity": "sha512-1UV0Y+5ewDe0pczuzrA2mMQj91wfjvTMbBWFrlxMPLX9ThOJGse3EuE+8qw1vWX46RUuMnoE94ytBEMFUVBKyg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -9620,6 +9643,23 @@
       "optional": true,
       "os": [
         "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html/node_modules/@swc/html-linux-x64-gnu": {
+      "version": "1.10.14",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.10.14.tgz",
+      "integrity": "sha512-iXHZ07fJqLPE6HX/NMtdc3GtVI1df//wn4EgVn49lRm9GiEZFhWtJrbvujBbaZF/g6KPt4GyQbXLm5ZFXOyayA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">=10"
@@ -22565,19 +22605,17 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
-      "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.2.tgz",
+      "integrity": "sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -22642,6 +22680,28 @@
       "optional": true,
       "os": [
         "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
+      "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "peer": true,
       "engines": {
@@ -32119,6 +32179,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.34.8",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
+      "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/rtl-css-js": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -75,5 +75,11 @@
     "express": {
       "cookie": "^0.7.0"
     }
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-linux-x64-gnu": "^4.34.9",
+    "@rspack/binding-linux-x64-gnu": "^1.2.7",
+    "@swc/html-linux-x64-gnu": "^1.11.7",
+    "lightningcss-linux-x64-gnu": "^1.29.2"
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
We're suffering from [a bug in NPM](https://github.com/npm/cli/issues/4828) that removes optional dependencies from the package-lock.json file which results in CI breaking due to package-lock.json changes with errors such as:

```
Error:  Error: To enable Docusaurus Faster options, your site must add the @docusaurus/faster package as a dependency.
    at ensureFaster (/home/runner/work/plugin-tools/plugin-tools/node_modules/@docusaurus/bundler/lib/importFaster.js:26:15)
    at async importRspack (/home/runner/work/plugin-tools/plugin-tools/node_modules/@docusaurus/bundler/lib/importFaster.js:30:20)
    ... 6 lines matching cause stack trace ...
    at async file:///home/runner/work/plugin-tools/plugin-tools/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
  [cause]: Error: Cannot find module '@rspack/binding-linux-x64-gnu'
  Require stack:
  - /home/runner/work/plugin-tools/plugin-tools/node_modules/@docusaurus/faster/node_modules/@rspack/binding/binding.js
  - /home/runner/work/plugin-tools/plugin-tools/node_modules/@docusaurus/faster/node_modules/@rspack/core/dist/index.js
  - /home/runner/work/plugin-tools/plugin-tools/node_modules/@docusaurus/faster/lib/index.js
      at Function._resolveFilename (node:internal/modules/cjs/loader:1225:15)
      at Function._load (node:internal/modules/cjs/loader:1055:27)
      at TracingChannel.traceSync (node:diagnostics_channel:322:[14](https://github.com/grafana/plugin-tools/actions/runs/13697726780/job/38303884972?pr=1597#step:5:15))
```

This PR runs the following command so we can workaround this until a fix is in place.

```
npm i -O @rollup/rollup-linux-x64-gnu lightningcss-linux-x64-gnu @rspack/binding-linux-x64-gnu @swc/html-linux-x64-gnu
```

This places the optional deps in our root package.json and guarantees they're available for CI.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
