### PR TITLE
Create Plugin: Include EOF newline when setting root config

### DIFF
--- a/packages/create-plugin/src/utils/utils.config.ts
+++ b/packages/create-plugin/src/utils/utils.config.ts
@@ -7,6 +7,7 @@ import { output } from './utils.console.js';
 import { partitionArr } from './utils.helpers.js';
 import path from 'node:path';
 import { writeFile } from 'node:fs/promises';
+import { EOL } from 'node:os';
 
 export type FeatureFlags = {
   bundleGrafanaUI?: boolean;
@@ -127,7 +128,7 @@ export async function setRootConfig(configOverride: Partial<CreatePluginConfig> 
   const rootConfigPath = path.resolve(process.cwd(), '.config/.cprc.json');
   const updatedConfig = { ...rootConfig, ...configOverride };
 
-  await writeFile(rootConfigPath, JSON.stringify(updatedConfig, null, 2) + '\n');
+  await writeFile(rootConfigPath, JSON.stringify(updatedConfig, null, 2) + EOL);
 
   return updatedConfig;
 }

--- a/packages/create-plugin/src/utils/utils.config.ts
+++ b/packages/create-plugin/src/utils/utils.config.ts
@@ -127,7 +127,7 @@ export async function setRootConfig(configOverride: Partial<CreatePluginConfig> 
   const rootConfigPath = path.resolve(process.cwd(), '.config/.cprc.json');
   const updatedConfig = { ...rootConfig, ...configOverride };
 
-  await writeFile(rootConfigPath, JSON.stringify(updatedConfig, null, 2));
+  await writeFile(rootConfigPath, JSON.stringify(updatedConfig, null, 2) + '\n');
 
   return updatedConfig;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Keep Prettier and other similar tooling happy when create-plugin generates update PRs with the root config updated.

**Which issue(s) this PR fixes**:

cc https://github.com/grafana/grafana-setupguide-app/pull/579/commits/648c319b738ded42910ae77e4ab3adb1371c29fc https://github.com/grafana/grafana-setupguide-app/actions/runs/18860044261/job/53816349410 (🔐)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.1.5-canary.2246.18877899648.0
  # or 
  yarn add @grafana/create-plugin@6.1.5-canary.2246.18877899648.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
