### PR TITLE
Create plugin: fix docker compose migration error

### DIFF
--- a/packages/create-plugin/src/migrations/scripts/001-update-grafana-compose-extend.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/001-update-grafana-compose-extend.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { Context } from '../context.js';
 import migrate from './001-update-grafana-compose-extend.js';
 import { parse, stringify } from 'yaml';
-import { inspect } from 'node:util';
 
 describe('001-update-grafana-compose-extend', () => {
   it('should not modify anything if docker-compose.yaml does not exist', async () => {

--- a/packages/create-plugin/src/migrations/scripts/001-update-grafana-compose-extend.ts
+++ b/packages/create-plugin/src/migrations/scripts/001-update-grafana-compose-extend.ts
@@ -27,7 +27,7 @@ export default async function migrate(context: Context) {
   // List of key value pairs to remove from the compose file
   const keyValuePairsToRemove: string[][] = [];
 
-  // Remove items that match the base configuration
+  // Visit key value pairs to find those that match the base configuration
   visit(composeData, {
     Pair: ((
       _key: unknown,
@@ -46,7 +46,7 @@ export default async function migrate(context: Context) {
         keyPath.push(pair.key.value as string);
       }
 
-      // If the current pair is in the base configuration, remove it
+      // We only care about the grafana service
       if (keyPath[0] === 'services' && keyPath[1] === 'grafana') {
         const baseValue = baseComposeData.getIn(keyPath);
 
@@ -58,10 +58,9 @@ export default async function migrate(context: Context) {
     }) as visitorFn<Pair<unknown, unknown>>,
   });
 
-  // Sort the items to remove by length to remove children before parents
+  // Sort the key paths by length to remove children before parents
   keyValuePairsToRemove.sort((a, b) => b.length - a.length);
 
-  // Remove the duplicate items from the compose file
   for (const keyPath of keyValuePairsToRemove) {
     composeData.deleteIn(keyPath);
   }

--- a/packages/create-plugin/src/migrations/scripts/001-update-grafana-compose-extend.ts
+++ b/packages/create-plugin/src/migrations/scripts/001-update-grafana-compose-extend.ts
@@ -24,8 +24,8 @@ export default async function migrate(context: Context) {
   if (buildContext?.toString() !== './.config') {
     return context;
   }
-  // List of items to remove from the compose file
-  const itemsToRemove: string[][] = [];
+  // List of key value pairs to remove from the compose file
+  const keyValuePairsToRemove: string[][] = [];
 
   // Remove items that match the base configuration
   visit(composeData, {
@@ -52,17 +52,17 @@ export default async function migrate(context: Context) {
 
         // If the current pair matches the base value, add it to the list of items to remove
         if (baseValue && JSON.stringify(pair.value) === JSON.stringify(baseValue)) {
-          itemsToRemove.push(keyPath);
+          keyValuePairsToRemove.push(keyPath);
         }
       }
     }) as visitorFn<Pair<unknown, unknown>>,
   });
 
   // Sort the items to remove by length to remove children before parents
-  itemsToRemove.sort((a, b) => b.length - a.length);
+  keyValuePairsToRemove.sort((a, b) => b.length - a.length);
 
   // Remove the duplicate items from the compose file
-  for (const keyPath of itemsToRemove) {
+  for (const keyPath of keyValuePairsToRemove) {
     composeData.deleteIn(keyPath);
   }
 


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

There's a bug in the docker-compose-base.yaml migration due to deleting key value pairs during iteration which is cause parent keys to be removed before attempting to remove child keys. Causes errors such as:

```
Error running migration "001-update-grafana-compose-extend (./scripts/001-update-grafana-compose-extend.js)":
Expected YAML collection at environment. Remaining path: NODE_ENV
```

This PR addresses it by collecting and sorting all paths that should be removed. Then after iteration doing the deletion. It additionally adds a test to assert that nested matching key value pairs are handled without error.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@3.7.2-canary.2126.17821357820.0
  npm install @grafana/create-plugin@5.26.5-canary.2126.17821357820.0
  npm install @grafana/eslint-plugin-plugins@0.4.7-canary.2126.17821357820.0
  npm install @grafana/plugin-e2e@2.1.13-canary.2126.17821357820.0
  # or 
  yarn add website@3.7.2-canary.2126.17821357820.0
  yarn add @grafana/create-plugin@5.26.5-canary.2126.17821357820.0
  yarn add @grafana/eslint-plugin-plugins@0.4.7-canary.2126.17821357820.0
  yarn add @grafana/plugin-e2e@2.1.13-canary.2126.17821357820.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
