### PR TITLE
renovate: when bumping grafana packages add release label

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/_package.json/"],
+      "labels": ["dependencies", "patch", "release"],
       "matchStrings": [
         "\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","
       ],
@@ -107,7 +108,7 @@
         "!/@grafana/*/",
         "!@grafana/e2e-selectors"
       ],
-      
+
       "rangeStrategy": "bump"
     },
     // patches will only touch the repo lock file so we apply no-changelog to prevent entries in the changelog

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,12 @@
+/*
+If you are editing this file, please consider the following:
+
+1. check config changes locally with `npx -y --package renovate -- renovate-config-validator`.
+2. use the branch name `renovate/reconfigure` so renovate can validate changes in PRs.
+
+See https://docs.renovatebot.com/configuration-options/ for more information.
+*/
+
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
@@ -18,6 +27,7 @@
   "postUpdateOptions": ["npmDedupe"],
   "labels": ["dependencies", "javascript"],
   // These custom managers are used to bump dependencies in create-plugin template files
+  // Any of the packageRules below that match these `matchStrings` properties will be applied by these managers.
   "customManagers": [
     {
       "customType": "regex",
@@ -38,20 +48,26 @@
     }
   ],
   "packageRules": [
+    // Keeps create-plugin templates up to date with patch releases of Grafana but does not publish.
+    // These are grouped and released with a future PR that includes the release label.
     {
       "automerge": true,
       "groupName": "grafana patch dependencies",
       "groupSlug": "all-grafana-patch",
-      "labels": ["dependencies", "patch", "release"],
+      "labels": ["dependencies", "patch"],
       "matchCurrentVersion": "!/^0/",
       "matchUpdateTypes": ["patch"],
       "matchPackageNames": [
         "/@grafana/*/",
         "/grafana/grafana-enterprise/",
-        "!@grafana/e2e-selectors"
+        "!@grafana/e2e-selectors",
+        "!@grafana/plugin-e2e"
       ],
       "minimumReleaseAge": null
     },
+    // Publishes plugin-e2e when @grafana/e2e-selectors is updated (has release label).
+    // plugin-e2e relies on the e2e-selectors package to be up to date to support latest changes in grafana core.
+    // watches the `@grafana/e2e-selectors "modified" npm dist-tag for new releases.
     {
       "automerge": true,
       "groupName": "e2e-selector dependencies",
@@ -66,21 +82,35 @@
       ],
       "minimumReleaseAge": null
     },
+    // Publishes create-plugin when @grafana/plugin-e2e is updated (has release label).
+    // This triggers on any release of plugin-e2e allowing create-plugin scaffolds to get fixes asap.
+    {
+      "automerge": true,
+      "groupName": "plugin-e2e updates",
+      "groupSlug": "plugin-e2e",
+      "labels": ["dependencies", "patch", "release"],
+      "matchPackageNames": ["@grafana/plugin-e2e"],
+      "rangeStrategy": "bump",
+      "minimumReleaseAge": null
+    },
+    // Publishes create-plugin after publishing a new minor/major version of grafana (has release label).
+    // This triggers on any update to grafana allowing create-plugin scaffolds to get the new and shiny asap.
     {
       "groupName": "grafana dependencies",
       "groupSlug": "all-grafana",
-      "labels": ["dependencies", "release", "patch"],
+      "labels": ["dependencies", "patch", "release"],
       "matchUpdateTypes": ["minor", "major"],
       "matchPackageNames": [
         "/@grafana/*/",
         "/grafana/grafana-enterprise/",
         "!@grafana/e2e-selectors",
         "!@grafana/eslint-config",
+        "!@grafana/plugin-e2e",
         "!@grafana/scenes"
       ],
       "minimumReleaseAge": null
     },
-    // Docusaurus dependencies have to be grouped together otherwise error out when building website.
+    // Docusaurus dependencies have to be grouped together otherwise it errors out when building website.
     {
       "groupName": "docusaurus dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
@@ -93,6 +123,7 @@
       "labels": ["dependencies", "javascript", "no-changelog"],
       "matchPackageNames": ["/^@auto-it/", "/^auto/"]
     },
+    // All other devDependencies are grouped to keep PR noise down.
     {
       "automerge": true,
       "groupName": "auto-merged devDependencies",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,7 +22,6 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/_package.json/"],
-      "labels": ["dependencies", "patch", "release"],
       "matchStrings": [
         "\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","
       ],
@@ -43,7 +42,7 @@
       "automerge": true,
       "groupName": "grafana patch dependencies",
       "groupSlug": "all-grafana-patch",
-      "labels": ["dependencies", "patch"],
+      "labels": ["dependencies", "patch", "release"],
       "matchCurrentVersion": "!/^0/",
       "matchUpdateTypes": ["patch"],
       "matchPackageNames": [


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Without a `release` label on the PRs that bump plugin-e2e in the create-plugin package.json template we don't get updates for plugin-e2e trickling down to plugins which rely on create-plugin update to bump deps which can leave canary e2e tests in a broken state even after fixes have been merged.

This Pr adds the missing label to resolve the above issue.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
