### PR TITLE
Remove path-to-regexp override

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,9 +82,6 @@
     "*.{css,md,json}": "prettier --write"
   },
   "overrides": {
-    "serve-handler": {
-      "path-to-regexp": "3.3.0"
-    },
     "express": {
       "cookie": "^0.7.0"
     },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The package ecosystem has caught up so this override is no longer needed (introduced in https://github.com/grafana/plugin-tools/pull/1137)