### PR TITLE
CODEOWNERS: fix wrong format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # these will be requested for review when someone opens a pull request.
-* @grafana/plugins-platform-frontend
-* @grafana/plugins-platform-backend
+* @grafana/plugins-platform-frontend @grafana/plugins-platform-backend


### PR DESCRIPTION
### What changed?
[In the previous PR](https://github.com/grafana/plugin-tools/pull/1686) I have made a mistake, listed the teams under each other, which actually means that last one takes precedence -> it's now the backend team that has to approve everything in the repo. (Listing them next to each = OR).