### PR TITLE
Eslint Plugin: fix broken download paths

### DIFF
--- a/packages/eslint-plugin-plugins/README.md
+++ b/packages/eslint-plugin-plugins/README.md
@@ -5,7 +5,7 @@
 ## How to install
 
 ```shell
-npm install eslint-plugin-plugins --save-dev
+npm install @grafana/eslint-plugin-plugins --save-dev
 ```
 
 ### Configure

--- a/packages/eslint-plugin-plugins/README.md
+++ b/packages/eslint-plugin-plugins/README.md
@@ -1,14 +1,39 @@
 # eslint-plugin-plugins
 
-is-compatible is a simple ESLint plugin that checks whether imports from any of the Grafana packages (`@grafana/ui`, `@grafana/data` and `@grafana/runtime`) from within a Grafana plugin source code exist in all the Grafana runtimes that the plugin is supposed to support (as specified in the `grafanaDependency` in `plugin.json`).
+`eslint-plugin-plugins` contains an ESLint rule that checks whether imports from any of the Grafana packages (`@grafana/ui`, `@grafana/data` and `@grafana/runtime`) from within a Grafana plugin source code exist in all the Grafana runtimes that the plugin is supposed to support (as specified in the `grafanaDependency` in `plugin.json`).
 
 ## How to install
 
 ```shell
-npm install @grafana/eslint-plugin-plugins --save-dev
+npm install eslint-plugin-plugins --save-dev
 ```
 
 ### Configure
+
+To determine the plugin's minimum supported Grafana version, the linter checks the `grafanaDependency` property in the plugin's `plugin.json`. By default, it looks for `plugin.json` in the `<projectRoot>/src` folder. If the file is located elsewhere or if you're using a monorepo with multiple plugins that have different `grafanaDependency` values, you can specify `minGrafanaVersion` directly in the ESLint configuration.
+
+#### Flat config
+
+```js
+const grafanaPlugins = require('@grafana/eslint-plugin-plugins');
+
+module.exports = [
+  // ...other configs
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: { '@grafana/plugins': grafanaPlugins },
+    rules: {
+      '@grafana/plugins/import-is-compatible': [
+        'warn',
+        // optionally pass the minimum supported version
+        // { minGrafanaVersion: '10.3.0' },
+      ],
+    },
+  },
+];
+```
+
+#### Legacy config
 
 Add the following to your Grafana plugin's `.eslintrc`:
 
@@ -17,19 +42,11 @@ Add the following to your Grafana plugin's `.eslintrc`:
   ...
   "plugins": ["@grafana/eslint-plugin-plugins"],
   "rules": {
-    "@grafana/plugins/import-is-compatible": ["warn"]
-  }
-}
-```
-
-To determine the plugin's minimum supported Grafana version, the linter checks the `grafanaDependency` property in the plugin's `plugin.json`. By default, it looks for `plugin.json` in the `<projectRoot>/src` folder. If the file is located elsewhere or if you're using a monorepo with multiple plugins that have different `grafanaDependency` values, you can specify `minGrafanaVersion` directly in the ESLint configuration.
-
-```js
-{
-  ...
-  "plugins": ["@grafana/eslint-plugin-plugins"],
-  "rules": {
-    "@grafana/plugins/import-is-compatible": ["warn", { "minGrafanaVersion": "10.3.0" }]
+    "@grafana/plugins/import-is-compatible": [
+      "warn"
+      // optionally pass the minimum supported version
+      // { minGrafanaVersion: '10.3.0' },
+    ]
   }
 }
 ```

--- a/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
+++ b/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { existsSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
-import { lt } from 'semver';
+import { lt, gt } from 'semver';
 import { getExportInfo } from './tscUtils';
 import { ExportInfo } from './types';
 
@@ -28,7 +28,7 @@ export function downloadPackages(tempDir: string, version: string) {
     );
   } else {
     packages.forEach((pkgName) => {
-      let typesFileUrl = `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/dist/index.d.ts`;
+      let typesFileUrl = getPackageDownloadUrl(pkgName, version);
       let downloadPath = join(tempDir, 'node_modules', pkgName);
       mkdirSync(downloadPath, { recursive: true });
 
@@ -57,6 +57,17 @@ export function downloadPackages(tempDir: string, version: string) {
       }
     });
   }
+}
+
+function getPackageDownloadUrl(pkgName: string, version: string) {
+  if (gt(version, '12.1.0')) {
+    return `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/dist/types/index.d.ts`;
+  }
+  if (gt(version, '11.0.0')) {
+    return `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/dist/esm/index.d.mts`;
+  }
+
+  return `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/dist/index.d.ts`;
 }
 
 function getPackageExportPaths(tempDir: string): Record<string, string> {

--- a/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
+++ b/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
@@ -74,6 +74,9 @@ function getPackageExportPaths(tempDir: string, minGrafanaVersion: string): Reco
         const packagePath = join(tempDir, 'node_modules', pkg);
         const packageJson = JSON.parse(readFileSync(join(packagePath, 'package.json'), 'utf8'));
         const typesPath = packageJson.types;
+        if (typeof typesPath !== 'string' || !typesPath) {
+          throw new Error(`Missing or invalid "types" field in ${pkg}'s package.json`);
+        }
         return {
           ...acc,
           [pkg]: join(packagePath, typesPath),

--- a/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
+++ b/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { existsSync, mkdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
-import { lt, gt } from 'semver';
+import { lt, gte } from 'semver';
 import { getExportInfo } from './tscUtils';
 import { ExportInfo } from './types';
 
@@ -60,10 +60,10 @@ export function downloadPackages(tempDir: string, version: string) {
 }
 
 function getPackageDownloadUrl(pkgName: string, version: string) {
-  if (gt(version, '12.1.0')) {
+  if (gte(version, '12.1.0')) {
     return `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/dist/types/index.d.ts`;
   }
-  if (gt(version, '11.0.0')) {
+  if (gte(version, '11.0.0')) {
     return `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/dist/esm/index.d.mts`;
   }
 

--- a/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
+++ b/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
@@ -71,7 +71,7 @@ function getPackageExportPaths(tempDir: string, minGrafanaVersion: string): Reco
   if (gte(minGrafanaVersion, '12.1.0')) {
     try {
       return packages.reduce<Record<string, string>>((acc, pkg) => {
-        const packagePath = require.resolve(pkg, { paths: [tempDir] });
+        const packagePath = join(tempDir, 'node_modules', pkg);
         const packageJson = JSON.parse(readFileSync(join(packagePath, 'package.json'), 'utf8'));
         const typesPath = packageJson.types;
         return {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Changes to the npm packages structure has caused 404s in the eslint plugin download paths. This PR should address errors such as:

```
Please wait... downloading Grafana types information for version 11.6.0.
Failed to download @grafana/data: HTTP status 404

Oops! Something went wrong! :(

ESLint: 9.28.0

Error: Error while loading rule '@grafana/plugins/import-is-compatible': Failed to download types for @grafana/data@11.6.0: Command failed: node -e "const https = require('https'); https.get('https://cdn.jsdelivr.net/npm/@grafana/data@11.6.0/dist/index.d.ts', (res) => {
            let data = '';
            res.on('data', chunk => data += chunk);
            res.on('end', () => {
              if (res.statusCode === 200) {
                require('fs').writeFileSync('/var/folders/7f/1_46h_kj2d15rltqk2jzh81c0000gn/T/gf-eslint-plugin-compatible-11.6.0/node_modules/@grafana/data/index.d.ts', data);
                process.exit(0);
              }
              console.error('Failed to download @grafana/data: HTTP status ' + res.statusCode);
              process.exit(1);
            });
          }).on('error', (e) => {
            console.error('Failed to download @grafana/data: ' + e.message);
            process.exit(1);
          })"
Failed to download @grafana/data: HTTP status 404
```

It also fixes the issue where the packages declarations are split across multiple files (>=12.1.0) by using npm install instead of attempting to download a single d.ts file from the cdn.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #2210 

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/eslint-plugin-plugins@0.5.1-canary.2208.18713544740.0
  # or 
  yarn add @grafana/eslint-plugin-plugins@0.5.1-canary.2208.18713544740.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
