### PR TITLE
Docs: Add clean up docs when publishing fails

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
   - [Contribute Code](#contribute-code)
 - Manage Something ✅🙆🏼💃👔
   - [Create a Release](#create-a-release)
-    - [Release Version Calculation](#release-version-calculation)- [How do I... ](#how-do-i-)
+    - [Release Version Calculation](#release-version-calculation)
     - [Help! The release failed after the packages were published to the NPM registry](#help-the-release-failed-after-the-packages-were-published-to-the-npm-registry)
 
 ## Introduction

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,8 @@
   - [Contribute Code](#contribute-code)
 - Manage Something ✅🙆🏼💃👔
   - [Create a Release](#create-a-release)
-    - [Release Version Calculation](#release-version-calculation)
+    - [Release Version Calculation](#release-version-calculation)- [How do I... ](#how-do-i-)
+    - [Help! The release failed after the packages were published to the NPM registry](#help-the-release-failed-after-the-packages-were-published-to-the-npm-registry)
 
 ## Introduction
 
@@ -208,7 +209,10 @@ To sync the repo with the latest release(s) on the NPM registry we need to intro
 - Locate the failed release workflow step from the `main` commit history.
 - Search the logs for `Commit  - @grafana/` to find the versions and `git tag` commands for each package that was published to the NPM registry.
 - Search the logs for `New Release Notes` to find the release notes markdown.
-- Checkout `main` (:scream:)
+- Checkout `main`.
 - For each published package update it's `changelog.md` file in the repo using the release notes markdown as a guide. It will not match each changelog file perfectly but the older entries can be used to match formatting. Now update the repos root `changelog.md` file, matching the formatting using older entries. Commit this to `main` with `git commit -m "Update CHANGELOG.md [skip ci]"`. ([example commit](https://github.com/grafana/plugin-tools/commit/e8b980e25e8752aaab9278cb43228f44733ca96f))
 - Update each published packages `package.json` file so the version matches the version published to the registry. Once done run `npm install`. Commit this to `main` with `git commit -m "Bump independent versions [skip ci]"`.
 - Now tag this version bump commit with the tag commands from the failed release workflow step. Tag the commit for each published package. The command should look like `git tag -a @grafana/create-plugin@<UPDATED_VERSION> -m "@grafana/create-plugin@<UPDATED_VERSION>"`. ([example commit](https://github.com/grafana/plugin-tools/commit/e8b980e25e8752aaab9278cb43228f44733ca96f))
+- Go to the [plugin-tools tags page](https://github.com/grafana/plugin-tools/tags) and delete any existing tags that match the versions of the packages that were released.
+- Once the tags are deleted push the commits and the tags from `main` to gh with `git push --follow-tags`.
+- Lastly create the GH releases for the packages from the [Github releases page](https://github.com/grafana/plugin-tools/releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,14 +199,16 @@ Below is a bulleted list of what occurs under the hood when Auto is asked to rel
 > [!TIP]
 > We enable verbose logging in the release packages CI step to give plenty of information related to what Auto and Lerna are doing. This can prove most useful should issues occur with releasing packages.
 
-### Help! The release failed but the packages were published to the NPM registry
+### Help! The release failed after the packages were published to the NPM registry
 
-If a release fails but the packages were published to the NPM registry manual clean up will be required to sync the repo to the NPM registry before the next publish occurs otherwise further failures or potentially major releases containing duplicate version calculations could be pushed to the NPM registry.
+If the release step fails after the packages were published to the NPM registry manual clean up is required to sync the repo to the NPM registry before the next publish occurs otherwise further failures or potentially major releases containing duplicate version calculations could be pushed to the NPM registry.
 
-To sync the repo with the latest release(s) on the NPM registry we need to introduce commits, tags and gh releases that mimick what Auto _would_ have done had the publish command completed fully. Auto relies on the last GH release information taken from https://github.com/grafana/plugin-tools/releases to know which PRs it needs to collect to calculate the version. Once it has this Lerna receives both the latest release tag and the calculated version bump from Auto.
+To sync the repo with the latest release(s) on the NPM registry we need to introduce the commits, tags and gh releases Auto _would_ have pushed had the publish command completed fully.
 
-- Check the logs from the release workflow step to understand what was published to NPM
-- Check the plugin-tools repo for tags associated with the versions that were published to NPM
-- Clicking the tags should lead to the commit
-- Clicking the parent of the tag commit will reveal the changelog changes
-- Checkout `main`
+- Locate the failed release workflow step from the `main` commit history.
+- Search the logs for `Commit  - @grafana/` to find the versions and `git tag` commands for each package that was published to the NPM registry.
+- Search the logs for `New Release Notes` to find the release notes markdown.
+- Checkout `main` (:scream:)
+- For each published package update it's `changelog.md` file in the repo using the release notes markdown as a guide. It will not match each changelog file perfectly but the older entries can be used to match formatting. Now update the repos root `changelog.md` file, matching the formatting using older entries. Commit this to `main` with `git commit -m "Update CHANGELOG.md [skip ci]"`. ([example commit](https://github.com/grafana/plugin-tools/commit/e8b980e25e8752aaab9278cb43228f44733ca96f))
+- Update each published packages `package.json` file so the version matches the version published to the registry. Once done run `npm install`. Commit this to `main` with `git commit -m "Bump independent versions [skip ci]"`.
+- Now tag this version bump commit with the tag commands from the failed release workflow step. Tag the commit for each published package. The command should look like `git tag -a @grafana/create-plugin@<UPDATED_VERSION> -m "@grafana/create-plugin@<UPDATED_VERSION>"`. ([example commit](https://github.com/grafana/plugin-tools/commit/e8b980e25e8752aaab9278cb43228f44733ca96f))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,3 +198,15 @@ Below is a bulleted list of what occurs under the hood when Auto is asked to rel
 
 > [!TIP]
 > We enable verbose logging in the release packages CI step to give plenty of information related to what Auto and Lerna are doing. This can prove most useful should issues occur with releasing packages.
+
+### Help! The release failed but the packages were published to the NPM registry
+
+If a release fails but the packages were published to the NPM registry manual clean up will be required to sync the repo to the NPM registry before the next publish occurs otherwise further failures or potentially major releases containing duplicate version calculations could be pushed to the NPM registry.
+
+To sync the repo with the latest release(s) on the NPM registry we need to introduce commits, tags and gh releases that mimick what Auto _would_ have done had the publish command completed fully. Auto relies on the last GH release information taken from https://github.com/grafana/plugin-tools/releases to know which PRs it needs to collect to calculate the version. Once it has this Lerna receives both the latest release tag and the calculated version bump from Auto.
+
+- Check the logs from the release workflow step to understand what was published to NPM
+- Check the plugin-tools repo for tags associated with the versions that were published to NPM
+- Clicking the tags should lead to the commit
+- Clicking the parent of the tag commit will reveal the changelog changes
+- Checkout `main`


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Auto and Lerna keep versioning and the repo in sync using git tags and gh releases. Should an npm package be published to the npm registry but the following steps that push versioning commits, tags and create the gh releases fail manual clean up is required to mimic Auto and Lerna automations.

This PR adds docs to explain what to do should this occur.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
