### PR TITLE
Docs: Refer to necessary plugin.json updates for extension registration

### DIFF
--- a/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
@@ -28,7 +28,7 @@ You must [update](#update-the-pluginjson-metadata) your `plugin.json` metadata t
 
 ### Register a link extension
 
-In the following example we are adding a link to the panel menu on dashboards:
+The following example shows how to add a link to the panel menu in a dashboard:
 
 1. Register the link when initialising your plugin:
 

--- a/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
@@ -89,7 +89,7 @@ export const plugin = new AppPlugin().addLink({
 });
 ```
 
-2. Make sure your `plugin.json` is up to date
+2. Make sure your `plugin.json` is up to date:
 <details>
 <summary>src/plugin.json</summary>
 
@@ -142,7 +142,7 @@ export const plugin = new AppPlugin().addLink({
 });
 ```
 
-2. Make sure your `plugin.json` is up to date
+2. Make sure your `plugin.json` is up to date:
 <details>
 <summary>src/plugin.json</summary>
 
@@ -171,7 +171,7 @@ import { PluginExtensionPoints } from '@grafana/data';
 import { Button, Modal } from '@grafana/ui';
 
 export const plugin = new AppPlugin().addLink({
-  title: 'My links',
+  title: 'My link',
   description: 'My links description',
   targets: [PluginExtensionPoints.DashboardPanelMenu],
   // `event` - the `React.MouseEvent` from the click event
@@ -199,7 +199,7 @@ export const plugin = new AppPlugin().addLink({
 });
 ```
 
-2. Make sure your `plugin.json` is up to date
+2. Make sure your `plugin.json` is up to date:
 <details>
 <summary>src/plugin.json</summary>
 
@@ -325,7 +325,7 @@ export const plugin = new AppPlugin().addComponent({
 });
 ```
 
-2. Make sure your `plugin.json` is up to date
+2. Make sure your `plugin.json` is up to date:
 <details>
 <summary>src/plugin.json</summary>
 
@@ -349,7 +349,7 @@ export const plugin = new AppPlugin().addComponent({
 
 Simply return `null` from your component in order to not render anything and thereby hide the component.
 
-1. Update the component to return `null` in certain scenarios
+1. Update the component to return `null` in certain scenarios:
 
 ```tsx title="src/module.tsx"
 import { usePluginContext, PluginExtensionPoints } from '@grafana/data';
@@ -372,7 +372,7 @@ export const plugin = new AppPlugin().addComponent({
 });
 ```
 
-2. Make sure your `plugin.json` is up to date
+2. Make sure your `plugin.json` is up to date:
 <details>
 <summary>src/plugin.json</summary>
 

--- a/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
@@ -315,13 +315,15 @@ export const plugin = new AppPlugin().addComponent({
   title: 'User profile tab',
   description: 'User profile tab description',
   targets: [PluginExtensionPoints.UserProfileTab],
-  component: () => (
+  component: () => {
     const { meta } = usePluginContext();
 
-    <MyCustomDataProvider>
-      <div>Plugin specific setting: {meta.jsonData.foo}</div>
-    </MyCustomDataProvider>
-  ),
+    return (
+      <MyCustomDataProvider>
+        <div>Plugin specific setting: {meta.jsonData.foo}</div>
+      </MyCustomDataProvider>
+    );
+  },
 });
 ```
 

--- a/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
@@ -28,30 +28,50 @@ You must [update](#update-the-pluginjson-metadata) your `plugin.json` metadata t
 
 ### Register a link extension
 
-You can add an extension for a link. For example:
+In the following example we are adding a link to the panel menu on dashboards:
 
-```tsx
+1. Register the link when initialising your plugin:
+
+```tsx title="src/module.tsx"
 import { PluginExtensionPoints } from '@grafana/data';
 import pluginJson from './plugin.json';
 
 export const plugin = new AppPlugin().addLink({
-  title: '...', // This appears as the label for the link
-  description: '...',
+  title: 'My link', // This appears as the label for the link
+  description: 'My links description',
   targets: [PluginExtensionPoints.DashboardPanelMenu], // Show it in the panel menu
   path: `/a/${pluginJson.id}/foo`, // Path can only point somewhere under the plugin
 });
 ```
 
+2. Update the `plugin.json` with necessary metadata:
+
+```json title="src/plugin.json"
+{
+  ...
+  "extensions": [
+    {
+      "type": "link",
+      "extensionPointId": "grafana/dashboard/panel/menu",
+      "title": "My link",
+      "description": "My links description"
+    }
+  ]
+}
+```
+
 ### Hide a link in certain conditions
 
-You can hide a link at the extension point. For example:
+You can hide a link in certain conditions using the `configure()` function.
 
-```tsx
+1. Add a `configure()` function:
+
+```tsx title="src/module.tsx"
 import { PluginExtensionPoints } from '@grafana/data';
 
 export const plugin = new AppPlugin().addLink({
-  title: '...',
-  description: '...',
+  title: 'My link',
+  description: 'My link description',
   targets: [PluginExtensionPoints.DashboardPanelMenu],
   path: `/a/${pluginJson.id}/foo`,
   // The `context` is coming from the extension point.
@@ -69,14 +89,36 @@ export const plugin = new AppPlugin().addLink({
 });
 ```
 
+2. Make sure your `plugin.json` is up to date
+<details>
+<summary>src/plugin.json</summary>
+
+```json title="src/plugin.json"
+{
+  ...
+  "extensions": [
+    {
+      "type": "link",
+      "extensionPointId": "grafana/dashboard/panel/menu",
+      "title": "My link",
+      "description": "My links description"
+    }
+  ]
+}
+```
+
+</details>
+
 ### Update the path based on the context
 
-```tsx
+1. Add a `configure()` function with the logic:
+
+```tsx title="src/module.tsx"
 import { PluginExtensionPoints } from '@grafana/data';
 
 export const plugin = new AppPlugin().addLink({
-  title: '...',
-  description: '...',
+  title: 'My link',
+  description: 'My link description',
   targets: [PluginExtensionPoints.DashboardPanelMenu],
   path: `/a/${pluginJson.id}/foo`,
   configure: (context) => {
@@ -100,15 +142,37 @@ export const plugin = new AppPlugin().addLink({
 });
 ```
 
+2. Make sure your `plugin.json` is up to date
+<details>
+<summary>src/plugin.json</summary>
+
+```json title="src/plugin.json"
+{
+  ...
+  "extensions": [
+    {
+      "type": "link",
+      "extensionPointId": "grafana/dashboard/panel/menu",
+      "title": "My link",
+      "description": "My links description"
+    }
+  ]
+}
+```
+
+</details>
+
 ### Open a modal from the `onClick()`
 
-```tsx
+1. Add an `onClick()` handler to your links config:
+
+```tsx title="src/module.tsx"
 import { PluginExtensionPoints } from '@grafana/data';
 import { Button, Modal } from '@grafana/ui';
 
 export const plugin = new AppPlugin().addLink({
-  title: '...',
-  description: '...',
+  title: 'My links',
+  description: 'My links description',
   targets: [PluginExtensionPoints.DashboardPanelMenu],
   // `event` - the `React.MouseEvent` from the click event
   // `context` - the `context` object shared with the extensions
@@ -135,6 +199,26 @@ export const plugin = new AppPlugin().addLink({
 });
 ```
 
+2. Make sure your `plugin.json` is up to date
+<details>
+<summary>src/plugin.json</summary>
+
+```json
+{
+  ...
+  "extensions": [
+    {
+      "type": "link",
+      "extensionPointId": "grafana/dashboard/panel/menu",
+      "title": "My link",
+      "description": "My links description"
+    }
+  ]
+}
+```
+
+</details>
+
 ## Work with component extensions
 
 ### Best practices for adding components
@@ -145,29 +229,49 @@ export const plugin = new AppPlugin().addLink({
 
 ### Register a component extension
 
-You can register a component extension. For example:
+In the following example we are registering a simple component extension.
 
-```tsx
+1. Register the component when initialising your plugin:
+
+```tsx title="src/module.tsx"
 import { PluginExtensionPoints } from '@grafana/data';
 
 export const plugin = new AppPlugin().addComponent({
   title: 'User profile tab',
-  description: '...',
+  description: 'User profile tab description',
   targets: [PluginExtensionPoints.UserProfileTab],
   component: () => <div>This is a new tab on the user profile page.</div>,
 });
+```
+
+2. Update the `plugin.json` with necessary metadata:
+
+```json title="src/plugin.json"
+{
+  ...
+  "extensions": [
+    {
+      "type": "component",
+      "extensionPointId": "grafana/user/profile/tab",
+      "title": "User profile tab",
+      "description": "User profile tab description"
+    }
+  ]
+}
 ```
 
 ### Access the plugin's meta in a component
 
 You can use the `usePluginContext()` hook to access any plugin specific meta information inside your component. The hook returns a [`PluginMeta`](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/plugin.ts#L62) object. This can be useful because the component that you register from your plugin won't be rendered under the React tree of your plugin, but somewhere else in the UI.
 
-```tsx
+1. Use the `usePluginContext()` hook in your component:
+
+```tsx title="src/module.tsx"
 import { usePluginContext, PluginExtensionPoints } from '@grafana/data';
 
 export const plugin = new AppPlugin().addComponent({
   title: 'User profile tab',
-  description: '...',
+  description: 'User profile tab description',
   targets: [PluginExtensionPoints.UserProfileTab],
   component: () => {
     const { meta } = usePluginContext();
@@ -179,19 +283,41 @@ export const plugin = new AppPlugin().addComponent({
 });
 ```
 
+2. Make sure your `plugin.json` is up to date
+<details>
+<summary>src/plugin.json</summary>
+
+```json title="src/plugin.json"
+{
+  ...
+  "extensions": [
+    {
+      "type": "component",
+      "extensionPointId": "grafana/user/profile/tab",
+      "title": "User profile tab",
+      "description": "User profile tab description"
+    }
+  ]
+}
+```
+
+</details>
+
 ### Access the plugin's state in a component
 
-To access the plugin's state, do the following:
+1. Use the `usePluginContext()` hook to access meta info of the content-provider plugin
 
-```tsx
-import { PluginExtensionPoints } from '@grafana/data';
+```tsx title="src/module.tsx"
+import { usePluginContext, PluginExtensionPoints } from '@grafana/data';
 import { MyCustomDataProvider } from './MyCustomDataProvider';
 
 export const plugin = new AppPlugin().addComponent({
   title: 'User profile tab',
-  description: '...',
+  description: 'User profile tab description',
   targets: [PluginExtensionPoints.UserProfileTab],
   component: () => (
+    const { meta } = usePluginContext();
+
     <MyCustomDataProvider>
       <div>Plugin specific setting: {meta.jsonData.foo}</div>
     </MyCustomDataProvider>
@@ -199,11 +325,33 @@ export const plugin = new AppPlugin().addComponent({
 });
 ```
 
+2. Make sure your `plugin.json` is up to date
+<details>
+<summary>src/plugin.json</summary>
+
+```json title="src/plugin.json"
+{
+  ...
+  "extensions": [
+    {
+      "type": "component",
+      "extensionPointId": "grafana/user/profile/tab",
+      "title": "User profile tab",
+      "description": "User profile tab description"
+    }
+  ]
+}
+```
+
+</details>
+
 ### Hide a component in certain conditions
 
 Simply return `null` from your component in order to not render anything and thereby hide the component.
 
-```tsx
+1. Update the component to return `null` in certain scenarios
+
+```tsx title="src/module.tsx"
 import { usePluginContext, PluginExtensionPoints } from '@grafana/data';
 
 export const plugin = new AppPlugin().addComponent({
@@ -223,6 +371,26 @@ export const plugin = new AppPlugin().addComponent({
   },
 });
 ```
+
+2. Make sure your `plugin.json` is up to date
+<details>
+<summary>src/plugin.json</summary>
+
+```json title="src/plugin.json"
+{
+  ...
+  "extensions": [
+    {
+      "type": "component",
+      "extensionPointId": "grafana/user/profile/tab",
+      "title": "User profile tab",
+      "description": "User profile tab description"
+    }
+  ]
+}
+```
+
+</details>
 
 ## Update the plugin.json metadata
 

--- a/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
@@ -49,14 +49,15 @@ export const plugin = new AppPlugin().addLink({
 ```json title="src/plugin.json"
 {
   ...
-  "extensions": [
-    {
-      "type": "link",
-      "extensionPointId": "grafana/dashboard/panel/menu",
-      "title": "My link",
-      "description": "My links description"
-    }
-  ]
+  "extensions": {
+    "addedLinks": [
+      {
+        "title": "My link",
+        "description": "My links description",
+        "targets": ["grafana/dashboard/panel/menu"],
+      }
+    ]
+  }
 }
 ```
 
@@ -96,14 +97,15 @@ export const plugin = new AppPlugin().addLink({
 ```json title="src/plugin.json"
 {
   ...
-  "extensions": [
-    {
-      "type": "link",
-      "extensionPointId": "grafana/dashboard/panel/menu",
-      "title": "My link",
-      "description": "My links description"
-    }
-  ]
+  "extensions": {
+    "addedLinks": [
+      {
+        "title": "My link",
+        "description": "My links description",
+        "targets": ["grafana/dashboard/panel/menu"],
+      }
+    ]
+  }
 }
 ```
 
@@ -149,14 +151,15 @@ export const plugin = new AppPlugin().addLink({
 ```json title="src/plugin.json"
 {
   ...
-  "extensions": [
-    {
-      "type": "link",
-      "extensionPointId": "grafana/dashboard/panel/menu",
-      "title": "My link",
-      "description": "My links description"
-    }
-  ]
+  "extensions": {
+    "addedLinks": [
+      {
+        "title": "My link",
+        "description": "My links description",
+        "targets": ["grafana/dashboard/panel/menu"],
+      }
+    ]
+  }
 }
 ```
 
@@ -206,14 +209,15 @@ export const plugin = new AppPlugin().addLink({
 ```json
 {
   ...
-  "extensions": [
-    {
-      "type": "link",
-      "extensionPointId": "grafana/dashboard/panel/menu",
-      "title": "My link",
-      "description": "My links description"
-    }
-  ]
+  "extensions": {
+    "addedLinks": [
+      {
+        "title": "My link",
+        "description": "My links description",
+        "targets": ["grafana/dashboard/panel/menu"],
+      }
+    ]
+  }
 }
 ```
 
@@ -249,14 +253,15 @@ export const plugin = new AppPlugin().addComponent({
 ```json title="src/plugin.json"
 {
   ...
-  "extensions": [
-    {
-      "type": "component",
-      "extensionPointId": "grafana/user/profile/tab",
-      "title": "User profile tab",
-      "description": "User profile tab description"
-    }
-  ]
+  "extensions": {
+    "addedComponents": [
+      {
+        "title": "User profile tab",
+        "description": "User profile tab description",
+        "targets": ["grafana/user/profile/tab"],
+      }
+    ]
+  }
 }
 ```
 
@@ -290,14 +295,15 @@ export const plugin = new AppPlugin().addComponent({
 ```json title="src/plugin.json"
 {
   ...
-  "extensions": [
-    {
-      "type": "component",
-      "extensionPointId": "grafana/user/profile/tab",
-      "title": "User profile tab",
-      "description": "User profile tab description"
-    }
-  ]
+  "extensions": {
+    "addedComponents": [
+      {
+        "title": "User profile tab",
+        "description": "User profile tab description",
+        "targets": ["grafana/user/profile/tab"],
+      }
+    ]
+  }
 }
 ```
 
@@ -334,14 +340,15 @@ export const plugin = new AppPlugin().addComponent({
 ```json title="src/plugin.json"
 {
   ...
-  "extensions": [
-    {
-      "type": "component",
-      "extensionPointId": "grafana/user/profile/tab",
-      "title": "User profile tab",
-      "description": "User profile tab description"
-    }
-  ]
+  "extensions": {
+    "addedComponents": [
+      {
+        "title": "User profile tab",
+        "description": "User profile tab description",
+        "targets": ["grafana/user/profile/tab"],
+      }
+    ]
+  }
 }
 ```
 
@@ -381,14 +388,15 @@ export const plugin = new AppPlugin().addComponent({
 ```json title="src/plugin.json"
 {
   ...
-  "extensions": [
-    {
-      "type": "component",
-      "extensionPointId": "grafana/user/profile/tab",
-      "title": "User profile tab",
-      "description": "User profile tab description"
-    }
-  ]
+  "extensions": {
+    "addedComponents": [
+      {
+        "title": "User profile tab",
+        "description": "User profile tab description",
+        "targets": ["grafana/user/profile/tab"],
+      }
+    ]
+  }
 }
 ```
 
@@ -400,15 +408,23 @@ After you have defined a link or component extension and registered it against a
 
 For example:
 
-```json
-"extensions": [
+```json title="src/plugin.json"
+"extensions": {
+  "addedLinks": [
     {
-      "extensionPointId": "grafana/dashboard/panel/menu/v1",
-      "type": "link",
       "title": "My app",
-      "description": "Link to my app"
+      "description": "Link to my app",
+      "targets": ["grafana/dashboard/panel/menu"],
     }
- ]
+  ],
+  "addedComponents": [
+    {
+      "title": "User profile tab",
+      "description": "User profile tab description",
+      "targets": ["grafana/user/profile/tab"],
+    }
+  ]
+}
 ```
 
 For more information, see the `plugin.json` [reference](../../reference/metadata.md#extensions).


### PR DESCRIPTION
**Related:** https://github.com/grafana/plugin-tools/pull/2199

### What changed?
This PR is updating the docs on _"Register content in an extension point"_ by highlighting necessary `plugin.json` updates.

https://github.com/user-attachments/assets/3e05be0a-418d-4577-9f3e-de005d2b384c


### Why?
I think the notification box on the top of the page is quite easy to be missed when someone is looking for a certain example / snippet, and can cause confusion later. 