### PR TITLE
swc-loader: allow node_modules `.ts` and `.tsx` files

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -118,7 +118,8 @@ const config = async (env: Env): Promise<Configuration> => {
           ],
         },
         {
-          exclude: /(node_modules)/,
+          // Exclude node_modules, except for typescript files (.ts, .tsx) possibly shared by git dependencies
+          exclude: /(node_modules)(?:(?!.*tsx?$))/,
           test: /\.[tj]sx?$/,
           use: {
             loader: 'swc-loader',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

It can be convenient to use github imports between private repositories in order to share typescript files.
The previous rule excluded all `node_modules` files from the swc-loader. This adjustment to the `excludes` pattern allows for `ts` and `tsx` files.

Without this change (or an override to this rule's `exclude` field), webpack would emit this failing error:
> You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file.


Here is a workaround that I have been using on webpack.config which overrides that of the `.config` folder:

```ts
...
function isSwcLoaderRule(rule: any): rule is RuleSetRule {
  return rule?.use?.loader === 'swc-loader';
}
...


  // BEGIN FIX swc-loader to work with our internal git dependencies
  // Prevents error: "You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file."
  const swcLoaderRule = baseConfig.module?.rules?.filter(isSwcLoaderRule)[0];
  if (!swcLoaderRule) {
    throw new Error('Could not find the swc-loader rule. Has the .config/webpack.config.ts changed?');
  }
  // Exclude node_modules, except for typescript files (.ts, .tsx) possibly shared by git dependencies
  swcLoaderRule.exclude = /(node_modules)(?:(?!.*tsx?$))/;
  // END FIX
```

Having this `exclude` pattern within the boilerplate `.config` would be preferable to pasting this workaround in multiple projects webpack overrides.