### PR TITLE
chore: fixes unexpected flaky component tests (#1749)

### DIFF
--- a/packages/create-plugin/templates/app/src/components/App/App.test.tsx
+++ b/packages/create-plugin/templates/app/src/components/App/App.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { AppRootProps, PluginType } from '@grafana/data';
-import { render, screen } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import App from './App';
 
 describe('Components/App', () => {
@@ -26,12 +26,13 @@ describe('Components/App', () => {
   });
 
   test('renders without an error"', async () => {
-    render(
-      <BrowserRouter>
+    const { queryByText } = render(
+      <MemoryRouter>
         <App {...props} />
-      </BrowserRouter>
+      </MemoryRouter>
     );
 
-    expect(await screen.findByText(/this is page one./i)).toBeInTheDocument();
+    // Application is lazy loaded, so we need to wait for the component and routes to be rendered
+    await waitFor(() => expect(queryByText(/this is page one./i)).toBeInTheDocument(), { timeout: 2000 });
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The `App.test.tsx` tests started failing for some unknown reason. Me and @jackw tried to figure out the root cause but we didn't manage so this PR should fix the tests so we can publish things again.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.19.8-canary.1749.14639949456.0
  npm install @grafana/eslint-plugin-plugins@0.3.5-canary.1749.14639949456.0
  # or 
  yarn add @grafana/create-plugin@5.19.8-canary.1749.14639949456.0
  yarn add @grafana/eslint-plugin-plugins@0.3.5-canary.1749.14639949456.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
