### PR TITLE
Fix: Init i18n in scenes app template

### DIFF
--- a/packages/create-plugin/templates/scenes-app/src/module.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/module.tsx
@@ -1,7 +1,11 @@
 import React, { Suspense, lazy } from 'react';
+import { initPluginTranslations } from '@grafana/i18n';
 import { AppPlugin, type AppRootProps } from '@grafana/data';
 import { LoadingPlaceholder } from '@grafana/ui';
 import type { AppConfigProps } from './components/AppConfig/AppConfig';
+import pluginJson from 'plugin.json';
+
+await initPluginTranslations(pluginJson.id);
 
 const LazyApp = lazy(() => import('./components/App/App'));
 const LazyAppConfig = lazy(() => import('./components/AppConfig/AppConfig'));


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR initializes plugin i18n in scenes app. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/plugin-tools/issues/2167

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@3.7.3-canary.2166.18090001936.0
  npm install @grafana/create-plugin@5.26.9-canary.2166.18090001936.0
  npm install @grafana/plugin-e2e@2.1.14-canary.2166.18090001936.0
  npm install @grafana/plugin-meta-extractor@0.9.3-canary.2166.18090001936.0
  # or 
  yarn add website@3.7.3-canary.2166.18090001936.0
  yarn add @grafana/create-plugin@5.26.9-canary.2166.18090001936.0
  yarn add @grafana/plugin-e2e@2.1.14-canary.2166.18090001936.0
  yarn add @grafana/plugin-meta-extractor@0.9.3-canary.2166.18090001936.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
