### PR TITLE
chore: replace deprecated i18next-parser

### DIFF
--- a/docusaurus/docs/shared/plugin-internationalization-shared.md
+++ b/docusaurus/docs/shared/plugin-internationalization-shared.md
@@ -90,7 +90,7 @@ Install the `i18next-cli`:
 npm install --save-dev i18next-cli
 ```
 
-Next, create a configuration file `i18next.config.ts` and configure it so the parser sweeps your plugin and extracts the translations into the `src/locales/[$LOCALE]/[your-plugin].json`:
+Next, create a configuration file `i18next.config.ts` and configure it so the CLI sweeps your plugin and extracts the translations into the `src/locales/[$LOCALE]/[your-plugin].json`:
 
 :::warning
 The path `src/locales/[$LOCALE]/[your-plugin-id].json` is mandatory. If you modify it translations won't work.

--- a/docusaurus/docs/shared/plugin-internationalization-shared.md
+++ b/docusaurus/docs/shared/plugin-internationalization-shared.md
@@ -80,11 +80,11 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
 
 ## Obtain the translated text
 
-Use the `i18next`-[cli](https://github.com/i18next/i18next-cli#readme) and `i18n-extract` to sweep all input files, extract tagged `i18n` keys, and save the translations.
+Use the [`i18next-cli`](https://github.com/i18next/i18next-cli#readme) and `i18n-extract` to sweep all input files, extract tagged `i18n` keys, and save the translations.
 
 ### Parse for translations
 
-Install the `i18next`-cli:
+Install the `i18next-cli`:
 
 ```shell npm2yarn
 npm install --save-dev i18next-cli
@@ -96,7 +96,7 @@ Next, create a configuration file `i18next.config.ts` and configure it so the pa
 The path `src/locales/[$LOCALE]/[your-plugin-id].json` is mandatory. If you modify it translations won't work.
 :::
 
-```js title="i18next.config.ts"
+```ts title="i18next.config.ts"
 import { defineConfig } from 'i18next-cli';
 import pluginJson from './src/plugin.json';
 

--- a/docusaurus/docs/shared/plugin-internationalization-shared.md
+++ b/docusaurus/docs/shared/plugin-internationalization-shared.md
@@ -80,36 +80,36 @@ export const plugin = new PanelPlugin<SimpleOptions>(SimplePanel).setPanelOption
 
 ## Obtain the translated text
 
-Use the `i18next` [parser](https://github.com/i18next/i18next-parser#readme) and `i18n-extract` to sweep all input files, extract tagged `i18n` keys, and save the translations.
+Use the `i18next`-[cli](https://github.com/i18next/i18next-cli#readme) and `i18n-extract` to sweep all input files, extract tagged `i18n` keys, and save the translations.
 
 ### Parse for translations
 
-Install the `i18next` parser:
+Install the `i18next`-cli:
 
 ```shell npm2yarn
-npm install --save-dev i18next-parser
+npm install --save-dev i18next-cli
 ```
 
-Next, create a configuration file `src/locales/i18next-parser.config.js` and configure it so the parser sweeps your plugin and extracts the translations into the `src/locales/[$LOCALE]/[your-plugin].json`:
+Next, create a configuration file `i18next.config.ts` and configure it so the parser sweeps your plugin and extracts the translations into the `src/locales/[$LOCALE]/[your-plugin].json`:
 
 :::warning
 The path `src/locales/[$LOCALE]/[your-plugin-id].json` is mandatory. If you modify it translations won't work.
 :::
 
-```js title="src/locales/i18next-parser.config.js"
-const pluginJson = require('../plugin.json');
+```js title="i18next.config.ts"
+import { defineConfig } from 'i18next-cli';
+import pluginJson from './src/plugin.json';
 
-module.exports = {
-  locales: pluginJson.languages, // An array of the locales your plugin supports
-  sort: true,
-  createOldCatalogs: false,
-  failOnWarnings: true,
-  verbose: false,
-  resetDefaultValueLocale: 'en-US', // Updates extracted values when they change in code
-  defaultNamespace: pluginJson.id,
-  input: ['../**/*.{tsx,ts}'],
-  output: 'src/locales/$LOCALE/$NAMESPACE.json',
-};
+export default defineConfig({
+  locales: pluginJson.languages,
+  extract: {
+    input: ['src/**/*.{tsx,ts}'],
+    output: 'src/locales/{{language}}/{{namespace}}.json',
+    defaultNS: pluginJson.id,
+    functions: ['t', '*.t'],
+    transComponents: ['Trans'],
+  },
+});
 ```
 
 ### Obtain your translation file
@@ -118,7 +118,7 @@ Add the translation script `i18n-extract` to `package.json`:
 
 ```json title="package.json"
   "scripts": {
-    "i18n-extract": "i18next --config src/locales/i18next-parser.config.js"
+    "i18n-extract": "i18next-cli extract"
   },
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the documentation for the internationalization workflow to use the newer `i18next-cli` tool instead of the deprecated `i18next-parser`. The instructions for configuring and running translation extraction scripts have been revised for clarity and to match the latest best practices.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
