### PR TITLE
Create Plugin: remove types/testing-library__jest-dom

### DIFF
--- a/packages/create-plugin/src/migrations/migrations.ts
+++ b/packages/create-plugin/src/migrations/migrations.ts
@@ -46,7 +46,7 @@ export default {
       migrationScript: './scripts/006-webpack-nested-fix.js',
     },
     '007-remove-testing-library-types': {
-      version: '6.1.12',
+      version: '6.1.13',
       description:
         'Add setupTests.d.ts for @testing-library/jest-dom types and remove @types/testing-library__jest-dom npm package.',
       migrationScript: './scripts/007-remove-testing-library-types.js',

--- a/packages/create-plugin/src/migrations/migrations.ts
+++ b/packages/create-plugin/src/migrations/migrations.ts
@@ -45,5 +45,11 @@ export default {
       description: 'Fix webpack variable replacement in nested plugins files.',
       migrationScript: './scripts/006-webpack-nested-fix.js',
     },
+    '007-remove-testing-library-types': {
+      version: '6.1.12',
+      description:
+        'Add setupTests.d.ts for @testing-library/jest-dom types and remove @types/testing-library__jest-dom npm package.',
+      migrationScript: './scripts/007-remove-testing-library-types.js',
+    },
   },
 } as Migrations;

--- a/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.test.ts
@@ -11,21 +11,19 @@ describe('006-remove-testing-library-types', () => {
       JSON.stringify({
         devDependencies: {
           '@types/testing-library__jest-dom': '^6.0.0',
+          '@testing-library/jest-dom': '6.0.0',
           '@testing-library/react': '14.0.0',
         },
       })
     );
 
     const result = migrate(context);
-
-    // Check that setupTests.d.ts was created
     const setupTestsContent = result.getFile('./.config/types/setupTests.d.ts');
     expect(setupTestsContent).toBe("import '@testing-library/jest-dom';\n");
 
-    // Check that the types package was removed
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
     expect(packageJson.devDependencies).toEqual({
-      '@testing-library/jest-dom': '^6.0.0',
+      '@testing-library/jest-dom': '6.0.0',
       '@testing-library/react': '14.0.0',
     });
   });
@@ -40,21 +38,19 @@ describe('006-remove-testing-library-types', () => {
       JSON.stringify({
         devDependencies: {
           '@types/testing-library__jest-dom': '^6.0.0',
+          '@testing-library/jest-dom': '6.1.4',
           '@testing-library/react': '14.0.0',
         },
       })
     );
 
     const result = migrate(context);
-
-    // Check that import was prepended
     const setupTestsContent = result.getFile('./.config/types/setupTests.d.ts');
     expect(setupTestsContent).toBe(`import '@testing-library/jest-dom';\n${existingContent}`);
 
-    // Check that the types package was removed
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
     expect(packageJson.devDependencies).toEqual({
-      '@testing-library/jest-dom': '^6.0.0',
+      '@testing-library/jest-dom': '6.1.4',
       '@testing-library/react': '14.0.0',
     });
   });
@@ -69,6 +65,7 @@ describe('006-remove-testing-library-types', () => {
       JSON.stringify({
         devDependencies: {
           '@types/testing-library__jest-dom': '^6.0.0',
+          '@testing-library/jest-dom': '6.1.4',
           '@testing-library/react': '14.0.0',
         },
       })
@@ -76,16 +73,25 @@ describe('006-remove-testing-library-types', () => {
 
     const result = migrate(context);
 
-    // Check that content was not modified
     const setupTestsContent = result.getFile('./.config/types/setupTests.d.ts');
     expect(setupTestsContent).toBe(existingContent);
 
-    // Check that the types package was still removed
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
     expect(packageJson.devDependencies).toEqual({
-      '@testing-library/jest-dom': '^6.0.0',
+      '@testing-library/jest-dom': '6.1.4',
       '@testing-library/react': '14.0.0',
     });
+  });
+
+  it('should not modify anything if @testing-library/jest-dom is not greater than 6.0.0', () => {
+    const context = new Context('/virtual');
+    const packageJsonContent = JSON.stringify({
+      devDependencies: { '@testing-library/jest-dom': '5.14.2' },
+    });
+    context.addFile('package.json', packageJsonContent);
+
+    const result = migrate(context);
+    expect(result.getFile('package.json')).toEqual(packageJsonContent);
   });
 
   it('should handle package.json without the types package', () => {
@@ -96,20 +102,18 @@ describe('006-remove-testing-library-types', () => {
       JSON.stringify({
         devDependencies: {
           '@testing-library/react': '14.0.0',
+          '@testing-library/jest-dom': '6.1.4',
         },
       })
     );
 
     const result = migrate(context);
-
-    // Check that setupTests.d.ts was created
     const setupTestsContent = result.getFile('./.config/types/setupTests.d.ts');
     expect(setupTestsContent).toBe("import '@testing-library/jest-dom';\n");
 
-    // Check that package.json was not modified (no types package to remove)
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
     expect(packageJson.devDependencies).toEqual({
-      '@testing-library/jest-dom': '^6.0.0',
+      '@testing-library/jest-dom': '6.1.4',
       '@testing-library/react': '14.0.0',
     });
   });
@@ -122,6 +126,8 @@ describe('006-remove-testing-library-types', () => {
       JSON.stringify({
         devDependencies: {
           '@types/testing-library__jest-dom': '^6.0.0',
+          '@testing-library/jest-dom': '6.1.4',
+          '@testing-library/react': '14.0.0',
         },
       })
     );

--- a/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import migrate from './007-remove-testing-library-types.js';
+import { Context } from '../context.js';
+
+describe('005-remove-testing-library-types', () => {
+  it('should create setupTests.d.ts and remove types package when file does not exist', () => {
+    const context = new Context('/virtual');
+
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@types/testing-library__jest-dom': '^6.0.0',
+          '@testing-library/react': '14.0.0',
+        },
+      })
+    );
+
+    const result = migrate(context);
+
+    // Check that setupTests.d.ts was created
+    const setupTestsContent = result.getFile('./.config/types/setupTests.d.ts');
+    expect(setupTestsContent).toBe("import '@testing-library/jest-dom';\n");
+
+    // Check that the types package was removed
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+    expect(packageJson.devDependencies).toEqual({
+      '@testing-library/react': '14.0.0',
+    });
+  });
+
+  it('should add import to existing setupTests.d.ts if missing', () => {
+    const context = new Context('/virtual');
+
+    const existingContent = '// Some other type declarations\n';
+    context.addFile('./.config/types/setupTests.d.ts', existingContent);
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@types/testing-library__jest-dom': '^6.0.0',
+        },
+      })
+    );
+
+    const result = migrate(context);
+
+    // Check that import was prepended
+    const setupTestsContent = result.getFile('./.config/types/setupTests.d.ts');
+    expect(setupTestsContent).toBe(`import '@testing-library/jest-dom';\n${existingContent}`);
+
+    // Check that the types package was removed
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+    expect(packageJson.devDependencies).toEqual({});
+  });
+
+  it('should not modify setupTests.d.ts if import already exists', () => {
+    const context = new Context('/virtual');
+
+    const existingContent = "// Other content\nimport 'react';\nimport '@testing-library/jest-dom';\n";
+    context.addFile('./.config/types/setupTests.d.ts', existingContent);
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@types/testing-library__jest-dom': '^6.0.0',
+          '@testing-library/react': '14.0.0',
+        },
+      })
+    );
+
+    const result = migrate(context);
+
+    // Check that content was not modified
+    const setupTestsContent = result.getFile('./.config/types/setupTests.d.ts');
+    expect(setupTestsContent).toBe(existingContent);
+
+    // Check that the types package was still removed
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+    expect(packageJson.devDependencies).toEqual({
+      '@testing-library/react': '14.0.0',
+    });
+  });
+
+  it('should handle package.json without the types package', () => {
+    const context = new Context('/virtual');
+
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@testing-library/react': '14.0.0',
+        },
+      })
+    );
+
+    const result = migrate(context);
+
+    // Check that setupTests.d.ts was created
+    const setupTestsContent = result.getFile('./.config/types/setupTests.d.ts');
+    expect(setupTestsContent).toBe("import '@testing-library/jest-dom';\n");
+
+    // Check that package.json was not modified (no types package to remove)
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+    expect(packageJson.devDependencies).toEqual({
+      '@testing-library/react': '14.0.0',
+    });
+  });
+
+  it('should be idempotent', async () => {
+    const context = new Context('/virtual');
+
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        devDependencies: {
+          '@types/testing-library__jest-dom': '^6.0.0',
+        },
+      })
+    );
+
+    await expect(migrate).toBeIdempotent(context);
+  });
+});

--- a/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import migrate from './007-remove-testing-library-types.js';
 import { Context } from '../context.js';
 
-describe('005-remove-testing-library-types', () => {
-  it('should create setupTests.d.ts and remove types package when file does not exist', () => {
+describe('006-remove-testing-library-types', () => {
+  it('should create setupTests.d.ts, remove types package, and add @testing-library/jest-dom when file does not exist', () => {
     const context = new Context('/virtual');
 
     context.addFile(
@@ -25,11 +25,12 @@ describe('005-remove-testing-library-types', () => {
     // Check that the types package was removed
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
     expect(packageJson.devDependencies).toEqual({
+      '@testing-library/jest-dom': '^6.0.0',
       '@testing-library/react': '14.0.0',
     });
   });
 
-  it('should add import to existing setupTests.d.ts if missing', () => {
+  it('should add import to existing setupTests.d.ts, remove types package, and add @testing-library/jest-dom if missing', () => {
     const context = new Context('/virtual');
 
     const existingContent = '// Some other type declarations\n';
@@ -39,6 +40,7 @@ describe('005-remove-testing-library-types', () => {
       JSON.stringify({
         devDependencies: {
           '@types/testing-library__jest-dom': '^6.0.0',
+          '@testing-library/react': '14.0.0',
         },
       })
     );
@@ -51,7 +53,10 @@ describe('005-remove-testing-library-types', () => {
 
     // Check that the types package was removed
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
-    expect(packageJson.devDependencies).toEqual({});
+    expect(packageJson.devDependencies).toEqual({
+      '@testing-library/jest-dom': '^6.0.0',
+      '@testing-library/react': '14.0.0',
+    });
   });
 
   it('should not modify setupTests.d.ts if import already exists', () => {
@@ -78,6 +83,7 @@ describe('005-remove-testing-library-types', () => {
     // Check that the types package was still removed
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
     expect(packageJson.devDependencies).toEqual({
+      '@testing-library/jest-dom': '^6.0.0',
       '@testing-library/react': '14.0.0',
     });
   });
@@ -103,6 +109,7 @@ describe('005-remove-testing-library-types', () => {
     // Check that package.json was not modified (no types package to remove)
     const packageJson = JSON.parse(result.getFile('package.json') || '{}');
     expect(packageJson.devDependencies).toEqual({
+      '@testing-library/jest-dom': '^6.0.0',
       '@testing-library/react': '14.0.0',
     });
   });

--- a/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.ts
+++ b/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.ts
@@ -1,5 +1,5 @@
 import type { Context } from '../context.js';
-import { removeDependenciesFromPackageJson } from '../utils.js';
+import { removeDependenciesFromPackageJson, addDependenciesToPackageJson } from '../utils.js';
 
 export default function migrate(context: Context) {
   if (context.doesFileExist('./.config/types/setupTests.d.ts')) {
@@ -15,6 +15,7 @@ export default function migrate(context: Context) {
   }
 
   if (context.doesFileExist('package.json')) {
+    addDependenciesToPackageJson(context, {}, { '@testing-library/jest-dom': '^6.0.0' });
     removeDependenciesFromPackageJson(context, [], ['@types/testing-library__jest-dom']);
   }
 

--- a/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.ts
+++ b/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.ts
@@ -1,0 +1,22 @@
+import type { Context } from '../context.js';
+import { removeDependenciesFromPackageJson } from '../utils.js';
+
+export default function migrate(context: Context) {
+  if (context.doesFileExist('./.config/types/setupTests.d.ts')) {
+    const setupTestsContent = context.getFile('./.config/types/setupTests.d.ts');
+    if (!setupTestsContent?.includes('@testing-library/jest-dom')) {
+      context.updateFile(
+        './.config/types/setupTests.d.ts',
+        `import '@testing-library/jest-dom';\n${setupTestsContent}`
+      );
+    }
+  } else {
+    context.addFile('./.config/types/setupTests.d.ts', "import '@testing-library/jest-dom';\n");
+  }
+
+  if (context.doesFileExist('package.json')) {
+    removeDependenciesFromPackageJson(context, [], ['@types/testing-library__jest-dom']);
+  }
+
+  return context;
+}

--- a/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.ts
+++ b/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.ts
@@ -1,5 +1,5 @@
 import type { Context } from '../context.js';
-import { removeDependenciesFromPackageJson, addDependenciesToPackageJson, isVersionGreater } from '../utils.js';
+import { removeDependenciesFromPackageJson, isVersionGreater } from '../utils.js';
 
 export default function migrate(context: Context) {
   if (context.doesFileExist('package.json')) {
@@ -17,7 +17,6 @@ export default function migrate(context: Context) {
         context.addFile('./.config/types/setupTests.d.ts', "import '@testing-library/jest-dom';\n");
       }
 
-      addDependenciesToPackageJson(context, {}, { '@testing-library/jest-dom': '^6.0.0' });
       removeDependenciesFromPackageJson(context, [], ['@types/testing-library__jest-dom']);
     }
   }

--- a/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.ts
+++ b/packages/create-plugin/src/migrations/scripts/007-remove-testing-library-types.ts
@@ -1,22 +1,25 @@
 import type { Context } from '../context.js';
-import { removeDependenciesFromPackageJson, addDependenciesToPackageJson } from '../utils.js';
+import { removeDependenciesFromPackageJson, addDependenciesToPackageJson, isVersionGreater } from '../utils.js';
 
 export default function migrate(context: Context) {
-  if (context.doesFileExist('./.config/types/setupTests.d.ts')) {
-    const setupTestsContent = context.getFile('./.config/types/setupTests.d.ts');
-    if (!setupTestsContent?.includes('@testing-library/jest-dom')) {
-      context.updateFile(
-        './.config/types/setupTests.d.ts',
-        `import '@testing-library/jest-dom';\n${setupTestsContent}`
-      );
-    }
-  } else {
-    context.addFile('./.config/types/setupTests.d.ts', "import '@testing-library/jest-dom';\n");
-  }
-
   if (context.doesFileExist('package.json')) {
-    addDependenciesToPackageJson(context, {}, { '@testing-library/jest-dom': '^6.0.0' });
-    removeDependenciesFromPackageJson(context, [], ['@types/testing-library__jest-dom']);
+    const packageJson = JSON.parse(context.getFile('package.json') || '{}');
+    if (isVersionGreater(packageJson.devDependencies['@testing-library/jest-dom'], '6.0.0', true)) {
+      if (context.doesFileExist('./.config/types/setupTests.d.ts')) {
+        const setupTestsContent = context.getFile('./.config/types/setupTests.d.ts');
+        if (!setupTestsContent?.includes('@testing-library/jest-dom')) {
+          context.updateFile(
+            './.config/types/setupTests.d.ts',
+            `import '@testing-library/jest-dom';\n${setupTestsContent}`
+          );
+        }
+      } else {
+        context.addFile('./.config/types/setupTests.d.ts', "import '@testing-library/jest-dom';\n");
+      }
+
+      addDependenciesToPackageJson(context, {}, { '@testing-library/jest-dom': '^6.0.0' });
+      removeDependenciesFromPackageJson(context, [], ['@types/testing-library__jest-dom']);
+    }
   }
 
   return context;

--- a/packages/create-plugin/templates/common/.config/types/setupTests.d.ts
+++ b/packages/create-plugin/templates/common/.config/types/setupTests.d.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -33,7 +33,6 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",{{#if isAppType}}{{#unless useReactRouterV6}}
     "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/unless}}{{/if}}
-    "@types/testing-library__jest-dom": "5.14.8",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",{{#unless useExperimentalRspack}}
     "copy-webpack-plugin": "^11.0.0",{{/unless}}


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
`@testing-library/jest-dom` added support for typescript types in v6 and [deprecated](https://www.npmjs.com/package/@types/testing-library__jest-dom) `@types/testing-library__jest-dom` package. This PR removes it and adds a declaration file to the `.config/types` directory so plugin devs continue to get typings for the extended matchers.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #2003

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.1.13-canary.2250.19497387794.0
  # or 
  yarn add @grafana/create-plugin@6.1.13-canary.2250.19497387794.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
