### PR TITLE
Create Plugin: fix migrations commit arg

### DIFF
--- a/packages/create-plugin/src/migrations/manager.test.ts
+++ b/packages/create-plugin/src/migrations/manager.test.ts
@@ -199,7 +199,7 @@ describe('Migrations', () => {
     it('should commit the changes for each migration if the CLI arg is present', async () => {
       await runMigrations(migrations, { commitEachMigration: true });
 
-      expect(gitCommitNoVerify).toHaveBeenCalledTimes(2);
+      expect(gitCommitNoVerify).toHaveBeenCalledTimes(3);
     });
 
     it('should not create a commit for a migration that has no changes', async () => {
@@ -207,7 +207,7 @@ describe('Migrations', () => {
 
       await runMigrations(migrations, { commitEachMigration: true });
 
-      expect(gitCommitNoVerify).toHaveBeenCalledTimes(1);
+      expect(gitCommitNoVerify).toHaveBeenCalledTimes(2);
     });
 
     it('should update version in ".config/.cprc.json" on a successful update', async () => {

--- a/packages/create-plugin/src/migrations/manager.ts
+++ b/packages/create-plugin/src/migrations/manager.ts
@@ -64,10 +64,12 @@ export async function runMigrations(migrations: Record<string, MigrationMeta>, o
       }
     }
   }
-  setRootConfig({ version: Object.values(migrations).at(-1)!.version });
+
+  const latestVersion = Object.values(migrations).at(-1)!.version;
+  setRootConfig({ version: latestVersion });
 
   if (options.commitEachMigration) {
-    await gitCommitNoVerify(`chore: update .config/.cprc.json to latest version.`);
+    await gitCommitNoVerify(`chore: update .config/.cprc.json to version ${latestVersion}.`);
   }
 }
 

--- a/packages/create-plugin/src/migrations/manager.ts
+++ b/packages/create-plugin/src/migrations/manager.ts
@@ -65,6 +65,10 @@ export async function runMigrations(migrations: Record<string, MigrationMeta>, o
     }
   }
   setRootConfig({ version: Object.values(migrations).at(-1)!.version });
+
+  if (options.commitEachMigration) {
+    await gitCommitNoVerify(`chore: update .config/.cprc.json to latest version.`);
+  }
 }
 
 export async function runMigration(migration: MigrationMeta, context: Context): Promise<Context> {

--- a/packages/create-plugin/src/utils/utils.git.ts
+++ b/packages/create-plugin/src/utils/utils.git.ts
@@ -31,7 +31,7 @@ export async function isGitDirectoryClean() {
 export async function gitCommitNoVerify(commitMsg: string) {
   try {
     let addAllCommand = 'git add -A';
-    let commitCommand = `git commit --no-verify -m ${commitMsg}`;
+    let commitCommand = `git commit --no-verify -m '${commitMsg}'`;
 
     await exec(addAllCommand);
     await exec(commitCommand);


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes two issues with the `--commit` arg that tells "update as migrations" to git commit after each migration has run.

1. Errors due to commit message not being treated as a literal string. 

```
Error running migration "003-update-eslint-deprecation-rule (./scripts/003-update-eslint-deprecation-rule.js)": Error committing changes:
Command failed: git commit --no-verify -m chore: run create-plugin migration - 003-update-eslint-deprecation-rule (./scripts/003-update-eslint-deprecation-rule.js)
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `git commit --no-verify -m chore: run create-plugin migration - 003-update-eslint-deprecation-rule (./scripts/003-update-eslint-deprecation-
```

2. Not committing the version update (done once all migrations have run) to `.config/.cprc.json` which leaves the branch in a modified state.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.25.6-canary.1971.16438156962.0
  npm install @grafana/plugin-meta-extractor@0.8.3-canary.1971.16438156962.0
  # or 
  yarn add @grafana/create-plugin@5.25.6-canary.1971.16438156962.0
  yarn add @grafana/plugin-meta-extractor@0.8.3-canary.1971.16438156962.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
