### PR TITLE
Website: Stop showing bun commands

### DIFF
--- a/docusaurus/docs/publish-a-plugin/package-a-plugin.md
+++ b/docusaurus/docs/publish-a-plugin/package-a-plugin.md
@@ -13,17 +13,18 @@ keywords:
   - packages
 ---
 
-import BuildNPM from '@shared/createplugin-build-ci.md';
-
 # Package a plugin
 
 Package a plugin to organize the plugin code and make it ready for use in your organization. Follow these steps to package the plugin in a ZIP file.
 
 1. Build the plugin
 
-   <BuildNPM />
+   ```shell npm2yarn
+    npm install
+    npm run build
+   ```
 
-1. Optional: If your data source plugin has a backend plugin, build it as well.
+2. Optional: If your plugin has a backend, build it as well.
 
    ```
    mage
@@ -31,16 +32,16 @@ Package a plugin to organize the plugin code and make it ready for use in your o
 
    Make sure that all the binaries are executable and have a `0755` (`-rwxr-xr-x`) permission.
 
-1. Sign the plugin. To learn more, refer to [Sign a plugin](./sign-a-plugin.md).
+3. Sign the plugin. To learn more, refer to [Sign a plugin](./sign-a-plugin.md).
 
-1. Rename the `dist` directory to match your plugin ID, and then create a ZIP archive.
+4. Rename the `dist` directory to match your plugin ID, and then create a ZIP archive.
 
    ```
    mv dist/ myorg-simple-panel
    zip myorg-simple-panel-1.0.0.zip myorg-simple-panel -r
    ```
 
-1. Optional: verify that your plugin is packaged correctly using [zipinfo](https://linux.die.net/man/1/zipinfo).
+5. Optional: verify that your plugin is packaged correctly using [zipinfo](https://linux.die.net/man/1/zipinfo).
    It should look like this:
 
    ```shell

--- a/docusaurus/docs/shared/createplugin-build-ci.md
+++ b/docusaurus/docs/shared/createplugin-build-ci.md
@@ -1,4 +1,0 @@
-```shell npm2yarn
-npm ci
-npm run build
-```

--- a/docusaurus/website/docusaurus.config.ts
+++ b/docusaurus/website/docusaurus.config.ts
@@ -101,7 +101,7 @@ const config: Config = {
               },
             ],
           ],
-          remarkPlugins: [[npm2yarn, { sync: true }]],
+          remarkPlugins: [[npm2yarn, { sync: true, converters: ['yarn', 'pnpm'] }]],
           routeBasePath: '/',
         },
         theme: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

A recent release of `@docusaurus/remark-plugin-npm2yarn` has added bun as a default converter causing the site to render bun commands in the node package manager tabs. We don't officially support bun so this PR removes it from the converter list. Additionally I've deleted the `shared/createplugin-build-ci.md` file as it's only used once and moved it's contents to the call site. I've had to replace `npm ci` with `npm install` and the npm2yarn package currently doesn't support this command and spits out the comment `#couldn't auto-convert command`.

![image](https://github.com/user-attachments/assets/ad0d8106-ca38-48ae-a4ea-a211ce844e75)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
