### PR TITLE
Create Plugin: Replace deprecated eslint deprecation plugin

### DIFF
--- a/packages/create-plugin/src/migrations/manager.test.ts
+++ b/packages/create-plugin/src/migrations/manager.test.ts
@@ -3,7 +3,7 @@ import { getMigrationsToRun, runMigration, runMigrations } from './manager.js';
 import migrationFixtures from './fixtures/migrations.js';
 import { Context } from './context.js';
 import { gitCommitNoVerify } from '../utils/utils.git.js';
-import { flushChanges, printChanges } from './utils.js';
+import { flushChanges, printChanges, formatFiles } from './utils.js';
 import { setRootConfig } from '../utils/utils.config.js';
 import { MigrationMeta } from './migrations.js';
 
@@ -11,6 +11,7 @@ vi.mock('./utils.js', () => ({
   flushChanges: vi.fn(),
   printChanges: vi.fn(),
   migrationsDebug: vi.fn(),
+  formatFiles: vi.fn(),
 }));
 
 vi.mock('../utils/utils.config.js', () => ({
@@ -170,6 +171,12 @@ describe('Migrations', () => {
       await runMigrations(migrations);
 
       expect(printChanges).toHaveBeenCalledTimes(2);
+    });
+
+    it('should format the files for each migration', async () => {
+      await runMigrations(migrations);
+
+      expect(formatFiles).toHaveBeenCalledTimes(2);
     });
 
     it('should not commit the changes for each migration by default', async () => {

--- a/packages/create-plugin/src/migrations/manager.test.ts
+++ b/packages/create-plugin/src/migrations/manager.test.ts
@@ -12,6 +12,7 @@ vi.mock('./utils.js', () => ({
   printChanges: vi.fn(),
   migrationsDebug: vi.fn(),
   formatFiles: vi.fn(),
+  installNPMDependencies: vi.fn(),
 }));
 
 vi.mock('../utils/utils.config.js', () => ({

--- a/packages/create-plugin/src/migrations/manager.test.ts
+++ b/packages/create-plugin/src/migrations/manager.test.ts
@@ -15,6 +15,16 @@ vi.mock('./utils.js', () => ({
   installNPMDependencies: vi.fn(),
 }));
 
+// Silence terminal output during tests.
+vi.mock('../utils/utils.console.js', () => ({
+  output: {
+    log: vi.fn(),
+    addHorizontalLine: vi.fn(),
+    logSingleLine: vi.fn(),
+    bulletList: vi.fn().mockReturnValue(['']),
+  },
+}));
+
 vi.mock('../utils/utils.config.js', () => ({
   setRootConfig: vi.fn(),
 }));

--- a/packages/create-plugin/src/migrations/manager.ts
+++ b/packages/create-plugin/src/migrations/manager.ts
@@ -1,7 +1,7 @@
 import { satisfies, gte } from 'semver';
 import { Context } from './context.js';
 import defaultMigrations, { MigrationMeta } from './migrations.js';
-import { flushChanges, printChanges, migrationsDebug, formatFiles } from './utils.js';
+import { flushChanges, printChanges, migrationsDebug, formatFiles, installNPMDependencies } from './utils.js';
 import { gitCommitNoVerify } from '../utils/utils.git.js';
 import { setRootConfig } from '../utils/utils.config.js';
 import { output } from '../utils/utils.console.js';
@@ -52,6 +52,8 @@ export async function runMigrations(migrations: Record<string, MigrationMeta>, o
       await formatFiles(context);
       flushChanges(context);
       printChanges(context, key, migration);
+
+      installNPMDependencies(context);
 
       if (shouldCommit) {
         await gitCommitNoVerify(`chore: run create-plugin migration - ${key} (${migration.migrationScript})`);

--- a/packages/create-plugin/src/migrations/manager.ts
+++ b/packages/create-plugin/src/migrations/manager.ts
@@ -1,7 +1,7 @@
 import { satisfies, gte } from 'semver';
 import { Context } from './context.js';
 import defaultMigrations, { MigrationMeta } from './migrations.js';
-import { flushChanges, printChanges, migrationsDebug } from './utils.js';
+import { flushChanges, printChanges, migrationsDebug, formatFiles } from './utils.js';
 import { gitCommitNoVerify } from '../utils/utils.git.js';
 import { setRootConfig } from '../utils/utils.config.js';
 import { output } from '../utils/utils.console.js';
@@ -49,6 +49,7 @@ export async function runMigrations(migrations: Record<string, MigrationMeta>, o
       migrationsDebug(`context for "${key} (${migration.migrationScript})":`);
       migrationsDebug('%O', context.listChanges());
 
+      await formatFiles(context);
       flushChanges(context);
       printChanges(context, key, migration);
 

--- a/packages/create-plugin/src/migrations/migrations.ts
+++ b/packages/create-plugin/src/migrations/migrations.ts
@@ -27,5 +27,10 @@ export default {
         'Update ./.github/workflows/is-compatible.yml to use is-compatible github action instead of calling levitate directly',
       migrationScript: './scripts/002-update-is-compatible-workflow.js',
     },
+    '003-update-eslint-deprecation-rule': {
+      version: '5.24.1',
+      description: 'Replace deprecated eslint-plugin-deprecation with @typescript-eslint/no-deprecated rule.',
+      migrationScript: './scripts/003-update-eslint-deprecation-rule.js',
+    },
   },
 } as Migrations;

--- a/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import migrate from './003-update-eslint-deprecation-rule.js';
+import { Context } from '../context.js';
+
+describe('003-update-eslint-deprecation-rule', () => {
+  it('should update ESLint config and package.json', () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      '.eslintrc',
+      JSON.stringify({
+        overrides: [
+          {
+            plugins: ['deprecation'],
+            files: ['src/**/*.{ts,tsx}'],
+            rules: {
+              'deprecation/deprecation': 'warn',
+            },
+          },
+        ],
+      })
+    );
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        devDependencies: {
+          'eslint-plugin-deprecation': '^2.0.0',
+          '@typescript-eslint/eslint-plugin': '^6.18.0',
+          '@typescript-eslint/parser': '^6.18.0',
+        },
+      })
+    );
+
+    const result = migrate(context);
+
+    // Check ESLint config changes
+    const eslintConfig = JSON.parse(result.getFile('.eslintrc') || '{}');
+    expect(eslintConfig.overrides[0].plugins).not.toContain('deprecation');
+    expect(eslintConfig.overrides[0].rules['deprecation/deprecation']).toBeUndefined();
+    expect(eslintConfig.overrides[0].rules['@typescript-eslint/no-deprecated']).toBe('warn');
+
+    // Check package.json changes
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+    expect(packageJson.devDependencies['eslint-plugin-deprecation']).toBeUndefined();
+    expect(packageJson.devDependencies['@typescript-eslint/eslint-plugin']).toBe('^8.3.0');
+    expect(packageJson.devDependencies['@typescript-eslint/parser']).toBe('^8.3.0');
+  });
+
+  it('should be idempotent', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      '.eslintrc',
+      JSON.stringify({
+        overrides: [
+          {
+            files: ['src/**/*.{ts,tsx}'],
+            rules: {
+              '@typescript-eslint/no-deprecated': 'warn',
+            },
+          },
+        ],
+      })
+    );
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@typescript-eslint/eslint-plugin': '^8.3.0',
+          '@typescript-eslint/parser': '^8.3.0',
+        },
+      })
+    );
+
+    await expect(migrate).toBeIdempotent(context);
+  });
+
+  it('should handle missing files gracefully', () => {
+    const context = new Context('/virtual');
+    const result = migrate(context);
+    expect(result.hasChanges()).toBe(false);
+  });
+});

--- a/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.test.ts
@@ -6,7 +6,7 @@ describe('003-update-eslint-deprecation-rule', () => {
   it('should update ESLint config and package.json', () => {
     const context = new Context('/virtual');
     context.addFile(
-      '.eslintrc',
+      '.config/.eslintrc',
       JSON.stringify({
         overrides: [
           {
@@ -33,7 +33,7 @@ describe('003-update-eslint-deprecation-rule', () => {
     const result = migrate(context);
 
     // Check ESLint config changes
-    const eslintConfig = JSON.parse(result.getFile('.eslintrc') || '{}');
+    const eslintConfig = JSON.parse(result.getFile('.config/.eslintrc') || '{}');
     expect(eslintConfig.overrides[0].plugins).not.toContain('deprecation');
     expect(eslintConfig.overrides[0].rules['deprecation/deprecation']).toBeUndefined();
     expect(eslintConfig.overrides[0].rules['@typescript-eslint/no-deprecated']).toBe('warn');
@@ -48,7 +48,7 @@ describe('003-update-eslint-deprecation-rule', () => {
   it('should be idempotent', async () => {
     const context = new Context('/virtual');
     context.addFile(
-      '.eslintrc',
+      '.config/.eslintrc',
       JSON.stringify({
         overrides: [
           {

--- a/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.test.ts
@@ -53,15 +53,26 @@ describe('003-update-eslint-deprecation-rule', () => {
 
     // Check ESLint config changes
     const eslintConfig = JSON.parse(result.getFile('.config/.eslintrc') || '{}');
-    expect(eslintConfig.overrides[0].plugins).toBeUndefined();
-    expect(eslintConfig.overrides[0].rules['deprecation/deprecation']).toBeUndefined();
-    expect(eslintConfig.overrides[0].rules['@typescript-eslint/no-deprecated']).toBe('warn');
+
+    expect(eslintConfig).toEqual({
+      overrides: [
+        {
+          files: ['src/**/*.{ts,tsx}'],
+          rules: {
+            '@typescript-eslint/no-deprecated': 'warn',
+          },
+        },
+      ],
+    });
 
     // Check package.json changes
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
-    expect(packageJson.devDependencies['eslint-plugin-deprecation']).toBeUndefined();
-    expect(packageJson.devDependencies['@typescript-eslint/eslint-plugin']).toBe('^8.3.0');
-    expect(packageJson.devDependencies['@typescript-eslint/parser']).toBe('^8.3.0');
+    expect(packageJson).toEqual({
+      devDependencies: {
+        '@typescript-eslint/eslint-plugin': '^8.3.0',
+        '@typescript-eslint/parser': '^8.3.0',
+      },
+    });
   });
 
   it('should preserve comments', async () => {

--- a/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.test.ts
@@ -53,7 +53,7 @@ describe('003-update-eslint-deprecation-rule', () => {
 
     // Check ESLint config changes
     const eslintConfig = JSON.parse(result.getFile('.config/.eslintrc') || '{}');
-    expect(eslintConfig.overrides[0].plugins).not.toContain('deprecation');
+    expect(eslintConfig.overrides[0].plugins).toBeUndefined();
     expect(eslintConfig.overrides[0].rules['deprecation/deprecation']).toBeUndefined();
     expect(eslintConfig.overrides[0].rules['@typescript-eslint/no-deprecated']).toBe('warn');
 

--- a/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.ts
+++ b/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.ts
@@ -1,14 +1,24 @@
 import type { Context } from '../context.js';
 
-export default function migrate(context: Context): Context {
+export default function migrate(context: Context) {
   if (context.doesFileExist('.config/.eslintrc')) {
-    const eslintConfig = JSON.parse(context.getFile('.config/.eslintrc') || '{}');
+    const eslintConfigRaw = context.getFile('.config/.eslintrc') || '';
+    const [eslintComments, eslintConfigJSON] = splitEslintConfig(eslintConfigRaw);
 
-    if (eslintConfig.overrides) {
+    const eslintConfig = JSON.parse(eslintConfigJSON);
+
+    const needsUpdate =
+      eslintConfig.overrides &&
+      eslintConfig.overrides.some((override: any) => override.rules?.['deprecation/deprecation']);
+
+    if (needsUpdate) {
       eslintConfig.overrides = eslintConfig.overrides.map((override: any) => {
         if (override.files?.includes('src/**/*.{ts,tsx}')) {
           if (override.plugins) {
             override.plugins = override.plugins.filter((plugin: string) => plugin !== 'deprecation');
+            if (override.plugins.length === 0) {
+              delete override.plugins;
+            }
           }
 
           if (override.rules) {
@@ -18,23 +28,45 @@ export default function migrate(context: Context): Context {
         }
         return override;
       });
+
+      const result = eslintComments.join('\n') + '\n' + JSON.stringify(eslintConfig, null, 2);
+      context.updateFile('.config/.eslintrc', result);
     }
 
-    context.updateFile('.config/.eslintrc', JSON.stringify(eslintConfig, null, 2));
-  }
+    if (context.doesFileExist('package.json')) {
+      const packageJson = JSON.parse(context.getFile('package.json') || '{}');
 
-  if (context.doesFileExist('package.json')) {
-    const packageJson = JSON.parse(context.getFile('package.json') || '{}');
+      if (packageJson.devDependencies) {
+        delete packageJson.devDependencies['eslint-plugin-deprecation'];
 
-    if (packageJson.devDependencies) {
-      delete packageJson.devDependencies['eslint-plugin-deprecation'];
+        packageJson.devDependencies['@typescript-eslint/eslint-plugin'] = '^8.3.0';
+        packageJson.devDependencies['@typescript-eslint/parser'] = '^8.3.0';
+      }
 
-      packageJson.devDependencies['@typescript-eslint/eslint-plugin'] = '^8.3.0';
-      packageJson.devDependencies['@typescript-eslint/parser'] = '^8.3.0';
+      context.updateFile('package.json', JSON.stringify(packageJson, null, 2));
     }
-
-    context.updateFile('package.json', JSON.stringify(packageJson, null, 2));
   }
 
   return context;
+}
+
+/**
+ * Splits an ESLint configuration file into comments and JSON configuration
+ * @param content The raw content of the ESLint configuration file
+ * @returns A tuple containing [comments, config] where comments is an array of comment lines and config is the JSON configuration
+ */
+export function splitEslintConfig(content: string): [string[], any] {
+  const [comments, config] = content.split('\n').reduce(
+    (acc: [string[], string], line) => {
+      if (line.trim().startsWith('/*') || line.trim().startsWith('*') || line.trim().startsWith('*/')) {
+        acc[0].push(line);
+      } else {
+        acc[1] += line + '\n';
+      }
+      return acc;
+    },
+    [[], '']
+  );
+
+  return [comments, config];
 }

--- a/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.ts
+++ b/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.ts
@@ -1,24 +1,18 @@
 import type { Context } from '../context.js';
 
 export default function migrate(context: Context): Context {
-  // Check if .eslintrc exists
-  if (context.doesFileExist('.eslintrc')) {
-    const eslintConfig = JSON.parse(context.getFile('.eslintrc') || '{}');
+  if (context.doesFileExist('.config/.eslintrc')) {
+    const eslintConfig = JSON.parse(context.getFile('.config/.eslintrc') || '{}');
 
-    // Update the overrides section if it exists
     if (eslintConfig.overrides) {
       eslintConfig.overrides = eslintConfig.overrides.map((override: any) => {
         if (override.files?.includes('src/**/*.{ts,tsx}')) {
-          // Remove deprecation plugin if it exists
           if (override.plugins) {
             override.plugins = override.plugins.filter((plugin: string) => plugin !== 'deprecation');
           }
 
-          // Update rules
           if (override.rules) {
-            // Remove old deprecation rule
             delete override.rules['deprecation/deprecation'];
-            // Add new TypeScript ESLint rule
             override.rules['@typescript-eslint/no-deprecated'] = 'warn';
           }
         }
@@ -26,18 +20,15 @@ export default function migrate(context: Context): Context {
       });
     }
 
-    context.updateFile('.eslintrc', JSON.stringify(eslintConfig, null, 2));
+    context.updateFile('.config/.eslintrc', JSON.stringify(eslintConfig, null, 2));
   }
 
-  // Update package.json to remove eslint-plugin-deprecation and update @typescript-eslint versions
   if (context.doesFileExist('package.json')) {
     const packageJson = JSON.parse(context.getFile('package.json') || '{}');
 
     if (packageJson.devDependencies) {
-      // Remove eslint-plugin-deprecation
       delete packageJson.devDependencies['eslint-plugin-deprecation'];
 
-      // Update @typescript-eslint versions
       packageJson.devDependencies['@typescript-eslint/eslint-plugin'] = '^8.3.0';
       packageJson.devDependencies['@typescript-eslint/parser'] = '^8.3.0';
     }

--- a/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.ts
+++ b/packages/create-plugin/src/migrations/scripts/003-update-eslint-deprecation-rule.ts
@@ -1,0 +1,49 @@
+import type { Context } from '../context.js';
+
+export default function migrate(context: Context): Context {
+  // Check if .eslintrc exists
+  if (context.doesFileExist('.eslintrc')) {
+    const eslintConfig = JSON.parse(context.getFile('.eslintrc') || '{}');
+
+    // Update the overrides section if it exists
+    if (eslintConfig.overrides) {
+      eslintConfig.overrides = eslintConfig.overrides.map((override: any) => {
+        if (override.files?.includes('src/**/*.{ts,tsx}')) {
+          // Remove deprecation plugin if it exists
+          if (override.plugins) {
+            override.plugins = override.plugins.filter((plugin: string) => plugin !== 'deprecation');
+          }
+
+          // Update rules
+          if (override.rules) {
+            // Remove old deprecation rule
+            delete override.rules['deprecation/deprecation'];
+            // Add new TypeScript ESLint rule
+            override.rules['@typescript-eslint/no-deprecated'] = 'warn';
+          }
+        }
+        return override;
+      });
+    }
+
+    context.updateFile('.eslintrc', JSON.stringify(eslintConfig, null, 2));
+  }
+
+  // Update package.json to remove eslint-plugin-deprecation and update @typescript-eslint versions
+  if (context.doesFileExist('package.json')) {
+    const packageJson = JSON.parse(context.getFile('package.json') || '{}');
+
+    if (packageJson.devDependencies) {
+      // Remove eslint-plugin-deprecation
+      delete packageJson.devDependencies['eslint-plugin-deprecation'];
+
+      // Update @typescript-eslint versions
+      packageJson.devDependencies['@typescript-eslint/eslint-plugin'] = '^8.3.0';
+      packageJson.devDependencies['@typescript-eslint/parser'] = '^8.3.0';
+    }
+
+    context.updateFile('package.json', JSON.stringify(packageJson, null, 2));
+  }
+
+  return context;
+}

--- a/packages/create-plugin/src/migrations/utils.test.ts
+++ b/packages/create-plugin/src/migrations/utils.test.ts
@@ -1,6 +1,6 @@
 import { dirSync } from 'tmp';
 import { Context } from './context.js';
-import { flushChanges, printChanges } from './utils.js';
+import { flushChanges, formatFiles, printChanges } from './utils.js';
 import { join } from 'node:path';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { readFileSync } from 'node:fs';
@@ -97,6 +97,18 @@ describe('utils', () => {
       printChanges(context, 'key', { migrationScript: 'test', description: 'test', version: '1.0.0' });
 
       expect(outputMock.logSingleLine).toHaveBeenCalledWith('No changes were made');
+    });
+  });
+
+  describe('formatFiles', () => {
+    it('should format files', async () => {
+      const context = new Context(tmpDir);
+      await context.addFile('file.json', '[{"foo":"bar", "baz": "qux"}]');
+      await context.addFile('file.txt', "file which isn't supported");
+      await formatFiles(context);
+      flushChanges(context);
+      expect(readFileSync(join(tmpDir, 'file.json'), 'utf-8')).toBe('[{ "foo": "bar", "baz": "qux" }]\n');
+      expect(readFileSync(join(tmpDir, 'file.txt'), 'utf-8')).toBe("file which isn't supported");
     });
   });
 });

--- a/packages/create-plugin/src/migrations/utils.ts
+++ b/packages/create-plugin/src/migrations/utils.ts
@@ -103,6 +103,7 @@ export async function formatFiles(context: Context) {
 }
 
 // Cache the package.json contents to avoid re-installing dependencies if the package.json hasn't changed
+// (This runs for each migration used in an update)
 let packageJsonInstallCache: string;
 
 export function installNPMDependencies(context: Context) {

--- a/packages/create-plugin/src/migrations/utils.ts
+++ b/packages/create-plugin/src/migrations/utils.ts
@@ -74,8 +74,11 @@ export async function formatFiles(context: Context) {
   for (const [filePath, { content, changeType }] of Object.entries(files)) {
     if (changeType !== 'delete' && content) {
       const prettierOptions = await prettier.resolveConfig(filePath);
-      const supported = await prettier.getFileInfo(filePath);
+      const supported = await prettier.getFileInfo(filePath, prettierOptions as any);
 
+      if (filePath.endsWith('.eslintrc')) {
+        supported.inferredParser = 'json';
+      }
       if (supported.ignored || !supported.inferredParser) {
         continue;
       }

--- a/packages/create-plugin/src/utils/utils.packageManager.ts
+++ b/packages/create-plugin/src/utils/utils.packageManager.ts
@@ -81,6 +81,23 @@ export function getPackageManagerInstallCmd(packageManagerName: string, packageM
   }
 }
 
+export function getPackageManagerSilentInstallCmd(packageManagerName: string, packageManagerVersion: string) {
+  switch (packageManagerName) {
+    case 'yarn':
+      if (lt(packageManagerVersion, '2.0.0')) {
+        return 'yarn install --silent --ignore-scripts';
+      }
+
+      return 'yarn install --silent';
+
+    case 'pnpm':
+      return 'pnpm install --no-frozen-lockfile --silent --ignore-scripts';
+
+    default:
+      return 'npm install --silent --ignore-scripts';
+  }
+}
+
 function getPackageManagerFromLockFile(): PackageManager | undefined {
   const closestLockfilePath = findUpSync([YARN_LOCKFILE, PNPM_LOCKFILE, NPM_LOCKFILE]);
   if (!Boolean(closestLockfilePath)) {

--- a/packages/create-plugin/templates/common/.config/_eslintrc
+++ b/packages/create-plugin/templates/common/.config/_eslintrc
@@ -12,10 +12,9 @@
   },
   "overrides": [
     {
-      "plugins": ["deprecation"],
       "files": ["src/**/*.{ts,tsx}"],
       "rules": {
-        "deprecation/deprecation": "warn"
+        "@typescript-eslint/no-deprecated": "warn"
       },
       "parserOptions": {
         "project": "./tsconfig.json"
@@ -24,8 +23,8 @@
     {
       "files": ["./tests/**/*"],
       "rules": {
-        "react-hooks/rules-of-hooks": "off",
-      },
+        "react-hooks/rules-of-hooks": "off"
+      }
     }
   ]
 }

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -36,8 +36,8 @@
     "@types/node": "^20.8.7",{{#if isAppType}}{{#unless useReactRouterV6}}
     "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/unless}}{{/if}}
     "@types/testing-library__jest-dom": "5.14.8",
-    "@typescript-eslint/eslint-plugin": "^6.18.0",
-    "@typescript-eslint/parser": "^6.18.0",{{#unless useExperimentalRspack}}
+    "@typescript-eslint/eslint-plugin": "^8.3.0",
+    "@typescript-eslint/parser": "^8.3.0",{{#unless useExperimentalRspack}}
     "copy-webpack-plugin": "^11.0.0",{{/unless}}
     "css-loader": "^6.7.3",
     "eslint": "^8.0.0",
@@ -45,7 +45,6 @@
     "eslint-plugin-jsdoc": "^46.8.0",
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-deprecation": "^2.0.0",
     "eslint-webpack-plugin": "^4.0.1",{{#unless useExperimentalRspack}}
     "fork-ts-checker-webpack-plugin": "^8.0.0",{{/unless}}
     "glob": "^10.2.7",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -41,6 +41,7 @@ if (pkg.name === '@grafana/create-plugin') {
   };
   const migrations = glob.sync('**/*.ts', globOptions).map((m) => m.toString());
   input.push(...migrations);
+  external.push('prettier');
 }
 
 if (pkg.dependencies) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Whilst working on getting ESLint 9 support into create plugin I discovered the deprecation eslint plugin we use to warn plugin devs they're using deprecated APIs is archived and (ironically) deprecated in favour of `@typescript-eslint/no-deprecated` rule.

This PR removes the deprecation eslint plugin, updates the eslintrc, adds a migration, and introduces a few utils / helpers for migrations:

- `formatFiles` - util function for formatting all files (that prettier can parse) in the context before writing to disk.
- `installNPMDependencies` package manager installation util to install updates after manager writes files to disk. This has a very crude cache to bypass running installation commands if the package.json hasn't changed since last run. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #879

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.25.0-canary.1883.15868693294.0
  npm install @grafana/eslint-plugin-plugins@0.4.0-canary.1883.15868693294.0
  npm install @grafana/plugin-meta-extractor@0.8.0-canary.1883.15868693294.0
  # or 
  yarn add @grafana/create-plugin@5.25.0-canary.1883.15868693294.0
  yarn add @grafana/eslint-plugin-plugins@0.4.0-canary.1883.15868693294.0
  yarn add @grafana/plugin-meta-extractor@0.8.0-canary.1883.15868693294.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
