### PR TITLE
Fix: remove unused bundler configs on update

### DIFF
--- a/packages/create-plugin/src/commands/update.standard.command.ts
+++ b/packages/create-plugin/src/commands/update.standard.command.ts
@@ -25,7 +25,7 @@ export const standardUpdate = async () => {
 
     const filesToRemove = getOnlyExistingInCwd(UDPATE_CONFIG.filesToRemove);
 
-    // Standard Update command rewrites the entire .config directory, so depending on the user's
+    // Standard update command rewrites the entire .config directory, so depending on the user's
     // choice of bundler we need to remove one of the directories.
     if (Boolean(getConfig().features.useExperimentalRspack)) {
       filesToRemove.push('./.config/webpack');

--- a/packages/create-plugin/src/commands/update.standard.command.ts
+++ b/packages/create-plugin/src/commands/update.standard.command.ts
@@ -25,9 +25,14 @@ export const standardUpdate = async () => {
 
     const filesToRemove = getOnlyExistingInCwd(UDPATE_CONFIG.filesToRemove);
 
+    // Standard Update command rewrites the entire .config directory, so depending on the user's
+    // choice of bundler we need to remove one of the directories.
     if (Boolean(getConfig().features.useExperimentalRspack)) {
-      filesToRemove.push('./config/webpack');
+      filesToRemove.push('./.config/webpack');
+    } else {
+      filesToRemove.push('./.config/rspack');
     }
+
     if (filesToRemove.length) {
       removeFilesInCwd(filesToRemove);
     }


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes the create-plugin update command from writing out rspack configs on update regardless of rspack feature flag settings.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.23.2-canary.1907.15725094649.0
  # or 
  yarn add @grafana/create-plugin@5.23.2-canary.1907.15725094649.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
