### PR TITLE
CODEOWNERS: update to @grafana/plugins-platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
-* @grafana/plugins-platform-frontend
+* @grafana/plugins-platform


### PR DESCRIPTION
### Why?
I don't think it makes sense that only frontend members can approve PRs (e.g. when not necessarily frontend parts need changes).