### PR TITLE
E2E: fix for flakiness in PanelEditPage.refreshPanel

### DIFF
--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -181,6 +181,9 @@ export class PanelEditPage extends GrafanaPage {
     });
 
     try {
+      await expect(refreshPanelButton).toBeVisible();
+      // if the refreshPanelButton has the text 'Cancel', then wait until it says Refresh otherwise we'll cancel all the ongoing requests
+      await expect(refreshPanelButton).toHaveText(/refresh/i, { timeout: 2000 });
       await refreshPanelButton.click({ timeout: 2000 });
     } catch (error) {
       // refresh button may be hidden behind the visualization options


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request introduces a small improvement to the `PanelEditPage` test automation. It ensures that the refresh button is visible and ready before clicking, which helps avoid issues when the button is temporarily in a "Cancel" state where a click would lead to cancelling all ongoing requests.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@2.2.1-canary.2207.18345400607.0
  # or 
  yarn add @grafana/plugin-e2e@2.2.1-canary.2207.18345400607.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
