### PR TITLE
Fix: Use proper install command for legacy plugin migrations

### DIFF
--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -1,14 +1,19 @@
-import minimist from 'minimist';
+import { getMigrationsToRun, runMigrations } from '../migrations/manager.js';
+import {
+  getPackageManagerExecCmd,
+  getPackageManagerSilentInstallCmd,
+  getPackageManagerWithFallback,
+} from '../utils/utils.packageManager.js';
 import { gte, lt } from 'semver';
 import { isGitDirectory, isGitDirectoryClean } from '../utils/utils.git.js';
-import { getConfig } from '../utils/utils.config.js';
-import { output } from '../utils/utils.console.js';
-import { isPluginDirectory } from '../utils/utils.plugin.js';
-import { getPackageManagerExecCmd, getPackageManagerWithFallback } from '../utils/utils.packageManager.js';
-import { LEGACY_UPDATE_CUTOFF_VERSION } from '../constants.js';
-import { spawnSync } from 'node:child_process';
-import { getMigrationsToRun, runMigrations } from '../migrations/manager.js';
+
 import { CURRENT_APP_VERSION } from '../utils/utils.version.js';
+import { LEGACY_UPDATE_CUTOFF_VERSION } from '../constants.js';
+import { getConfig } from '../utils/utils.config.js';
+import { isPluginDirectory } from '../utils/utils.plugin.js';
+import minimist from 'minimist';
+import { output } from '../utils/utils.console.js';
+import { spawnSync } from 'node:child_process';
 
 export const update = async (argv: minimist.ParsedArgs) => {
   await performPreUpdateChecks(argv);
@@ -93,10 +98,11 @@ async function performPreUpdateChecks(argv: minimist.ParsedArgs) {
 function preparePluginForMigrations(argv: minimist.ParsedArgs) {
   const { packageManagerName, packageManagerVersion } = getPackageManagerWithFallback();
   const packageManagerExecCmd = getPackageManagerExecCmd(packageManagerName, packageManagerVersion);
+  const installCmd = getPackageManagerSilentInstallCmd(packageManagerName, packageManagerVersion);
 
   const updateCmdList = [
     `${packageManagerExecCmd}@${LEGACY_UPDATE_CUTOFF_VERSION} update${argv.force ? ' --force' : ''}`,
-    `${packageManagerName} install`,
+    installCmd,
   ];
   const gitCmdList = [
     'git add -A',

--- a/packages/create-plugin/src/utils/utils.packageManager.ts
+++ b/packages/create-plugin/src/utils/utils.packageManager.ts
@@ -1,8 +1,9 @@
+import { gte, lt } from 'semver';
+
 import { basename } from 'node:path';
-import { spawnSync } from 'node:child_process';
 import { findUpSync } from 'find-up';
 import { getPackageJson } from './utils.packagejson.js';
-import { gte, lt } from 'semver';
+import { spawnSync } from 'node:child_process';
 
 const NPM_LOCKFILE = 'package-lock.json';
 const PNPM_LOCKFILE = 'pnpm-lock.yaml';
@@ -104,8 +105,8 @@ export function getPackageManagerSilentInstallCmd(packageManagerName: string, pa
       if (lt(packageManagerVersion, '2.0.0')) {
         return 'yarn install --silent --ignore-scripts';
       }
-
-      return 'yarn install --silent';
+      // Yarn Berry: --mode update-lockfile allows lockfile updates in CI
+      return 'yarn install --mode update-lockfile --silent';
 
     case 'pnpm':
       return 'pnpm install --no-frozen-lockfile --silent --ignore-scripts';


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `create-plugin update` failing in CI for plugins older than v5.27.1.

The `preparePluginForMigrations()` function runs a bare `pnpm install` (or `npm`/`yarn` install) after the legacy update modifies `package.json`. In CI environments, package managers default to strict lockfile modes (`--frozen-lockfile`, `npm ci`, `--immutable`) which fail when the lockfile doesn't match the modified `package.json`.

The fix is to use `getPackageManagerSilentInstallCmd()` which includes `--no-frozen-lockfile` for pnpm and appropriate flags for other package managers.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/plugin-tools/issues/2220

**Special notes for your reviewer**:
Should only affects plugins with `.config/.cprc.json` version < 5.27.1

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@4.0.2-canary.2221.18520107145.0
  npm install @grafana/create-plugin@6.1.1-canary.2221.18520107145.0
  npm install @grafana/plugin-e2e@2.2.2-canary.2221.18520107145.0
  # or 
  yarn add website@4.0.2-canary.2221.18520107145.0
  yarn add @grafana/create-plugin@6.1.1-canary.2221.18520107145.0
  yarn add @grafana/plugin-e2e@2.2.2-canary.2221.18520107145.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
