### PR TITLE
Docs: Updates extend-configuration.md

### DIFF
--- a/docusaurus/docs/how-to-guides/extend-configuration.md
+++ b/docusaurus/docs/how-to-guides/extend-configuration.md
@@ -112,10 +112,10 @@ Use the [webpack-merge](https://github.com/survivejs/webpack-merge) package to e
 ```ts title="webpack.config.ts"
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
-import grafanaConfig from './.config/webpack/webpack.config';
+import grafanaConfig, { Env } from './.config/webpack/webpack.config';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 
-const config = async (env: Record<string, unknown>): Promise<Configuration> => {
+const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
 
   return merge(baseConfig, {
@@ -145,9 +145,9 @@ The following example excludes a "libs" directory from typescript/javascript com
 ```ts title="webpack.config.ts"
 import type { Configuration } from 'webpack';
 import { mergeWithRules } from 'webpack-merge';
-import grafanaConfig from './.config/webpack/webpack.config';
+import grafanaConfig, { Env } from './.config/webpack/webpack.config';
 
-const config = async (env: Record<string, unknown>): Promise<Configuration> => {
+const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
   const customConfig = {
     module: {
@@ -176,9 +176,9 @@ Webpack 5 does not polyfill [Node.js core modules](https://webpack.js.org/config
 ```ts title="webpack.config.ts"
 import type { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
-import grafanaConfig from './.config/webpack/webpack.config';
+import grafanaConfig, { Env } from './.config/webpack/webpack.config';
 
-const config = async (env: Record<string, unknown>): Promise<Configuration> => {
+const config = async (env: Env): Promise<Configuration> => {
   const baseConfig = await grafanaConfig(env);
 
   return merge(baseConfig, {


### PR DESCRIPTION
This pull request updates the `webpack.config.ts` examples in the `docusaurus/docs/how-to-guides/extend-configuration.md` file to improve type safety and consistency by introducing the `Env` type from the `grafanaConfig` module.

### Updates to Webpack Configuration Examples:

* Replaced the generic `Record<string, unknown>` type for the `env` parameter with the more specific `Env` type in all `webpack.config.ts` examples. This change ensures better type safety and clarity in the configuration examples. [[1]](diffhunk://#diff-afbded9179760b3170b714fee5a75a951b18b7fa474cd759c687f3d0db9783f5L115-R118) [[2]](diffhunk://#diff-afbded9179760b3170b714fee5a75a951b18b7fa474cd759c687f3d0db9783f5L148-R150) [[3]](diffhunk://#diff-afbded9179760b3170b714fee5a75a951b18b7fa474cd759c687f3d0db9783f5L179-R181)

* Updated imports in each example to include the `Env` type from `./.config/webpack/webpack.config`, aligning the examples with the new type usage. [[1]](diffhunk://#diff-afbded9179760b3170b714fee5a75a951b18b7fa474cd759c687f3d0db9783f5L115-R118) [[2]](diffhunk://#diff-afbded9179760b3170b714fee5a75a951b18b7fa474cd759c687f3d0db9783f5L148-R150) [[3]](diffhunk://#diff-afbded9179760b3170b714fee5a75a951b18b7fa474cd759c687f3d0db9783f5L179-R181)
