### PR TITLE
fix: mention required config setting in service account how-to

### DIFF
--- a/docusaurus/docs/how-to-guides/app-plugins/use_a_service_account.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/use_a_service_account.md
@@ -23,6 +23,7 @@ Ensure your development environment meets the following prerequisites:
 
 - **Grafana version:** Use Grafana 10.3 or later
 - **Feature toggle:** Enable the `externalServiceAccounts` feature toggle. Refer to our documentation [on configuring Grafana feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles)
+- **Config variable:** Enable the [auth.managed_service_accounts_enabled](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#managed_service_accounts_enabled) configuration variable. Refer to our documentation [on configuring Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#configure-grafana)
 - **Deployment type:** This feature currently **only supports single-organization deployments**
 
 ## Add service account configuration


### PR DESCRIPTION
Grafana requires the `auth.managed_service_accounts_enabled` configuration variable to be set to true in order to use service accounts (see [the code]). This commit updates the doc to mention this requirement.

I'm not sure why this didn't come up before though, perhaps it's a new requirement? It seems to have been the same for 9 months :thinking: 

[the code]: https://github.com/grafana/grafana/blob/7f63b18e826bc1aba2ba215ee329b989a63fc018/pkg/services/pluginsintegration/serviceregistration/serviceregistration.go#L25
