### PR TITLE
Add useExperimentalUpdates to feature flags for migration adoption

### DIFF
--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -4,6 +4,7 @@ import { migrationUpdate } from './update.migrate.command.js';
 import { isGitDirectory, isGitDirectoryClean } from '../utils/utils.git.js';
 import { output } from '../utils/utils.console.js';
 import { isPluginDirectory } from '../utils/utils.plugin.js';
+import { getConfig } from '../utils/utils.config.js';
 
 export const update = async (argv: minimist.ParsedArgs) => {
   if (!(await isGitDirectory()) && !argv.force) {
@@ -46,7 +47,7 @@ export const update = async (argv: minimist.ParsedArgs) => {
     process.exit(1);
   }
 
-  if (argv.experimentalUpdates) {
+  if (argv.experimentalUpdates || getConfig().features.useExperimentalUpdates) {
     return await migrationUpdate(argv);
   }
 

--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -48,6 +48,7 @@ export const DEFAULT_FEATURE_FLAGS = {
   bundleGrafanaUI: false,
   usePlaywright: true,
   useExperimentalRspack: false,
+  useExperimentalUpdates: false,
 };
 
 export const GRAFANA_FE_PACKAGES = [

--- a/packages/create-plugin/src/utils/utils.config.ts
+++ b/packages/create-plugin/src/utils/utils.config.ts
@@ -15,6 +15,7 @@ export type FeatureFlags = {
   useReactRouterV6?: boolean;
   usePlaywright?: boolean;
   useExperimentalRspack?: boolean;
+  useExperimentalUpdates?: boolean;
 };
 
 export type CreatePluginConfig = UserConfig & {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Adds `useExperimentalUpdates` to create-plugin feature flags so plugin devs can persist migration updates to test out the functionality via the `.cprc.json` file.

```
{
  "features": {
    "useExperimentalUpdates": true
  }
}
```

Thanks for suggesting this change @hugohaggmark ! 🥳 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@3.6.7-canary.1935.15968700885.0
  npm install @grafana/create-plugin@5.25.1-canary.1935.15968700885.0
  npm install @grafana/plugin-e2e@2.1.2-canary.1935.15968700885.0
  npm install @grafana/plugin-types-bundler@0.4.1-canary.1935.15968700885.0
  # or 
  yarn add website@3.6.7-canary.1935.15968700885.0
  yarn add @grafana/create-plugin@5.25.1-canary.1935.15968700885.0
  yarn add @grafana/plugin-e2e@2.1.2-canary.1935.15968700885.0
  yarn add @grafana/plugin-types-bundler@0.4.1-canary.1935.15968700885.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
