### PR TITLE
fix(deps): bump rxjs to 7.8.2 to match @grafana/ui version

### DIFF
--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -83,7 +83,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0"{{#if isAppType}},
     "react-router-dom": "^{{ reactRouterVersion }}",
-    "rxjs": "7.8.1"{{/if}}
+    "rxjs": "7.8.2"{{/if}}
   },
   "packageManager": "{{ packageManagerName }}@{{ packageManagerVersion }}"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I'd quite like #1903 to land as I'd like to make use of some bits landed in 12.1.0. Tests were failing on that though due to the `rxjs` version in `@grafana/ui` being bumped.

With this change locally, `cd packages/create-plugin && npm ci && npm run build && ./dist/bin/run.js --plugin-name='backend' --org-name='myorg' --plugin-type='app' --backend && cd myorg-backend-app && npm install && npm run typecheck` passes, where before it would not due to an `rxjs` type-error.