### PR TITLE
Replace direct call to levitate with usage of is-compatible github workflow

### DIFF
--- a/packages/create-plugin/CONTRIBUTING.md
+++ b/packages/create-plugin/CONTRIBUTING.md
@@ -226,6 +226,6 @@ describe('Migration - append profile to webpack', () => {
 
 To test a migration locally you'll need a plugin to test on.
 
-- Change the create-plugin package.json to a newer version (same as your migration works fine)
+- Bump the version of create-plugin _(This can be necessary if your plugin was already updated using the latest create-plugin version.)_
 - Verify that the `.config/.cprc.json` in your plugin has a version that is lower than the bumped create-plugin version _(The `.cprc.json` holds the version of create-plugin that was used to scaffold / last update the plugin)
 - Run `npx create-plugin update --experimentalUpdates` in your plugin (see instructions on how to link your create-plugin dev version)

--- a/packages/create-plugin/CONTRIBUTING.md
+++ b/packages/create-plugin/CONTRIBUTING.md
@@ -227,5 +227,5 @@ describe('Migration - append profile to webpack', () => {
 To test a migration locally you'll need a plugin to test on.
 
 - Change the create-plugin package.json to a newer version (same as your migration works fine)
-- Verify the `.config/.cprc.json` of the plugin you are testing on is less than the create-plugin version
+- Verify that the `.config/.cprc.json` in your plugin has a version that is lower than the bumped create-plugin version _(The `.cprc.json` holds the version of create-plugin that was used to scaffold / last update the plugin)
 - Run `npx create-plugin update --experimentalUpdates` in your plugin (see instructions on how to link your create-plugin dev version)

--- a/packages/create-plugin/CONTRIBUTING.md
+++ b/packages/create-plugin/CONTRIBUTING.md
@@ -226,6 +226,6 @@ describe('Migration - append profile to webpack', () => {
 
 To test a migration locally you'll need a plugin to test on.
 
-- Change the create-plugin pacakge.json to a newer version (same as your migration works fine)
+- Change the create-plugin package.json to a newer version (same as your migration works fine)
 - Verify the `.config/.cprc.json` of the plugin you are testing on is less than the create-plugin version
 - Run `npx create-plugin update --experimentalUpdates` (see instructions on how to link your create-plugin dev version)

--- a/packages/create-plugin/CONTRIBUTING.md
+++ b/packages/create-plugin/CONTRIBUTING.md
@@ -167,7 +167,7 @@ The update command follows these steps:
    }
    ```
 
-#### How to test a migration?
+#### How to write tests for a migration?
 
 Migrations should be thoroughly tested using the provided testing utilities. Create a test file alongside your migration script (e.g., `add-webpack-profile.test.ts`).
 
@@ -221,3 +221,11 @@ describe('Migration - append profile to webpack', () => {
   });
 });
 ```
+
+#### How to test a migration locally
+
+To test a migration locally you'll need a plugin to test on.
+
+- Change the create-plugin pacakge.json to a newer version (same as your migration works fine)
+- Verify the `.config/.cprc.json` of the plugin you are testing on is less than the create-plugin version
+- Run `npx create-plugin update --experimentalUpdates` (see instructions on how to link your create-plugin dev version)

--- a/packages/create-plugin/CONTRIBUTING.md
+++ b/packages/create-plugin/CONTRIBUTING.md
@@ -228,4 +228,4 @@ To test a migration locally you'll need a plugin to test on.
 
 - Change the create-plugin package.json to a newer version (same as your migration works fine)
 - Verify the `.config/.cprc.json` of the plugin you are testing on is less than the create-plugin version
-- Run `npx create-plugin update --experimentalUpdates` (see instructions on how to link your create-plugin dev version)
+- Run `npx create-plugin update --experimentalUpdates` in your plugin (see instructions on how to link your create-plugin dev version)

--- a/packages/create-plugin/src/migrations/migrations.ts
+++ b/packages/create-plugin/src/migrations/migrations.ts
@@ -21,5 +21,11 @@ export default {
       description: 'Update ./docker-compose.yaml to extend from ./.config/docker-compose-base.yaml.',
       migrationScript: './scripts/001-update-grafana-compose-extend.js',
     },
+    '002-update-is-compatible-workflow': {
+      version: '5.23.2',
+      description:
+        'Update ./.github/workflows/is-compatible.yml to use is-compatible github action instead of calling levitate directly',
+      migrationScript: './scripts/002-update-is-compatible-workflow.js',
+    },
   },
 } as Migrations;

--- a/packages/create-plugin/src/migrations/migrations.ts
+++ b/packages/create-plugin/src/migrations/migrations.ts
@@ -22,7 +22,7 @@ export default {
       migrationScript: './scripts/001-update-grafana-compose-extend.js',
     },
     '002-update-is-compatible-workflow': {
-      version: '5.23.2',
+      version: '5.24.0',
       description:
         'Update ./.github/workflows/is-compatible.yml to use is-compatible github action instead of calling levitate directly',
       migrationScript: './scripts/002-update-is-compatible-workflow.js',

--- a/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
@@ -69,7 +69,7 @@ jobs:
     expect(context.listChanges()).toEqual(initialChanges);
   });
 
-  it('should update the compatibility check step with the new pattern', async () => {
+  it.only('should update the compatibility check step with the new pattern', async () => {
     const context = new Context('/virtual');
     context.addFile(
       './.github/workflows/is-compatible.yml',
@@ -107,7 +107,9 @@ jobs:
     expect(migrated.jobs.compatibilitycheck.steps[4]).toEqual({
       name: 'Find module.ts or module.tsx',
       id: 'find-module-ts',
-      run: 'MODULETS="$(find ./src -type f ( -name "module.ts" -o -name "module.tsx" ))"\necho "modulets=${MODULETS}" >> $GITHUB_OUTPUT',
+      // notice the double backslash `\\(`  even though the actual file has only `\(`
+      // this is because `parse` will return the strings escaped and as we are comparing strings directly we also have to escape it
+      run: 'MODULETS="$(find ./src -type f \\( -name "module.ts" -o -name "module.tsx" \\))"\necho "modulets=${MODULETS}" >> $GITHUB_OUTPUT',
     });
 
     expect(migrated.jobs.compatibilitycheck.steps[5]).toEqual({

--- a/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Context } from '../context.js';
 import migrate from './002-update-is-compatible-workflow.js';
-import { parse, stringify } from 'yaml';
+import { parse } from 'yaml';
 
 describe('002-update-is-compatible-workflow', () => {
   it('should not modify anything if workflow file does not exist', async () => {

--- a/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
@@ -69,7 +69,7 @@ jobs:
     expect(context.listChanges()).toEqual(initialChanges);
   });
 
-  it.only('should update the compatibility check step with the new pattern', async () => {
+  it('should update the compatibility check step with the new pattern', async () => {
     const context = new Context('/virtual');
     context.addFile(
       './.github/workflows/is-compatible.yml',

--- a/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Context } from '../context.js';
 import migrate from './002-update-is-compatible-workflow.js';
-import { parse } from 'yaml';
+import { parse, stringify } from 'yaml';
 
 describe('002-update-is-compatible-workflow', () => {
   it('should not modify anything if workflow file does not exist', async () => {
@@ -162,5 +162,48 @@ jobs:
     expect(steps[2].name).toBe('Install dependencies');
     expect(steps[steps.length - 1].name).toBe('Post build summary');
     expect(steps[0].uses).toBe('actions/checkout@v4');
+  });
+
+  it('should be idempotent', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './.github/workflows/is-compatible.yml',
+      `name: Latest Grafana API compatibility check
+on:
+  - pull_request
+jobs:
+  compatibilitycheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Node.js environment
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build plugin
+        run: npm run build
+      - name: Find module.ts or module.tsx
+        id: find-module-ts
+        run: >-
+          MODULETS="$(find ./src -type f ( -name "module.ts" -o -name
+          "module.tsx" ))"
+
+          echo "modulets=$\{MODULETS}" >> $GITHUB_OUTPUT
+      - name: Compatibility check
+        uses: grafana/plugin-actions/is-compatible@main
+        with:
+          module: $\{{ steps.find-module-ts.outputs.modulets }}
+          comment-pr: no
+          fail-if-incompatible: yes
+`
+    );
+    await expect(migrate).toBeIdempotent(context);
   });
 });

--- a/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { Context } from '../context.js';
+import migrate from './002-update-is-compatible-workflow.js';
+import { parse } from 'yaml';
+
+describe('002-update-is-compatible-workflow', () => {
+  it('should not modify anything if workflow file does not exist', async () => {
+    const context = new Context('/virtual');
+    await migrate(context);
+    expect(context.listChanges()).toEqual({});
+  });
+
+  it('should not modify anything if workflow file is empty', async () => {
+    const context = new Context('/virtual');
+    context.addFile('./.github/workflows/is-compatible.yml', '');
+    const initialChanges = context.listChanges();
+    await migrate(context);
+    expect(context.listChanges()).toEqual(initialChanges);
+  });
+
+  it('should not modify anything if jobs section is missing', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './.github/workflows/is-compatible.yml',
+      `name: Latest Grafana API compatibility check
+on: [pull_request]
+`
+    );
+    const initialChanges = context.listChanges();
+    await migrate(context);
+    expect(context.listChanges()).toEqual(initialChanges);
+  });
+
+  it('should not modify anything if compatibilitycheck job is missing', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './.github/workflows/is-compatible.yml',
+      `name: Latest Grafana API compatibility check
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+`
+    );
+    const initialChanges = context.listChanges();
+    await migrate(context);
+    expect(context.listChanges()).toEqual(initialChanges);
+  });
+
+  it('should not modify anything if compatibility check step is not found', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './.github/workflows/is-compatible.yml',
+      `name: Latest Grafana API compatibility check
+on: [pull_request]
+jobs:
+  compatibilitycheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build plugin
+        run: {{ packageManagerName }} run build
+`
+    );
+    const initialChanges = context.listChanges();
+    await migrate(context);
+    expect(context.listChanges()).toEqual(initialChanges);
+  });
+
+  it('should update the compatibility check step with the new pattern', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './.github/workflows/is-compatible.yml',
+      `name: Latest Grafana API compatibility check
+on: [pull_request]
+
+jobs:
+  compatibilitycheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Node.js environment
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build plugin
+        run: npm run build
+      - name: Compatibility check
+        run: npx --yes @grafana/levitate@latest is-compatible --path $(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \)) --target @grafana/data,@grafana/ui,@grafana/runtime
+`
+    );
+
+    await migrate(context);
+
+    const migratedContent = context.getFile('./.github/workflows/is-compatible.yml') || '';
+    const migrated = parse(migratedContent);
+
+    expect(migrated.jobs.compatibilitycheck.steps[4]).toEqual({
+      name: 'Find module.ts or module.tsx',
+      id: 'find-module-ts',
+      run: 'MODULETS="$(find ./src -type f ( -name "module.ts" -o -name "module.tsx" ))"\necho "modulets=${MODULETS}" >> $GITHUB_OUTPUT',
+    });
+
+    expect(migrated.jobs.compatibilitycheck.steps[5]).toEqual({
+      name: 'Compatibility check',
+      uses: 'grafana/plugin-actions/is-compatible@main',
+      with: {
+        'fail-if-incompatible': 'yes',
+        'comment-pr': 'no',
+        module: '${{ steps.find-module-ts.outputs.modulets }}',
+      },
+    });
+  });
+
+  it('should preserve other steps in the workflow', async () => {
+    const context = new Context('/virtual');
+    const originalWorkflow = `name: Latest Grafana API compatibility check
+on: [pull_request]
+
+jobs:
+  compatibilitycheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Setup Node.js environment
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build plugin
+        run: npm run build
+      - name: Compatibility check
+        run: npx --yes @grafana/levitate@latest is-compatible --path $(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \)) --target @grafana/data,@grafana/ui,@grafana/runtime
+      - name: Post build summary
+        run: echo "Build completed successfully" >> $GITHUB_STEP_SUMMARY
+`;
+
+    context.addFile('./.github/workflows/is-compatible.yml', originalWorkflow);
+
+    await migrate(context);
+
+    const migratedContent = context.getFile('./.github/workflows/is-compatible.yml') || '';
+    const migrated = parse(migratedContent);
+    const steps = migrated.jobs.compatibilitycheck.steps;
+    expect(Array.isArray(steps)).toBe(true);
+    expect(steps.length).toBeGreaterThan(0);
+    expect(steps[2].name).toBe('Install dependencies');
+    expect(steps[steps.length - 1].name).toBe('Post build summary');
+    expect(steps[0].uses).toBe('actions/checkout@v4');
+  });
+});

--- a/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.ts
+++ b/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.ts
@@ -1,0 +1,64 @@
+import { type Context } from '../context.js';
+import { parseDocument, stringify, YAMLSeq } from 'yaml';
+
+export default async function migrate(context: Context) {
+  const workflowPath = './.github/workflows/is-compatible.yml';
+
+  if (!context.doesFileExist(workflowPath)) {
+    return context;
+  }
+
+  const workflowContent = context.getFile(workflowPath);
+
+  if (!workflowContent) {
+    return context;
+  }
+
+  const workflowDoc = parseDocument(workflowContent);
+  const jobs = workflowDoc.getIn(['jobs']);
+
+  if (!jobs) {
+    return context;
+  }
+
+  // Find the jobs.compatibilitycheck.steps sequence
+  const steps = workflowDoc.getIn(['jobs', 'compatibilitycheck', 'steps']);
+
+  if (!(steps instanceof YAMLSeq)) {
+    return context;
+  }
+
+  // Find the compatibility check step (case insensitive)
+  const compatibilityStepIndex = steps.items.findIndex((step) => {
+    const nameValue = step?.get('name')?.toString().toLowerCase();
+    return nameValue && nameValue.includes('compatibility check');
+  });
+
+  // If we found the step, replace it with the two new steps
+  if (compatibilityStepIndex !== -1) {
+    // Create the two new steps
+    const findModuleStep = {
+      name: 'Find module.ts or module.tsx',
+      id: 'find-module-ts',
+      run: 'MODULETS="$(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \))"\necho "modulets=${MODULETS}" >> $GITHUB_OUTPUT',
+    };
+
+    const compatibilityStep = {
+      name: 'Compatibility check',
+      uses: 'grafana/plugin-actions/is-compatible@main',
+      with: {
+        module: '${{ steps.find-module-ts.outputs.modulets }}',
+        'comment-pr': 'no',
+        'fail-if-incompatible': 'yes',
+      },
+    };
+
+    // Replace the old step with the two new steps
+    steps.items.splice(compatibilityStepIndex, 1, findModuleStep, compatibilityStep);
+
+    // Write the updated workflow back to the file
+    context.updateFile(workflowPath, stringify(workflowDoc));
+  }
+
+  return context;
+}

--- a/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.ts
+++ b/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.ts
@@ -36,6 +36,16 @@ export default async function migrate(context: Context) {
 
   // If we found the step, replace it with the two new steps
   if (compatibilityStepIndex !== -1) {
+    // check if find module.ts step already exists
+    // meaning the migration has already been applied
+    const findModuleStepIndex = steps.items.findIndex((step) => {
+      const nameValue = step?.get('name')?.toString().toLowerCase();
+      return nameValue && nameValue.includes('find module.ts');
+    });
+    if (findModuleStepIndex !== -1) {
+      return context;
+    }
+
     // Create the two new steps
     const findModuleStep = {
       name: 'Find module.ts or module.tsx',

--- a/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.ts
+++ b/packages/create-plugin/src/migrations/scripts/002-update-is-compatible-workflow.ts
@@ -50,7 +50,7 @@ export default async function migrate(context: Context) {
     const findModuleStep = {
       name: 'Find module.ts or module.tsx',
       id: 'find-module-ts',
-      run: 'MODULETS="$(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \))"\necho "modulets=${MODULETS}" >> $GITHUB_OUTPUT',
+      run: 'MODULETS="$(find ./src -type f \\( -name "module.ts" -o -name "module.tsx" \\))"\necho "modulets=${MODULETS}" >> $GITHUB_OUTPUT',
     };
 
     const compatibilityStep = {

--- a/packages/create-plugin/templates/github/workflows/is-compatible.yml
+++ b/packages/create-plugin/templates/github/workflows/is-compatible.yml
@@ -28,5 +28,16 @@ jobs:
 
       - name: Build plugin
         run: {{ packageManagerName }} run build
+
+      - name: Find module.ts or module.tsx
+        id: find-module-ts
+        run: |
+          MODULETS="$(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \))"
+          echo "modulets=${MODULETS}" >> $GITHUB_OUTPUT
+
       - name: Compatibility check
-        run: npx --yes @grafana/levitate@latest is-compatible --path $(find ./src -type f \( -name "module.ts" -o -name "module.tsx" \)) --target @grafana/data,@grafana/ui,@grafana/runtime
+        uses: grafana/plugin-actions/is-compatible@main
+        with:
+          module: $\{{ steps.find-module-ts.outputs.modulets }}
+          comment-pr: "no"
+          fail-if-incompatible: "yes"


### PR DESCRIPTION
**What this PR does / why we need it**:

It replaces the direct levitate call with our own github action is-compatible 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.24.0-canary.1909.15779152467.0
  npm install @grafana/plugin-e2e@2.1.0-canary.1909.15779152467.0
  # or 
  yarn add @grafana/create-plugin@5.24.0-canary.1909.15779152467.0
  yarn add @grafana/plugin-e2e@2.1.0-canary.1909.15779152467.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
