### PR TITLE
Chore: shares the externals config between bundlers

### DIFF
--- a/packages/create-plugin/templates/common/.config/bundler/externals.ts
+++ b/packages/create-plugin/templates/common/.config/bundler/externals.ts
@@ -1,7 +1,9 @@
 {{#unless useExperimentalRspack}}import type { Configuration, ExternalItemFunctionData } from 'webpack';{{/unless}}{{#if useExperimentalRspack}}
 import type { RspackOptions, ExternalItemFunctionData } from '@rspack/core';{{/if}}
 
-export const externals: {{#unless useExperimentalRspack}}Configuration['externals']{{/unless}}{{#if useExperimentalRspack}}RspackOptions['externals']{{/if}} = [
+{{#unless useExperimentalRspack}} type ExternalsType = Configuration['externals'];{{/unless}}{{#if useExperimentalRspack}}type ExternalsType = RspackOptions['externals'];{{/if}}
+
+export const externals: ExternalsType = [
   // Required for dynamic publicPath resolution
   { 'amd-module': 'module' },
   'lodash',
@@ -27,13 +29,13 @@ export const externals: {{#unless useExperimentalRspack}}Configuration['external
   /^@grafana\/ui/i,{{/unless}}
   /^@grafana\/runtime/i,
   /^@grafana\/data/i,{{#if bundleGrafanaUI}}
-  'react-inlinesvg', {{/if }}
+  'react-inlinesvg',{{/if}}
   
   // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
   ({ request }: ExternalItemFunctionData, callback: (error?: Error, result?: string) => void) => {
     const prefix = 'grafana/';
     const hasPrefix = (request: string) => request.indexOf(prefix) === 0;
-    const stripPrefix = (request: string) => request.substr(prefix.length);
+    const stripPrefix = (request: string) => request.slice(prefix.length);
 
     if (request && hasPrefix(request)) {
       return callback(undefined, stripPrefix(request));

--- a/packages/create-plugin/templates/common/.config/bundler/externals.ts
+++ b/packages/create-plugin/templates/common/.config/bundler/externals.ts
@@ -1,7 +1,7 @@
-import type { Configuration } from 'webpack';
-import type { RspackOptions } from '@rspack/core';
+{{#unless useExperimentalRspack}}import type { Configuration, ExternalItemFunctionData } from 'webpack';{{/unless}}{{#if useExperimentalRspack}}
+import type { RspackOptions, ExternalItemFunctionData } from '@rspack/core';{{/if}}
 
-const externals = [
+export const externals: {{#unless useExperimentalRspack}}Configuration['externals']{{/unless}}{{#if useExperimentalRspack}}RspackOptions['externals']{{/if}} = [
   // Required for dynamic publicPath resolution
   { 'amd-module': 'module' },
   'lodash',
@@ -30,7 +30,7 @@ const externals = [
   'react-inlinesvg', {{/if }}
   
   // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
-  ({ request }, callback) => {
+  ({ request }: ExternalItemFunctionData, callback: (error?: Error, result?: string) => void) => {
     const prefix = 'grafana/';
     const hasPrefix = (request: string) => request.indexOf(prefix) === 0;
     const stripPrefix = (request: string) => request.substr(prefix.length);
@@ -42,6 +42,3 @@ const externals = [
     callback();
   },
 ];
-
-export const webpackExternals = externals as Configuration['externals'];
-export const rspackExternals = externals as RspackOptions['externals'];

--- a/packages/create-plugin/templates/common/.config/bundler/externals.ts
+++ b/packages/create-plugin/templates/common/.config/bundler/externals.ts
@@ -1,0 +1,47 @@
+import type { Configuration } from 'webpack';
+import type { RspackOptions } from '@rspack/core';
+
+const externals = [
+  // Required for dynamic publicPath resolution
+  { 'amd-module': 'module' },
+  'lodash',
+  'jquery',
+  'moment',
+  'slate',
+  'emotion',
+  '@emotion/react',
+  '@emotion/css',
+  'prismjs',
+  'slate-plain-serializer',
+  '@grafana/slate-react',
+  'react',
+  'react-dom',
+  'react-redux',
+  'redux',
+  'rxjs',
+  'i18next',
+  'react-router',{{#unless useReactRouterV6}}
+  'react-router-dom',{{/unless}}
+  'd3',
+  'angular',{{#unless bundleGrafanaUI}}
+  /^@grafana\/ui/i,{{/unless}}
+  /^@grafana\/runtime/i,
+  /^@grafana\/data/i,{{#if bundleGrafanaUI}}
+  'react-inlinesvg', {{/if }}
+  
+  // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
+  ({ request }, callback) => {
+    const prefix = 'grafana/';
+    const hasPrefix = (request: string) => request.indexOf(prefix) === 0;
+    const stripPrefix = (request: string) => request.substr(prefix.length);
+
+    if (request && hasPrefix(request)) {
+      return callback(undefined, stripPrefix(request));
+    }
+
+    callback();
+  },
+];
+
+export const webpackExternals = externals as Configuration['externals'];
+export const rspackExternals = externals as RspackOptions['externals'];

--- a/packages/create-plugin/templates/common/.config/rspack/rspack.config.ts
+++ b/packages/create-plugin/templates/common/.config/rspack/rspack.config.ts
@@ -16,7 +16,7 @@ import RspackLiveReloadPlugin from './liveReloadPlugin';
 import { BuildModeRspackPlugin } from './BuildModeRspackPlugin';
 import { DIST_DIR, SOURCE_DIR } from './constants';
 import { getCPConfigVersion, getEntries, getPackageJson, getPluginJson, hasReadme, isWSL } from './utils';
-import { rspackExternals } from '../bundler/externals';
+import { externals } from '../bundler/externals';
 
 const { SubresourceIntegrityPlugin } = rspack.experiments;
 const pluginJson = getPluginJson();
@@ -41,7 +41,7 @@ const config = async (env): Promise<Configuration> => {
 
     entry: await getEntries(),
 
-    externals: rspackExternals,
+    externals,
 
     // Support WebAssembly according to latest spec - makes WebAssembly module async
     experiments: {

--- a/packages/create-plugin/templates/common/.config/rspack/rspack.config.ts
+++ b/packages/create-plugin/templates/common/.config/rspack/rspack.config.ts
@@ -16,6 +16,7 @@ import RspackLiveReloadPlugin from './liveReloadPlugin';
 import { BuildModeRspackPlugin } from './BuildModeRspackPlugin';
 import { DIST_DIR, SOURCE_DIR } from './constants';
 import { getCPConfigVersion, getEntries, getPackageJson, getPluginJson, hasReadme, isWSL } from './utils';
+import { rspackExternals } from '../bundler/externals';
 
 const { SubresourceIntegrityPlugin } = rspack.experiments;
 const pluginJson = getPluginJson();
@@ -40,48 +41,7 @@ const config = async (env): Promise<Configuration> => {
 
     entry: await getEntries(),
 
-    externals: [
-      // Required for dynamic publicPath resolution
-      { 'amd-module': 'module' },
-      'lodash',
-      'jquery',
-      'moment',
-      'slate',
-      'emotion',
-      '@emotion/react',
-      '@emotion/css',
-      'prismjs',
-      'slate-plain-serializer',
-      '@grafana/slate-react',
-      'react',
-      'react-dom',
-      'react-redux',
-      'redux',
-      'rxjs',
-      'i18next',
-      'react-router',{{#unless useReactRouterV6}}
-      'react-router-dom',{{/unless}}
-      'd3',
-      'angular',{{#unless bundleGrafanaUI}}
-      /^@grafana\/ui/i,{{/unless}}
-      /^@grafana\/runtime/i,
-      /^@grafana\/data/i,{{#if bundleGrafanaUI}}
-      'react-inlinesvg',{{/if}}
-
-      // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
-      //@ts-ignore - rspack types seem to be a bit broken here.
-      ({ request }, callback) => {
-        const prefix = 'grafana/';
-        const hasPrefix = (request) => request.indexOf(prefix) === 0;
-        const stripPrefix = (request) => request.substr(prefix.length);
-
-        if (hasPrefix(request)) {
-          return callback(undefined, stripPrefix(request));
-        }
-
-        callback();
-      },
-    ],
+    externals: rspackExternals,
 
     // Support WebAssembly according to latest spec - makes WebAssembly module async
     experiments: {

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -19,6 +19,7 @@ import VirtualModulesPlugin from 'webpack-virtual-modules';
 import { BuildModeWebpackPlugin } from './BuildModeWebpackPlugin.ts';
 import { DIST_DIR, SOURCE_DIR } from './constants.ts';
 import { getCPConfigVersion, getEntries, getPackageJson, getPluginJson, hasReadme, isWSL } from './utils.ts';
+import { webpackExternals } from '../bundler/externals.ts';
 
 const pluginJson = getPluginJson();
 const cpVersion = getCPConfigVersion();
@@ -55,47 +56,7 @@ const config = async (env: Env): Promise<Configuration> => {
 
     entry: await getEntries(),
 
-    externals: [
-      // Required for dynamic publicPath resolution
-      { 'amd-module': 'module' },
-      'lodash',
-      'jquery',
-      'moment',
-      'slate',
-      'emotion',
-      '@emotion/react',
-      '@emotion/css',
-      'prismjs',
-      'slate-plain-serializer',
-      '@grafana/slate-react',
-      'react',
-      'react-dom',
-      'react-redux',
-      'redux',
-      'rxjs',
-      'i18next',
-      'react-router',{{#unless useReactRouterV6}}
-      'react-router-dom',{{/unless}}
-      'd3',
-      'angular',{{#unless bundleGrafanaUI}}
-      /^@grafana\/ui/i,{{/unless}}
-      /^@grafana\/runtime/i,
-      /^@grafana\/data/i,{{#if bundleGrafanaUI}}
-      'react-inlinesvg',{{/if}}
-
-      // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
-      ({ request }, callback) => {
-        const prefix = 'grafana/';
-        const hasPrefix = (request: string) => request.indexOf(prefix) === 0;
-        const stripPrefix = (request: string) => request.substr(prefix.length);
-
-        if (request && hasPrefix(request)) {
-          return callback(undefined, stripPrefix(request));
-        }
-
-        callback();
-      },
-    ],
+    externals: webpackExternals,
 
     // Support WebAssembly according to latest spec - makes WebAssembly module async
     experiments: {

--- a/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/webpack.config.ts
@@ -19,7 +19,7 @@ import VirtualModulesPlugin from 'webpack-virtual-modules';
 import { BuildModeWebpackPlugin } from './BuildModeWebpackPlugin.ts';
 import { DIST_DIR, SOURCE_DIR } from './constants.ts';
 import { getCPConfigVersion, getEntries, getPackageJson, getPluginJson, hasReadme, isWSL } from './utils.ts';
-import { webpackExternals } from '../bundler/externals.ts';
+import { externals } from '../bundler/externals.ts';
 
 const pluginJson = getPluginJson();
 const cpVersion = getCPConfigVersion();
@@ -56,7 +56,7 @@ const config = async (env: Env): Promise<Configuration> => {
 
     entry: await getEntries(),
 
-    externals: webpackExternals,
+    externals,
 
     // Support WebAssembly according to latest spec - makes WebAssembly module async
     experiments: {


### PR DESCRIPTION
**What this PR does / why we need it**:
This pull request refactors how external dependencies are configured for both Webpack and Rspack builds in the plugin templates. The main improvement is centralizing the externals list and logic into a shared module, which reduces duplication and simplifies maintenance. The change also ensures that the externals configuration adapts to whether Rspack or Webpack is used, and maintains all previous logic for marking dependencies as external.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@5.26.7-canary.2141.17942132946.0
  # or 
  yarn add @grafana/create-plugin@5.26.7-canary.2141.17942132946.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
