### PR TITLE
RBAC: Updates the docs on `actionSets` with limitations on folders and dashboard actions only

### DIFF
--- a/docusaurus/docs/how-to-guides/app-plugins/implement-rbac-in-app-plugins.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/implement-rbac-in-app-plugins.md
@@ -139,6 +139,18 @@ In your `plugin.json`, add the `iam` section to get a service account token with
 
 The action set system provides a way for plugins to extend Grafana's View, Edit or Admin access to a folder.
 
+Note:
+
+- **Folder Only**: Restricted to `folders:view/edit/admin` action sets
+- **Already Scoped**: The permission will be scoped to a particular folder once a user gets View/Edit/Admin access to the folder.
+- **Append Only**: Action sets can only be extended, not modified or restricted
+
+trying to extend something other than the action sets, results in an error.
+```bash
+logger=plugins.actionsets.registration pluginId=grafana-lokiexplore-app error="[accesscontrol.actionSetInvalid] 
+currently only folder and dashboard action sets are supported, provided action set grafana-lokiexplore-app:view is not a folder or dashboard action set"
+```
+
 ### Grafana Action Sets
 
 Grafana has several action sets for folders that can be extended:
@@ -147,12 +159,6 @@ Grafana has several action sets for folders that can be extended:
 - `folders:view` → `["folders:read", "dashboards:read"]`
 - `folders:edit` → `["folders:read", "folders:write", "dashboards:read", "dashboards:write", "folders:create"]`
 - `folders:admin` → `["folders:read", "folders:write", "folders:delete", "folders.permissions:read", "folders.permissions:write", ...]`
-
-### Limitations
-
-- **Folder Only**: Currently restricted to `folders:view/edit/admin` action sets
-- **Already Scoped**: The permission will be scoped to a particular folder once a user gets View/Edit/Admin access to the folder.
-- **Append Only**: Action sets can only be extended, not modified or restricted
 
 ### Codepaths
 [RegistrationsOfActionSets](https://github.com/grafana/grafana/blob/main/pkg/services/accesscontrol/resourcepermissions/service.go#L574
@@ -188,23 +194,6 @@ Plugins can define action sets in their `plugin.json`:
 ```
 
 ### Practical Example
-
-**Before Action Sets (individual permissions):**
-```json
-{
-  "roles": [
-    {
-      "role": {
-        "name": "Document Manager inside folder",
-        "permissions": [
-          {"action": "my-plugin.docs:create"},
-          {"action": "my-plugin.docs:edit"}
-        ]
-      }
-    }
-  ]
-}
-```
 
 **With Action Sets (extending existing sets):**
 ```json

--- a/docusaurus/docs/how-to-guides/app-plugins/implement-rbac-in-app-plugins.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/implement-rbac-in-app-plugins.md
@@ -145,7 +145,7 @@ Note:
 - **Already Scoped**: The permission will be scoped to a particular folder once a user gets View/Edit/Admin access to the folder.
 - **Append Only**: Action sets can only be extended, not modified or restricted
 
-trying to extend something other than the action sets, results in an error.
+Extending anything other than the action sets results in an error.
 ```bash
 logger=plugins.actionsets.registration pluginId=grafana-lokiexplore-app error="[accesscontrol.actionSetInvalid] 
 currently only folder and dashboard action sets are supported, provided action set grafana-lokiexplore-app:view is not a folder or dashboard action set"


### PR DESCRIPTION
moved the actionsets section to the top to make it clearer that we only support extending the actionsets on folders