### PR TITLE
Plugin e2e: fix color picker selector

### DIFF
--- a/packages/plugin-e2e/src/models/components/ColorPicker.ts
+++ b/packages/plugin-e2e/src/models/components/ColorPicker.ts
@@ -28,7 +28,7 @@ export class ColorPicker extends ComponentBase {
 
   private getContainer(): Locator {
     const { grafanaVersion, page, selectors } = this.ctx;
-    if (gte(grafanaVersion, '11.4.1')) {
+    if (gte(grafanaVersion, '11.5.0')) {
       return page.locator(resolveGrafanaSelector(selectors.components.Portal.container));
     }
     if (gte(grafanaVersion, '8.7.0')) {

--- a/packages/plugin-e2e/tests/as-admin-user/page-loading/goto.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/page-loading/goto.spec.ts
@@ -16,7 +16,7 @@ test.describe('gotoPanelEditPage', () => {
     gotoPanelEditPage,
     readProvisionedDashboard,
   }) => {
-    const dashboard = await readProvisionedDashboard({ fileName: 'testdatasource.jsonnpm' });
+    const dashboard = await readProvisionedDashboard({ fileName: 'testdatasource.json' });
     const panelEditPage = await gotoPanelEditPage({ dashboard, id: '3' });
     await expect(panelEditPage.panel.locator).toBeVisible();
   });

--- a/packages/plugin-e2e/tests/as-admin-user/page-loading/goto.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/page-loading/goto.spec.ts
@@ -1,40 +1,22 @@
 import { test, expect } from '../../../src';
 
 test.describe('gotoDashboardPage', () => {
-  test('should not display elements when waitUntil `load` is used', async ({
+  test('should display elements when waitUntil `load` (default) is used', async ({
     gotoDashboardPage,
     readProvisionedDashboard,
   }) => {
     const dashboard = await readProvisionedDashboard({ fileName: 'testdatasource.json' });
-    const dashboardPage = await gotoDashboardPage({ ...dashboard, waitUntil: 'load' });
-    await expect(dashboardPage.getPanelByTitle('Table data').locator).toHaveCount(0);
-  });
-
-  test('should not display elements when waitUntil `networkidle` (default) is used', async ({
-    gotoDashboardPage,
-    readProvisionedDashboard,
-  }) => {
-    const dashboard = await readProvisionedDashboard({ fileName: 'testdatasource.json' });
-    const dashboardPage = await gotoDashboardPage(dashboard);
+    const dashboardPage = await gotoDashboardPage({ ...dashboard });
     await expect(dashboardPage.getPanelByTitle('Table data').locator).toBeVisible();
   });
 });
 
 test.describe('gotoPanelEditPage', () => {
-  test('should not display elements when waitUntil `load` is used', async ({
+  test('should display elements when waitUntil `load` (default) is used', async ({
     gotoPanelEditPage,
     readProvisionedDashboard,
   }) => {
-    const dashboard = await readProvisionedDashboard({ fileName: 'testdatasource.json' });
-    const panelEditPage = await gotoPanelEditPage({ dashboard, id: '3', waitUntil: 'load' });
-    await expect(panelEditPage.panel.locator).toHaveCount(0);
-  });
-
-  test('should not display elements when waitUntil `networkidle` (default) is used', async ({
-    gotoPanelEditPage,
-    readProvisionedDashboard,
-  }) => {
-    const dashboard = await readProvisionedDashboard({ fileName: 'testdatasource.json' });
+    const dashboard = await readProvisionedDashboard({ fileName: 'testdatasource.jsonnpm' });
     const panelEditPage = await gotoPanelEditPage({ dashboard, id: '3' });
     await expect(panelEditPage.panel.locator).toBeVisible();
   });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Spec tests for Grafana versions 11.4.1 -> 11.4.7 are failing on color picker custom tab selection. ([Failing run example](https://github.com/grafana/plugin-tools/actions/runs/16798910153/job/47575444526?pr=2015))

This PR aligns the version checks with changes made to e2e-selectors in [this PR](https://github.com/grafana/grafana/pull/98784) to fix this issue.

Additionally I've aligned the goTo specs with the implementation as we no longer use `waitUntil: 'networkIdle'`. ([associated PR](https://github.com/grafana/plugin-tools/issues/1746)).


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@2.1.8-canary.2017.16804424217.0
  # or 
  yarn add @grafana/plugin-e2e@2.1.8-canary.2017.16804424217.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
