### PR TITLE
Chore: externalize i18next in rspack config

### DIFF
--- a/packages/create-plugin/templates/common/.config/rspack/rspack.config.ts
+++ b/packages/create-plugin/templates/common/.config/rspack/rspack.config.ts
@@ -58,6 +58,7 @@ const config = async (env): Promise<Configuration> => {
       'react-redux',
       'redux',
       'rxjs',
+      'i18next',
       'react-router',{{#unless useReactRouterV6}}
       'react-router-dom',{{/unless}}
       'd3',
@@ -65,8 +66,7 @@ const config = async (env): Promise<Configuration> => {
       /^@grafana\/ui/i,{{/unless}}
       /^@grafana\/runtime/i,
       /^@grafana\/data/i,{{#if bundleGrafanaUI}}
-      'react-inlinesvg',
-      'i18next',{{/if}}
+      'react-inlinesvg',{{/if}}
 
       // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
       //@ts-ignore - rspack types seem to be a bit broken here.


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the external dependencies configuration in the `rspack.config.ts` template. The main change is to ensure that `i18next` is always treated as an external dependency, regardless of the `bundleGrafanaUI` option.

Missed in this previous PR: https://github.com/grafana/plugin-tools/pull/2047

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.26.6-canary.2140.17938013230.0
  npm install @grafana/eslint-plugin-plugins@0.4.8-canary.2140.17938013230.0
  npm install @grafana/plugin-meta-extractor@0.9.2-canary.2140.17938013230.0
  # or 
  yarn add @grafana/create-plugin@5.26.6-canary.2140.17938013230.0
  yarn add @grafana/eslint-plugin-plugins@0.4.8-canary.2140.17938013230.0
  yarn add @grafana/plugin-meta-extractor@0.9.2-canary.2140.17938013230.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
