### PR TITLE
Create Plugin: always externalize i18next

### DIFF
--- a/docusaurus/docs/how-to-guides/plugin-internationalization.md
+++ b/docusaurus/docs/how-to-guides/plugin-internationalization.md
@@ -104,24 +104,10 @@ Install the latest version of the `@grafana/i18n` translation package:
 npm install @grafana/i18n@latest
 ```
 
-Next, mark `i18next` as an external in your Webpack configuration. If you're using `@grafana/create-plugin` version 5.25.9 or later you can skip this section otherwise see how in [Extend default configurations](extend-configurations).
+Next, make sure to update your create-plugin configs to latest using the following command:
 
-:::caution
-Remember to change the path to `webpack.config.ts` in `package.json`.
-:::
-
-```ts title="webpack.config.ts"
-import type { Configuration } from 'webpack';
-import { merge } from 'webpack-merge';
-import grafanaConfig, { Env } from './.config/webpack/webpack.config';
-
-const config = async (env: Env): Promise<Configuration> => {
-  const baseConfig = await grafanaConfig(env);
-  const externals = baseConfig.externals as string[];
-  return merge(baseConfig, { externals: [...externals, 'i18next'] });
-};
-
-export default config;
+```shell npm2yarn
+npx @grafana/create-plugin@latest update
 ```
 
 ### Initialize translations in `module.ts`

--- a/docusaurus/docs/how-to-guides/plugin-internationalization.md
+++ b/docusaurus/docs/how-to-guides/plugin-internationalization.md
@@ -20,7 +20,7 @@ By default, plugins are available in English only and are not translated when yo
 If you want your plugin to be translatable to other languages you need to perform the changes described in this document. You can find the [list of available languages](https://github.com/grafana/grafana/blob/main/packages/grafana-i18n/src/constants.ts) in GitHub.
 
 :::note
-While this example is based on a panel plugin, the process is the same for data source and app plugins. 
+While this example is based on a panel plugin, the process is the same for data source and app plugins.
 :::
 
 ## Before you begin
@@ -31,15 +31,15 @@ Translation is available starting from Grafana 12.1.0 using the feature flag. If
 
 The following is recommended:
 
-* Basic knowledge of Grafana plugin development
-* Basic understanding of the [`t` function](https://www.i18next.com/overview/api#t)
-* Basic understanding of the [`Trans` component](https://react.i18next.com/latest/trans-component)
+- Basic knowledge of Grafana plugin development
+- Basic understanding of the [`t` function](https://www.i18next.com/overview/api#t)
+- Basic understanding of the [`Trans` component](https://react.i18next.com/latest/trans-component)
 
 ## Overview of the files affected by translation
 
 If you create your plugin running the `create-plugin` scaffolding tool, enabling plugin translation involves updating the following files:
 
-- `docker-compose.yaml` 
+- `docker-compose.yaml`
 - `plugin.json`
 - `module.ts`
 - `webpack.config.ts`
@@ -49,28 +49,24 @@ By the end of the translation process you'll have a file structure like this:
 
 ```
 myorg-myplugin-plugintype/
-├── pkg/
-│   ├── main.go
-│   └── plugin/
 ├── src/
 │   ├── locales
-│      ├── en-US
-│         └──myorg-myplugin-plugintype.json 
-│      ├── pt-BR
-│         └──--.json 
+│   │  ├── en-US
+│   │  │  └──myorg-myplugin-plugintype.json
+│   │  └── pt-BR
+│   │     └──myorg-myplugin-plugintype.json
 │   ├── module.ts
-│   ├── plugin.json
-└── tests/
+│   └── plugin.json
+├── tests/
 ├── docker-compose.yaml
-├── webpack.config.ts
-├── package.json
+└── package.json
 ```
 
 ## Set up your plugin for translation
 
-Follow these steps to update your plugin and set it up for translation. 
+Follow these steps to update your plugin and set it up for translation.
 
-### Enable translation in your Grafana instance 
+### Enable translation in your Grafana instance
 
 To translate your plugin you need to [enable the feature toggle](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/feature-toggles/) `localizationForPlugins` in your Grafana instance.
 
@@ -94,7 +90,7 @@ To do so, add the relevant `grafanaDependency` and `languages` you want to trans
 
 ```json title="plugin.json"
 "dependencies": {
-    "grafanaDependency": ">=12.1.0", // @grafana/i18n works from version 11.0.0 and higher for en-US translations 
+    "grafanaDependency": ">=12.1.0", // @grafana/i18n works from version 11.0.0 and higher for en-US translations
     "plugins": []
   },
 "languages": ["en-US", "pt-BR"] // the languages that the plugin supports
@@ -108,7 +104,7 @@ Install the latest version of the `@grafana/i18n` translation package:
 npm install @grafana/i18n@latest
 ```
 
-Next, mark `i18next` as an external in your Webpack configuration. See how in [Extend default configurations](extend-configurations).
+Next, mark `i18next` as an external in your Webpack configuration. If you're using `@grafana/create-plugin` version 5.25.9 or later you can skip this section otherwise see how in [Extend default configurations](extend-configurations).
 
 :::caution
 Remember to change the path to `webpack.config.ts` in `package.json`.
@@ -128,9 +124,9 @@ const config = async (env: Env): Promise<Configuration> => {
 export default config;
 ```
 
-### Initialize translations in `module.ts` 
+### Initialize translations in `module.ts`
 
-Add plugin translation to `module.ts`: 
+Add plugin translation to `module.ts`:
 
 ```ts title="module.ts"
 import { initPluginTranslations } from '@grafana/i18n';
@@ -141,8 +137,9 @@ await initPluginTranslations(pluginJson.id);
 
 ## Determine the text to translate
 
-After you've configured your plugin for translation you can proceed to mark up the language strings you want to translate. Each translatable string is assigned an unique key that ends up in each translation file under `locales/<locale>/<plugin id>.json`. 
+After you've configured your plugin for translation you can proceed to mark up the language strings you want to translate. Each translatable string is assigned an unique key that ends up in each translation file under `locales/<locale>/<plugin id>.json`.
 Example using the `t` function:
+
 ```diff
 export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
    return builder
@@ -188,17 +185,18 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
 ```
 
 ### Example using the `Trans` component:
+
 ```diff
  import { SimpleOptions } from 'types';
  import { css, cx } from '@emotion/css';
  import { useStyles2, useTheme2 } from '@grafana/ui';
  import { PanelDataErrorView } from '@grafana/runtime';
 +import { Trans } from '@grafana/i18n';
- 
+
  interface Props extends PanelProps<SimpleOptions> {}
- 
+
 @@ -60,9 +61,15 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height, fie
- 
+
        <div className={styles.textBox}>
          {options.showSeriesCount && (
 -          <div data-testid="simple-panel-series-counter">Number of series: {data.series.length}</div>
@@ -219,7 +217,7 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
 
 ## Obtain the translated text
 
-Use the `i18next` [parser](https://github.com/i18next/i18next-parser#readme) and `i18n-extract` to sweep all input files, extract tagged `i18n` keys, and save the translations. 
+Use the `i18next` [parser](https://github.com/i18next/i18next-parser#readme) and `i18n-extract` to sweep all input files, extract tagged `i18n` keys, and save the translations.
 
 ### Parse for translations
 
@@ -258,7 +256,7 @@ Add the translation script `i18n-extract` to `package.json`:
 ```json title="package.json"
   "scripts": {
     "i18n-extract": "i18next --config src/locales/i18next-parser.config.js",
-  },    
+  },
 ```
 
 Run the script to translate the files:
@@ -302,9 +300,8 @@ The translation file will look similar to this:
 }
 ```
 
-## Test the translated plugin 
+## Test the translated plugin
 
-To test the plugin follow the steps in [Set up your development environment](../get-started/set-up-development-environment#docker-development-environment) to run your plugin locally. 
+To test the plugin follow the steps in [Set up your development environment](../get-started/set-up-development-environment#docker-development-environment) to run your plugin locally.
 
 You can then verify your plugin is displaying the appropriate text as you [change the language](https://grafana.com/docs/grafana/latest/administration/organization-preferences/#change-grafana-language).
-

--- a/docusaurus/docs/how-to-guides/plugin-internationalization.md
+++ b/docusaurus/docs/how-to-guides/plugin-internationalization.md
@@ -96,15 +96,9 @@ To do so, add the relevant `grafanaDependency` and `languages` you want to trans
 "languages": ["en-US", "pt-BR"] // the languages that the plugin supports
 ```
 
-### Extend your plugin configuration to include translation
+### Update to the latest version of `create-plugin`
 
-Install the latest version of the `@grafana/i18n` translation package:
-
-```shell npm2yarn
-npm install @grafana/i18n@latest
-```
-
-Next, make sure to update your `create-plugin` configs to the latest version using the following command:
+Update your `create-plugin` configs to the latest version using the following command:
 
 ```shell npm2yarn
 npx @grafana/create-plugin@latest update

--- a/docusaurus/docs/how-to-guides/plugin-internationalization.md
+++ b/docusaurus/docs/how-to-guides/plugin-internationalization.md
@@ -52,9 +52,9 @@ myorg-myplugin-plugintype/
 ├── src/
 │   ├── locales
 │   │  ├── en-US
-│   │  │  └──myorg-myplugin-plugintype.json
+│   │  │  └── myorg-myplugin-plugintype.json
 │   │  └── pt-BR
-│   │     └──myorg-myplugin-plugintype.json
+│   │     └── myorg-myplugin-plugintype.json
 │   ├── module.ts
 │   └── plugin.json
 ├── tests/

--- a/docusaurus/docs/how-to-guides/plugin-internationalization.md
+++ b/docusaurus/docs/how-to-guides/plugin-internationalization.md
@@ -117,7 +117,7 @@ await initPluginTranslations(pluginJson.id);
 
 ## Determine the text to translate
 
-After you've configured your plugin for translation you can proceed to mark up the language strings you want to translate. Each translatable string is assigned an unique key that ends up in each translation file under `locales/<locale>/<plugin id>.json`.
+After you've configured your plugin for translation you can proceed to mark up the language strings you want to translate. Each translatable string is assigned a unique key that ends up in each translation file under `locales/<locale>/<plugin id>.json`.
 Example using the `t` function:
 
 ```diff

--- a/docusaurus/docs/how-to-guides/plugin-internationalization.md
+++ b/docusaurus/docs/how-to-guides/plugin-internationalization.md
@@ -104,7 +104,7 @@ Install the latest version of the `@grafana/i18n` translation package:
 npm install @grafana/i18n@latest
 ```
 
-Next, make sure to update your create-plugin configs to latest using the following command:
+Next, make sure to update your `create-plugin` configs to the latest version using the following command:
 
 ```shell npm2yarn
 npx @grafana/create-plugin@latest update

--- a/packages/create-plugin/CONTRIBUTING.md
+++ b/packages/create-plugin/CONTRIBUTING.md
@@ -227,5 +227,5 @@ describe('Migration - append profile to webpack', () => {
 To test a migration locally you'll need a plugin to test on.
 
 - Bump the version of create-plugin _(This can be necessary if your plugin was already updated using the latest create-plugin version.)_
-- Verify that the `.config/.cprc.json` in your plugin has a version that is lower than the bumped create-plugin version \_(The `.cprc.json` holds the version of create-plugin that was used to scaffold / last update the plugin)
+- Verify that the `.config/.cprc.json` in your plugin has a version that is lower than the bumped `create-plugin` version. `.cprc.json` holds the version of `create-plugin` that was used to scaffold or make the last update of the plugin.
 - Run `npx create-plugin update --experimentalUpdates` in your plugin (see instructions on how to link your create-plugin dev version)

--- a/packages/create-plugin/CONTRIBUTING.md
+++ b/packages/create-plugin/CONTRIBUTING.md
@@ -47,7 +47,7 @@ npm install
 
 ## Development
 
-There are a collection of [commands](#commmands) to assist with developing `create-plugin`. Please read the main [contributing guide](../../CONTRIBUTING.md) before contributing any code changes to the project.
+There are a collection of [commands](#commands) to assist with developing `create-plugin`. Please read the main [contributing guide](../../CONTRIBUTING.md) before contributing any code changes to the project.
 
 Development requires linking this application so you can run it in your terminal to see what effect your changes have.
 
@@ -69,7 +69,7 @@ You should now be able to run `npx create-plugin` or `npx create-plugin update` 
 
 If you see `create-plugin not found` try running `npm unlink -g @grafana/create-plugin` then run the build and link commands again.
 
-### Commmands
+### Commands
 
 Below are the main commands used for developing `create-plugin`. They can be run using either `npx nx run`, `npm run` or navigating to `packages/create-plugin` and running the command directly.
 
@@ -227,5 +227,5 @@ describe('Migration - append profile to webpack', () => {
 To test a migration locally you'll need a plugin to test on.
 
 - Bump the version of create-plugin _(This can be necessary if your plugin was already updated using the latest create-plugin version.)_
-- Verify that the `.config/.cprc.json` in your plugin has a version that is lower than the bumped create-plugin version _(The `.cprc.json` holds the version of create-plugin that was used to scaffold / last update the plugin)
+- Verify that the `.config/.cprc.json` in your plugin has a version that is lower than the bumped create-plugin version \_(The `.cprc.json` holds the version of create-plugin that was used to scaffold / last update the plugin)
 - Run `npx create-plugin update --experimentalUpdates` in your plugin (see instructions on how to link your create-plugin dev version)

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -72,6 +72,7 @@ const config = async (env: Env): Promise<Configuration> => {
       'react-redux',
       'redux',
       'rxjs',
+      'i18next',
       'react-router',{{#unless useReactRouterV6}}
       'react-router-dom',{{/unless}}
       'd3',
@@ -79,8 +80,7 @@ const config = async (env: Env): Promise<Configuration> => {
       /^@grafana\/ui/i,{{/unless}}
       /^@grafana\/runtime/i,
       /^@grafana\/data/i,{{#if bundleGrafanaUI}}
-      'react-inlinesvg',
-      'i18next',{{/if}}
+      'react-inlinesvg',{{/if}}
 
       // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
       ({ request }, callback) => {

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "@emotion/css": "11.10.6",
     "@grafana/data": "^12.1.0",
+    "@grafana/i18n": "^12.1.0",
     "@grafana/runtime": "^12.1.0",
     "@grafana/ui": "^12.1.0",
     "@grafana/schema": "^12.1.0",{{#if_eq pluginType "scenesapp" }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Now that we have a first release of `@grafana/i18n` I think we can always externalize `i18next`. This also takes care of the documentation around this.

**Which issue(s) this PR fixes**:
Relates #1829

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@3.6.11-canary.2047.17259108840.0
  npm install @grafana/create-plugin@5.25.9-canary.2047.17259108840.0
  npm install @grafana/eslint-plugin-plugins@0.4.4-canary.2047.17259108840.0
  npm install @grafana/plugin-e2e@2.1.9-canary.2047.17259108840.0
  npm install @grafana/plugin-meta-extractor@0.8.4-canary.2047.17259108840.0
  # or 
  yarn add website@3.6.11-canary.2047.17259108840.0
  yarn add @grafana/create-plugin@5.25.9-canary.2047.17259108840.0
  yarn add @grafana/eslint-plugin-plugins@0.4.4-canary.2047.17259108840.0
  yarn add @grafana/plugin-e2e@2.1.9-canary.2047.17259108840.0
  yarn add @grafana/plugin-meta-extractor@0.8.4-canary.2047.17259108840.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
