### PR TITLE
Moving towards self hosted renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/_package.json/"],
+      "fileMatch": ["/_package.json/"],
       "matchStrings": [
         "\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","
       ],
@@ -27,7 +27,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/(^|/)(?:docker-)?compose[^/]*\\.ya?ml$/"],
+      "fileMatch": ["/(^|/)(?:docker-)?compose[^/]*\\.ya?ml$/"],
       "matchStrings": [
         "grafana_version:\\s\\$\\{GRAFANA_VERSION:-(?<currentValue>.*)\\}"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,7 +37,7 @@
   ],
   "packageRules": [
     {
-      "automerge": true,
+      "automerge": false,
       "groupName": "grafana patch dependencies",
       "groupSlug": "all-grafana-patch",
       "labels": ["dependencies", "patch"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,37 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
   "includePaths": ["package.json", "packages/**", "docusaurus/**", ".github/**"],
-  "ignoreDeps": [
-    "react",
-    "react-dom",
-    "lerna",
-    "@grafana/scenes",
-    "@libs/output",
-    "@libs/version"
-  ],
+  "ignoreDeps": ["react", "react-dom", "lerna", "@grafana/scenes", "@libs/output", "@libs/version"],
   "separateMajorMinor": false,
   "skipInstalls": false,
   "reviewers": ["team:grafana/plugins-platform-frontend"],
   "enabledManagers": ["custom.regex", "npm", "github-actions"],
   "postUpdateOptions": ["npmDedupe"],
   "labels": ["dependencies", "javascript"],
-  // These custom managers are used to bump dependencies in create-plugin template files
   "customManagers": [
     {
       "customType": "regex",
       "managerFilePatterns": ["/_package.json/"],
-      "matchStrings": [
-        "\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","
-      ],
+      "matchStrings": ["\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","],
       "datasourceTemplate": "npm"
     },
     {
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)(?:docker-)?compose[^/]*\\.ya?ml$/"],
-      "matchStrings": [
-        "grafana_version:\\s\\$\\{GRAFANA_VERSION:-(?<currentValue>.*)\\}"
-      ],
+      "matchStrings": ["grafana_version:\\s\\$\\{GRAFANA_VERSION:-(?<currentValue>.*)\\}"],
       "depNameTemplate": "grafana/grafana-enterprise",
       "datasourceTemplate": "docker"
     }
@@ -44,11 +32,7 @@
       "labels": ["dependencies", "patch"],
       "matchCurrentVersion": "!/^0/",
       "matchUpdateTypes": ["patch"],
-      "matchPackageNames": [
-        "/@grafana/*/",
-        "/grafana/grafana-enterprise/",
-        "!@grafana/e2e-selectors"
-      ],
+      "matchPackageNames": ["/@grafana/*/", "/grafana/grafana-enterprise/", "!@grafana/e2e-selectors"],
       "minimumReleaseAge": null
     },
     {
@@ -59,10 +43,7 @@
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
       "rangeStrategy": "bump",
-      "matchFileNames": [
-        "packages/plugin-e2e/package.json",
-        "package-lock.json"
-      ],
+      "matchFileNames": ["packages/plugin-e2e/package.json", "package-lock.json"],
       "minimumReleaseAge": null
     },
     {
@@ -79,14 +60,12 @@
       ],
       "minimumReleaseAge": null
     },
-    // Docusaurus dependencies have to be grouped together otherwise error out when building website.
     {
       "groupName": "docusaurus dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
       "rangeStrategy": "bump",
       "matchPackageNames": ["/@?docusaurus/"]
     },
-    // Auto dependencies should be grouped together to avoid issues
     {
       "groupName": "auto dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
@@ -99,18 +78,10 @@
       "labels": ["dependencies", "javascript", "no-changelog"],
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["devDependencies", "optionalDependencies"],
-      "matchPackageNames": [
-        "!/^@?docusaurus/",
-        "!/^@auto-it/",
-        "!/^auto/",
-        "!/@grafana/*/",
-        "!@grafana/e2e-selectors"
-      ],
+      "matchPackageNames": ["!/^@?docusaurus/", "!/^@auto-it/", "!/^auto/", "!/@grafana/*/", "!@grafana/e2e-selectors"],
 
       "rangeStrategy": "bump"
     },
-    // patches will only touch the repo lock file so we apply no-changelog to prevent entries in the changelog
-    // which would be misleading to consumers.
     {
       "automerge": true,
       "groupName": "auto-merged patch dependencies",
@@ -128,9 +99,6 @@
       "matchManagers": ["github-actions"]
     }
   ],
-  "minimumReleaseAge": "14 days",
-  "prConcurrentLimit": 10,
-  "rebaseWhen": "conflicted",
   "vulnerabilityAlerts": {
     "addLabels": ["security"]
   }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
   "includePaths": ["package.json", "packages/**", "docusaurus/**", ".github/**"],
-  "ignoreDeps": ["react", "react-dom", "lerna", "@grafana/scenes", "@libs/output", "@libs/version"],
+  "ignoreDeps": [
+    "react",
+    "react-dom",
+    "lerna",
+    "@grafana/scenes",
+    "@libs/output",
+    "@libs/version"
+  ],
   "separateMajorMinor": false,
   "skipInstalls": false,
   "reviewers": ["team:grafana/plugins-platform-frontend"],
@@ -13,13 +20,17 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/_package.json/"],
-      "matchStrings": ["\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","],
+      "matchStrings": [
+        "\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","
+      ],
       "datasourceTemplate": "npm"
     },
     {
       "customType": "regex",
       "managerFilePatterns": ["/(^|/)(?:docker-)?compose[^/]*\\.ya?ml$/"],
-      "matchStrings": ["grafana_version:\\s\\$\\{GRAFANA_VERSION:-(?<currentValue>.*)\\}"],
+      "matchStrings": [
+        "grafana_version:\\s\\$\\{GRAFANA_VERSION:-(?<currentValue>.*)\\}"
+      ],
       "depNameTemplate": "grafana/grafana-enterprise",
       "datasourceTemplate": "docker"
     }
@@ -32,7 +43,11 @@
       "labels": ["dependencies", "patch"],
       "matchCurrentVersion": "!/^0/",
       "matchUpdateTypes": ["patch"],
-      "matchPackageNames": ["/@grafana/*/", "/grafana/grafana-enterprise/", "!@grafana/e2e-selectors"],
+      "matchPackageNames": [
+        "/@grafana/*/",
+        "/grafana/grafana-enterprise/",
+        "!@grafana/e2e-selectors"
+      ],
       "minimumReleaseAge": null
     },
     {
@@ -43,7 +58,10 @@
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
       "rangeStrategy": "bump",
-      "matchFileNames": ["packages/plugin-e2e/package.json", "package-lock.json"],
+      "matchFileNames": [
+        "packages/plugin-e2e/package.json",
+        "package-lock.json"
+      ],
       "minimumReleaseAge": null
     },
     {
@@ -59,13 +77,13 @@
         "!@grafana/scenes"
       ],
       "minimumReleaseAge": null
-    },
+    },    
     {
       "groupName": "docusaurus dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
       "rangeStrategy": "bump",
       "matchPackageNames": ["/@?docusaurus/"]
-    },
+    },    
     {
       "groupName": "auto dependencies",
       "labels": ["dependencies", "javascript", "no-changelog"],
@@ -78,7 +96,13 @@
       "labels": ["dependencies", "javascript", "no-changelog"],
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["devDependencies", "optionalDependencies"],
-      "matchPackageNames": ["!/^@?docusaurus/", "!/^@auto-it/", "!/^auto/", "!/@grafana/*/", "!@grafana/e2e-selectors"],
+      "matchPackageNames": [
+        "!/^@?docusaurus/",
+        "!/^@auto-it/",
+        "!/^auto/",
+        "!/@grafana/*/",
+        "!@grafana/e2e-selectors"
+      ],
 
       "rangeStrategy": "bump"
     },

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,6 @@
 
 /.nx/cache
 /.nx/workspace-data
+
+# Renovate config should not be formatted by prettier
+/.github/renovate.json


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Moving towards self hosted renovate instead of mend hosted one.

Due to: 

```
npx --yes --package renovate -- renovate-config-validator 
 INFO: Validating .github/renovate.json
ERROR: Found errors in configuration
       "file": ".github/renovate.json",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Custom Manager contains disallowed fields: managerFilePatterns"
         },
         {
           "topic": "Configuration Error",
           "message": "Custom Manager contains disallowed fields: managerFilePatterns"
         },
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: customManagers[0].managerFilePatterns"
         },
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: customManagers[1].managerFilePatterns"
         }
       ]
```

I had to switch to using `fileMatch` (https://github.com/grafana/plugin-tools/pull/2223/commits/6930ac562535b3f42e964375c8625ac3274f0f79)
