### PR TITLE
chore: fix download paths for package versions >=11.0.0 and <11.6.0

### DIFF
--- a/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
+++ b/packages/eslint-plugin-plugins/src/rules/getPackageExports.ts
@@ -60,7 +60,7 @@ export function downloadPackages(tempDir: string, version: string) {
 }
 
 function getPackageDownloadUrl(pkgName: string, version: string) {
-  if (gte(version, '11.0.0')) {
+  if (gte(version, '11.6.0')) {
     return `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/dist/cjs/index.d.cts`;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

```bash
Error: Error while loading rule '@grafana/plugins/import-is-compatible': Failed to download types for @grafana/data@11.0.0: Command failed: node -e "const https = require('https'); https.get('https://cdn.jsdelivr.net/npm/@grafana/data@11.0.0/dist/cjs/index.d.cts', (res) => {
            let data = '';
            res.on('data', chunk => data += chunk);
            res.on('end', () => {
              if (res.statusCode === 200) {
                require('fs').writeFileSync('/tmp/gf-eslint-plugin-compatible-11.0.0/node_modules/@grafana/data/index.d.ts', data);
                process.exit(0);
              }
              console.error('Failed to download @grafana/data: HTTP status ' + res.statusCode);
              process.exit(1);
            });
          }).on('error', (e) => {
            console.error('Failed to download @grafana/data: ' + e.message);
            process.exit(1);
          })"
Failed to download @grafana/data: HTTP status 404
```

This pull request makes a small update to the logic that determines the download URL for a package. The version check in `getPackageDownloadUrl` was changed from `11.0.0` to `11.6.0`, which means the new URL format will only be used for versions `11.6.0` and above.

| 11.5.10 | 11.6.0 |
|-----|-----|
|https://cdn.jsdelivr.net/npm/@grafana/data@11.5.10/dist/|https://cdn.jsdelivr.net/npm/@grafana/data@11.6.0/dist/|
|https://cdn.jsdelivr.net/npm/@grafana/runtime@11.5.10/dist/|https://cdn.jsdelivr.net/npm/@grafana/runtime@11.6.0/dist/|
|https://cdn.jsdelivr.net/npm/@grafana/ui@11.5.10/dist/|https://cdn.jsdelivr.net/npm/@grafana/ui@11.6.0/dist/|

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@4.0.4-canary.2239.18737998012.0
  npm install @grafana/eslint-plugin-plugins@0.5.2-canary.2239.18737998012.0
  # or 
  yarn add website@4.0.4-canary.2239.18737998012.0
  yarn add @grafana/eslint-plugin-plugins@0.5.2-canary.2239.18737998012.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
