### PR TITLE
CI: use gh hosted runner for npm provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,7 @@ jobs:
           retention-days: 7
 
   release:
-    runs-on: ubuntu-x64
+    runs-on: ubuntu-latest
     needs: [test, generate-plugins]
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.actor != 'dependabot[bot]'"
     name: Release packages


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Looks like our self-hosted runners cannot be used with npm provenance. Error message when attempting to publish looks like:

```
lerna sill   statusCode: 422,
lerna sill   code: 'E422',
lerna sill   method: 'PUT',
lerna sill   uri: 'https://registry.npmjs.org/@grafana%2fplugin-e2e',
lerna sill   body: {
lerna sill     success: false,
lerna sill     error: 'Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.'
lerna sill   },
lerna sill   pkgid: '@grafana/plugin-e2e@2.2.0-canary.1970.17124463860.0'
lerna sill }
lerna WARN notice Package failed to publish: @grafana/plugin-e2e
lerna ERR! E422 Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.
lerna ERR! errno "undefined" is not a valid exit code - exiting with code 1

    at ChildProcess.<anonymous> (/opt/actions-runner/_work/plugin-tools/plugin-tools/node_modules/@auto-it/core/src/utils/exec-promise.ts:76:23)
    at ChildProcess.emit (node:events:518:28)
    at ChildProcess.emit (node:domain:489:12)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)Error
    at Object.execPromise (/opt/actions-runner/_work/plugin-tools/plugin-tools/node_modules/@auto-it/core/src/utils/exec-promise.ts:17:20)
    at /opt/actions-runner/_work/plugin-tools/plugin-tools/node_modules/@auto-it/npm/src/index.ts:1153:17
Error: Process completed with exit code 1.

```

So switching the release job in this pr back to `ubuntu-latest`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
