### PR TITLE
Chore: bump stylistic/eslint-plugin-ts and remove from renovate ignore list

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,6 @@
   "ignoreDeps": [
     "react",
     "react-dom",
-    "@stylistic/eslint-plugin-ts",
     "lerna",
     "@grafana/scenes",
     "@libs/output",
@@ -107,7 +106,7 @@
         "!/@grafana/*/",
         "!@grafana/e2e-selectors"
       ],
-      
+
       "rangeStrategy": "bump"
     },
     // patches will only touch the repo lock file so we apply no-changelog to prevent entries in the changelog

--- a/nx.json
+++ b/nx.json
@@ -24,5 +24,8 @@
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
   "defaultBase": "main",
-  "nxCloudAccessToken": "ZDU3OTNkMTItNWIwZi00N2U4LTk2MjYtNzJkYzA0YzgwNWNlfHJlYWQ="
+  "nxCloudAccessToken": "ZDU3OTNkMTItNWIwZi00N2U4LTk2MjYtNzJkYzA0YzgwNWNlfHJlYWQ=",
+  "tui": {
+    "enabled": false
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@rollup/plugin-commonjs": "^28.0.6",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.1",
-        "@stylistic/eslint-plugin-ts": "^3.1.0",
+        "@stylistic/eslint-plugin-ts": "^4.4.1",
         "@swc/core": "^1.13.5",
         "@tsconfig/node20": "^20.1.6",
         "@tsconfig/recommended": "^1.0.10",
@@ -5372,23 +5372,6 @@
         "levitate": "dist/bin.js"
       }
     },
-    "node_modules/@grafana/levitate/node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-4.4.1.tgz",
-      "integrity": "sha512-2r6cLcmdF6til66lx8esBYvBvsn7xCmLT50gw/n1rGGlTq/OxeNjBIh4c3VEaDGMa/5TybrZTia6sQUHdIWx1w==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^8.32.1",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9.0.0"
-      }
-    },
     "node_modules/@grafana/levitate/node_modules/@types/node": {
       "version": "24.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
@@ -9826,11 +9809,12 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin-ts": {
-      "version": "3.1.0",
-      "dev": true,
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-4.4.1.tgz",
+      "integrity": "sha512-2r6cLcmdF6til66lx8esBYvBvsn7xCmLT50gw/n1rGGlTq/OxeNjBIh4c3VEaDGMa/5TybrZTia6sQUHdIWx1w==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.13.0",
+        "@typescript-eslint/utils": "^8.32.1",
         "eslint-visitor-keys": "^4.2.0",
         "espree": "^10.3.0"
       },
@@ -9838,7 +9822,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.40.0"
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.1",
-    "@stylistic/eslint-plugin-ts": "^3.1.0",
+    "@stylistic/eslint-plugin-ts": "^4.4.1",
     "@swc/core": "^1.13.5",
     "@tsconfig/node20": "^20.1.6",
     "@tsconfig/recommended": "^1.0.10",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Bumps stylistic/eslint-plugin-ts to latest and removes it from renovate ignore list. I think it was ignored because it caused issues with eslint and earlier minor versions of node 22.

Also disables the [NX tui](https://nx.dev/recipes/running-tasks/terminal-ui) which feels rather over the top for this repo.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
