### PR TITLE
fix broken link

### DIFF
--- a/packages/plugin-e2e/README.md
+++ b/packages/plugin-e2e/README.md
@@ -4,7 +4,7 @@ end-to-end test Grafana plugins with ease.
 
 **Links**
 
-- [`@grafana/plugin-e2e` docs](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/index.md)
+- [`@grafana/plugin-e2e` docs](https://grafana.com/developers/plugin-tools/e2e-test-a-plugin)
 
 ## Overview
 


### PR DESCRIPTION
This PR fixes a broken link pointing to docs in the grafana website