### PR TITLE
fix: don't exit Webpack on ESLint error in development

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -256,6 +256,7 @@ const config = async (env: Env): Promise<Configuration> => {
         new ESLintPlugin({
           extensions: ['.ts', '.tsx'],
           lintDirtyModulesOnly: Boolean(env.development), // don't lint on start, only lint changed files
+          failOnError: Boolean(env.production),
         }),
       ] : []),
     ],


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/webpack-contrib/eslint-webpack-plugin/pull/275 fixed the default behaviour to now fail on error, which is quite annoying in development.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.22.5-canary.1890.15645459200.0
  # or 
  yarn add @grafana/create-plugin@5.22.5-canary.1890.15645459200.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
