### PR TITLE
Docs: Update the migration guide for G12

### DIFF
--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v11.6.x-v12.0.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v11.6.x-v12.0.x.md
@@ -135,11 +135,7 @@ The types `PluginExtensionLinkConfig` and `PluginExtensionComponentConfig` have 
 
 ### GetPluginExtensionsOptions
 
-The type `GetPluginExtensionsOptions` has been removed from `@grafana/runtime`. Replace it with one of the following types based on your use case:
-
-- `UsePluginLinksOptions` - For `usePluginLinks()`
-- `UsePluginComponentsOptions` - For `usePluginComponents()`
-- `UsePluginFunctionsOptions` - For `usePluginFunctions()`
+The `GetPluginExtensionsOptions` type has been removed from `@grafana/runtime` in favor of specific types that match their corresponding hook parameters.
 
 ## Quick reference
 

--- a/docusaurus/docs/migration-guides/update-from-grafana-versions/v11.6.x-v12.0.x.md
+++ b/docusaurus/docs/migration-guides/update-from-grafana-versions/v11.6.x-v12.0.x.md
@@ -131,21 +131,30 @@ Replace the `getPluginExtensions()` function and the `usePluginExtensions()` Rea
 
 ### PluginExtensionLinkConfig and PluginExtensionComponentConfig
 
-The types `PluginExtensionLinkConfig` and `PluginExtensionComponentConfig` have been removed from `@grafana/data`.Replace them with `PluginExtensionAddedLinkConfig` and `PluginExtensionAddedComponentConfig`, respectively.
+The types `PluginExtensionLinkConfig` and `PluginExtensionComponentConfig` have been removed from `@grafana/data`. Replace them with `PluginExtensionAddedLinkConfig` and `PluginExtensionAddedComponentConfig`, respectively.
+
+### GetPluginExtensionsOptions
+
+The type `GetPluginExtensionsOptions` has been removed from `@grafana/runtime`. Replace it with one of the following types based on your use case:
+
+- `UsePluginLinksOptions` - For `usePluginLinks()`
+- `UsePluginComponentsOptions` - For `usePluginComponents()`
+- `UsePluginFunctionsOptions` - For `usePluginFunctions()`
 
 ## Quick reference
 
 The following table summarizes the API changes with notes explaining the key differences:
 
-| Deprecated API                            | Equivalent API                                | Notes                                                                             |
-| ----------------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------- |
-| `AppPlugin.configureExtensionLink()`      | `AppPlugin.addLink()`                         | `extensionPointId` parameter renamed to `targets`, accepts `string` or `string[]` |
-| `AppPlugin.configureExtensionComponent()` | `AppPlugin.addComponent()`                    | `extensionPointId` parameter renamed to `targets`, accepts `string` or `string[]` |
-| `getPluginLinkExtensions()`               | `usePluginLinks()`                            | Returns `{ links, isLoading }` instead of `{ extensions }`                        |
-| `usePluginLinkExtensions()`               | `usePluginLinks()`                            | Returns `{ links, isLoading }` instead of `{ extensions }`                        |
-| `getPluginComponentExtensions()`          | `usePluginComponents()`                       | Returns `{ components, isLoading }` instead of `{ extensions }`                   |
-| `usePluginComponentExtensions()`          | `usePluginComponents()`                       | Returns `{ components, isLoading }` instead of `{ extensions, isLoading }`        |
-| `getPluginExtensions()`                   | `usePluginLinks()` or `usePluginComponents()` | Split into two separate hooks based on extension type (links or components)       |
-| `usePluginExtensions()`                   | `usePluginLinks()` or `usePluginComponents()` | Split into two separate hooks based on extension type (links or components)       |
-| `PluginExtensionComponentConfig`          | `PluginExtensionAddedComponentConfig`         | Updated type definition for component configuration                               |
-| `PluginExtensionLinkConfig`               | `PluginExtensionAddedLinkConfig`              | Updated type definition for link configuration                                    |
+| Deprecated API                            | Equivalent API                                                                         | Notes                                                                             |
+| ----------------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `AppPlugin.configureExtensionLink()`      | `AppPlugin.addLink()`                                                                  | `extensionPointId` parameter renamed to `targets`, accepts `string` or `string[]` |
+| `AppPlugin.configureExtensionComponent()` | `AppPlugin.addComponent()`                                                             | `extensionPointId` parameter renamed to `targets`, accepts `string` or `string[]` |
+| `getPluginLinkExtensions()`               | `usePluginLinks()`                                                                     | Returns `{ links, isLoading }` instead of `{ extensions }`                        |
+| `usePluginLinkExtensions()`               | `usePluginLinks()`                                                                     | Returns `{ links, isLoading }` instead of `{ extensions }`                        |
+| `getPluginComponentExtensions()`          | `usePluginComponents()`                                                                | Returns `{ components, isLoading }` instead of `{ extensions }`                   |
+| `usePluginComponentExtensions()`          | `usePluginComponents()`                                                                | Returns `{ components, isLoading }` instead of `{ extensions, isLoading }`        |
+| `getPluginExtensions()`                   | `usePluginLinks()` or `usePluginComponents()`                                          | Split into two separate hooks based on extension type (links or components)       |
+| `usePluginExtensions()`                   | `usePluginLinks()` or `usePluginComponents()`                                          | Split into two separate hooks based on extension type (links or components)       |
+| `PluginExtensionComponentConfig`          | `PluginExtensionAddedComponentConfig`                                                  | Updated type definition for component configuration                               |
+| `PluginExtensionLinkConfig`               | `PluginExtensionAddedLinkConfig`                                                       | Updated type definition for link configuration                                    |
+| `GetPluginExtensionsOptions`              | `UsePluginLinksOptions` or `UsePluginComponentsOptions` or `UsePluginFunctionsOptions` | Updated type definition for hook parameters                                       |


### PR DESCRIPTION
### What's changed?

Updated migration guide with a note about the removed `GetPluginExtensionsOptions` type and the alternatives.