### PR TITLE
CI: Add optionDependencies to devDependencies group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
   "includePaths": ["package.json", "packages/**", "docusaurus/**", ".github"],
   "ignoreDeps": ["react", "react-dom", "@stylistic/eslint-plugin-ts", "lerna"],
   "separateMajorMinor": false,
+  "skipInstalls": false,
   "reviewers": ["team:grafana/plugins-platform-frontend"],
   "enabledManagers": ["regex", "npm", "github-actions"],
   "postUpdateOptions": ["npmDedupe"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,7 +73,7 @@
       "groupSlug": "dev-dependencies-automerge",
       "labels": ["dependencies", "javascript", "no-changelog"],
       "matchCurrentVersion": "!/^0/",
-      "matchDepTypes": ["devDependencies"],
+      "matchDepTypes": ["devDependencies", "optionalDependencies"],
       "excludePackageNames": ["@grafana/e2e-selectors"],
       "rangeStrategy": "bump"
     },


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
We need this to keep the devDependencies that have optionalDependencies listed in package.json aligned.

Dev dependencies in this repo are auto merged but due to the NPM bug related to optionalDependencies, we're seeing rust bindings PRs being created that should likely be bumped at the same time as their dependent NPM packages.

e.g. when `rollup` is bumped we should also bump `@rollup/rollup-linux-x64-gnu`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
