### PR TITLE
Create-plugin: fix migration manager error and eslint ignores patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6148,6 +6148,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@ivanmaxlogiudice/gitignore": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@ivanmaxlogiudice/gitignore/-/gitignore-0.0.2.tgz",
+      "integrity": "sha512-M4QIwdc6PhxOLYq+rmQqRnRwl/BSi9Wi6Zvzwk+lQ4hFf+tPuZjJNsxYTosUfFZ0Zhd8NYCzlakSZE/LNiW8rw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5.5.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "license": "MIT",
@@ -34677,6 +34691,7 @@
       "version": "5.26.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ivanmaxlogiudice/gitignore": "^0.0.2",
         "chalk": "^5.3.0",
         "change-case": "^5.4.0",
         "debug": "^4.3.4",

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -25,6 +25,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ivanmaxlogiudice/gitignore": "^0.0.2",
     "chalk": "^5.3.0",
     "change-case": "^5.4.0",
     "debug": "^4.3.4",

--- a/packages/create-plugin/src/migrations/manager.ts
+++ b/packages/create-plugin/src/migrations/manager.ts
@@ -39,6 +39,11 @@ export async function runMigrations(migrations: Record<string, MigrationMeta>, o
     ([key, migrationMeta]) => `${key} (${migrationMeta.description})`
   );
 
+  if (migrationList.length === 0) {
+    output.log({ title: 'No updates required.' });
+    return;
+  }
+
   output.log({ title: 'Running the following migrations:', body: output.bulletList(migrationList) });
 
   for (const [key, migration] of Object.entries(migrations)) {

--- a/packages/create-plugin/src/migrations/manager.ts
+++ b/packages/create-plugin/src/migrations/manager.ts
@@ -5,6 +5,7 @@ import { flushChanges, printChanges, migrationsDebug, formatFiles, installNPMDep
 import { gitCommitNoVerify } from '../utils/utils.git.js';
 import { setRootConfig } from '../utils/utils.config.js';
 import { output } from '../utils/utils.console.js';
+import { CURRENT_APP_VERSION } from '../utils/utils.version.js';
 
 export type MigrationFn = (context: Context) => Context | Promise<Context>;
 
@@ -39,12 +40,9 @@ export async function runMigrations(migrations: Record<string, MigrationMeta>, o
     ([key, migrationMeta]) => `${key} (${migrationMeta.description})`
   );
 
-  if (migrationList.length === 0) {
-    output.log({ title: 'No updates required.' });
-    return;
-  }
+  const migrationListBody = migrationList.length > 0 ? output.bulletList(migrationList) : ['No migrations to run.'];
 
-  output.log({ title: 'Running the following migrations:', body: output.bulletList(migrationList) });
+  output.log({ title: 'Running the following migrations:', body: migrationListBody });
 
   for (const [key, migration] of Object.entries(migrations)) {
     try {
@@ -70,7 +68,8 @@ export async function runMigrations(migrations: Record<string, MigrationMeta>, o
     }
   }
 
-  const latestVersion = Object.values(migrations).at(-1)!.version;
+  // If there are no migrations to run, we should set the version to the current create-plugin version.
+  const latestVersion = migrationList.length > 0 ? Object.values(migrations).at(-1)?.version : CURRENT_APP_VERSION;
   setRootConfig({ version: latestVersion });
 
   if (options.commitEachMigration) {

--- a/packages/create-plugin/src/migrations/scripts/004-eslint9-flat-config.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/004-eslint9-flat-config.test.ts
@@ -1,4 +1,4 @@
-import migrate, { convertIgnorePatternToMinimatch } from './004-eslint9-flat-config.js';
+import migrate from './004-eslint9-flat-config.js';
 import { Context } from '../context.js';
 
 describe('004-eslint9-flat-config', () => {
@@ -225,45 +225,6 @@ describe('004-eslint9-flat-config', () => {
       );
 
       await expect(migrate).toBeIdempotent(context);
-    });
-  });
-
-  // Because of all the regex-foo in this function I think it's best to test it separately.
-  describe('convertIgnorePatternToMinimatch', () => {
-    describe('should convert ignore patterns to minimatch patterns', () => {
-      const tests = [
-        ['', ''],
-        ['**', '**'],
-        ['/**', '/**'],
-        ['**/', '**/'],
-        ['src/', '**/src/'],
-        ['src', '**/src'],
-        ['src/**', 'src/**/*'],
-        ['!src/', '!**/src/'],
-        ['!src', '!**/src'],
-        ['!src/**', '!src/**/*'],
-        ['*/foo.js', '*/foo.js'],
-        ['*/foo.js/', '*/foo.js/'],
-        ['src/{a,b}.js', 'src/\\{a,b}.js'],
-        ['src/?(a)b.js', 'src/?\\(a)b.js'],
-        ['{.js', '**/\\{.js'],
-        ['(.js', '**/\\(.js'],
-        ['(.js', '**/\\(.js'],
-        ['{(.js', '**/\\{\\(.js'],
-        ['{bar}/{baz}', '\\{bar}/\\{baz}'],
-        ['\\[foo]/{bar}/{baz}', '\\[foo]/\\{bar}/\\{baz}'],
-        ['src/\\{a}', 'src/\\{a}'],
-        ['src/\\(a)', 'src/\\(a)'],
-        ['src/\\{a}/{b}', 'src/\\{a}/\\{b}'],
-        ['src/\\(a)/(b)', 'src/\\(a)/\\(b)'],
-        ['a\\bc{de(f\\gh\\{i\\(j{(', '**/a\\bc\\{de\\(f\\gh\\{i\\(j\\{\\('],
-      ];
-
-      for (const [pattern, expected] of tests) {
-        it(`should convert "${pattern}" to "${expected}"`, () => {
-          expect(convertIgnorePatternToMinimatch(pattern)).toBe(expected);
-        });
-      }
     });
   });
 });

--- a/packages/create-plugin/src/migrations/scripts/004-eslint9-flat-config.ts
+++ b/packages/create-plugin/src/migrations/scripts/004-eslint9-flat-config.ts
@@ -445,7 +445,7 @@ export function convertIgnorePatternToMinimatch(pattern: string): string {
    * Minimatch pattern `src/\{a,b}.js` is equivalent to gitignore pattern `src/{a,b}.js`.
    */
   const escapedPatternWithoutLeadingSlash = patternWithoutLeadingSlash.replaceAll(
-    /(?=((?:\\.|[^{(])*))\1([{(])/guy,
+    /(?=((?:\\.|[^{(\\])*))\1([{(])/guy,
     '$1\\$2'
   );
 

--- a/packages/create-plugin/src/migrations/scripts/004-eslint9-flat-config.ts
+++ b/packages/create-plugin/src/migrations/scripts/004-eslint9-flat-config.ts
@@ -1,4 +1,5 @@
 import { camelCase } from 'change-case';
+import { convertIgnorePatternToMinimatch } from '@ivanmaxlogiudice/gitignore';
 import type { Linter } from 'eslint';
 import { parse } from 'jsonc-parser';
 import minimist from 'minimist';
@@ -419,40 +420,6 @@ const addIgnoreLinesToSet = (content: string) =>
     .split('\n')
     .filter((line) => line.length > 0 && !line.startsWith('#'))
     .map((line) => convertIgnorePatternToMinimatch(line.trim()));
-
-export function convertIgnorePatternToMinimatch(pattern: string): string {
-  const isNegated = pattern.startsWith('!');
-  const negatedPrefix = isNegated ? '!' : '';
-  const patternToTest = (isNegated ? pattern.slice(1) : pattern).trimEnd();
-
-  // Special cases
-  if (['', '**', '/**', '**/'].includes(patternToTest)) {
-    return `${negatedPrefix}${patternToTest}`;
-  }
-
-  const firstIndexOfSlash = patternToTest.indexOf('/');
-
-  const matchEverywherePrefix = firstIndexOfSlash < 0 || firstIndexOfSlash === patternToTest.length - 1 ? '**/' : '';
-  const patternWithoutLeadingSlash = firstIndexOfSlash === 0 ? patternToTest.slice(1) : patternToTest;
-
-  /*
-   * Escape `{` and `(` because in gitignore patterns they are just
-   * literal characters without any specific syntactic meaning,
-   * while in minimatch patterns they can form brace expansion or extglob syntax.
-   *
-   * For example, gitignore pattern `src/{a,b}.js` ignores file `src/{a,b}.js`.
-   * But, the same minimatch pattern `src/{a,b}.js` ignores files `src/a.js` and `src/b.js`.
-   * Minimatch pattern `src/\{a,b}.js` is equivalent to gitignore pattern `src/{a,b}.js`.
-   */
-  const escapedPatternWithoutLeadingSlash = patternWithoutLeadingSlash.replaceAll(
-    /(?=((?:\\.|[^{(\\])*))\1([{(])/guy,
-    '$1\\$2'
-  );
-
-  const matchInsideSuffix = patternToTest.endsWith('/**') ? '/*' : '';
-
-  return `${negatedPrefix}${matchEverywherePrefix}${escapedPatternWithoutLeadingSlash}${matchInsideSuffix}`;
-}
 
 function discoverRelativeLegacyConfigs(
   context: Context,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Spotted a couple of bugs whilst testing out #2093. This PR fixes the following issues:

1. If the migrations manager runs but there are no migrations to run it currently errors with:
   ```
   npx create-plugin update --feature-flags=useExperimentalUpdates --force
   Running migrations from 5.26.0 to 5.26.2.

    create-plugin@5.26.2  Running the following migrations:

    create-plugin@5.26.2  Update failed

   Cannot read properties of undefined (reading 'version')
   ```
2. The eslint flat config migration doesn't translate ignore file entries into minimatch entries which eslint expects causing previously ignored files (e.g. dist/**) to be linted. Added separate tests for this due to all the logic.

This PR fixes the following issues related to 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.26.4-canary.2112.17669696463.0
  # or 
  yarn add @grafana/create-plugin@5.26.4-canary.2112.17669696463.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
