### PR TITLE
Chore: fix cspell "doesn't" spelling in create-plugin Webpack config

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -43,7 +43,7 @@ const config = async (env: Env): Promise<Configuration> => {
     cache: {
       type: 'filesystem',
       buildDependencies: {
-        // __filename doesnt work in Node 24
+        // __filename doesn't work in Node 24
         config: [path.resolve(process.cwd(), '.config', 'webpack', 'webpack.config.ts')],
       },
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

Keeps cspell happy when running against the files generated by create-plugin

🔐 https://github.com/grafana/grafana-setupguide-app/actions/runs/15126010030/job/42518080435

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@3.6.5-canary.1809.15126327026.0
  npm install @grafana/create-plugin@5.22.1-canary.1809.15126327026.0
  npm install @grafana/plugin-meta-extractor@0.6.1-canary.1809.15126327026.0
  npm install @grafana/plugin-types-bundler@0.3.5-canary.1809.15126327026.0
  # or 
  yarn add website@3.6.5-canary.1809.15126327026.0
  yarn add @grafana/create-plugin@5.22.1-canary.1809.15126327026.0
  yarn add @grafana/plugin-meta-extractor@0.6.1-canary.1809.15126327026.0
  yarn add @grafana/plugin-types-bundler@0.3.5-canary.1809.15126327026.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
