### PR TITLE
Add ignore presets list to the main config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
+  "ignorePresets": [
+    "github>grafana/grafana-renovate-config//presets/base",
+    "github>grafana/grafana-renovate-config//presets/automerge",
+    "github>grafana/grafana-renovate-config//presets/labels",
+    "github>grafana/grafana-renovate-config//presets/npm"
+  ],
   "includePaths": [
     "package.json",
     "packages/**",
@@ -50,7 +56,7 @@
       "automerge": false,
       "groupName": "grafana patch dependencies",
       "groupSlug": "all-grafana-patch",
-      "labels": ["dependencies", "patch"],
+      "addLabels": ["patch"],
       "matchCurrentVersion": "!/^0/",
       "matchUpdateTypes": ["patch"],
       "matchPackageNames": [
@@ -64,7 +70,7 @@
       "automerge": true,
       "groupName": "e2e-selector dependencies",
       "groupSlug": "plugin-e2e-selectors",
-      "labels": ["dependencies", "patch", "release"],
+      "addLabels": ["patch", "release"],
       "matchPackageNames": ["@grafana/e2e-selectors"],
       "followTag": "modified",
       "rangeStrategy": "bump",
@@ -77,7 +83,7 @@
     {
       "groupName": "grafana dependencies",
       "groupSlug": "all-grafana",
-      "labels": ["dependencies", "release", "patch"],
+      "addLabels": ["release", "patch"],
       "matchUpdateTypes": ["minor", "major"],
       "matchPackageNames": [
         "/@grafana/*/",
@@ -90,7 +96,7 @@
     },
     {
       "groupName": "docusaurus dependencies",
-      "labels": ["dependencies", "javascript", "no-changelog"],
+      "addLabels": ["no-changelog"],
       "rangeStrategy": "bump",
       "matchPackageNames": ["/@?docusaurus/"]
     },
@@ -103,7 +109,7 @@
       "automerge": true,
       "groupName": "auto-merged devDependencies",
       "groupSlug": "dev-dependencies-automerge",
-      "labels": ["dependencies", "javascript", "no-changelog"],
+      "addLabels": ["no-changelog"],
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["devDependencies", "optionalDependencies"],
       "matchPackageNames": [
@@ -119,7 +125,7 @@
       "automerge": true,
       "groupName": "auto-merged patch dependencies",
       "groupSlug": "prod-dependencies-automerge",
-      "labels": ["dependencies", "javascript", "no-changelog"],
+      "addLabels": ["no-changelog"],
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"],
@@ -132,7 +138,7 @@
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
       "reviewers": ["jackw"],
       "matchManagers": ["github-actions"]
-    }
+    }   
   ],
   "vulnerabilityAlerts": {
     "addLabels": ["security"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -138,7 +138,7 @@
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
       "reviewers": ["jackw"],
       "matchManagers": ["github-actions"]
-    }   
+    }
   ],
   "vulnerabilityAlerts": {
     "addLabels": ["security"]


### PR DESCRIPTION
Looks like it does not inherit the ignores from
github>grafana/grafana-community-team//renovate/renovate due to https://docs.renovatebot.com/config-overview/#you-can-not-ignore-presets-from-inherited-config