### PR TITLE
Chore: Add custom manager for workflow templates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
   "ignorePresets": [
-    "github>grafana/grafana-renovate-config//presets/github-actions",
     "github>grafana/grafana-renovate-config//presets/base",
     "github>grafana/grafana-renovate-config//presets/automerge",
     "github>grafana/grafana-renovate-config//presets/labels",
@@ -143,7 +142,7 @@
       "matchFiles": ["packages/create-plugin/templates/github/workflows/**"]
     },
     {
-      "automerge": true,
+      "automerge": false,
       "groupName": "auto-merged gitHub actions",
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
   "ignorePresets": [
-    "github>grafana/grafana-renovate-config//presets/github-actions",
     "github>grafana/grafana-renovate-config//presets/base",
     "github>grafana/grafana-renovate-config//presets/automerge",
     "github>grafana/grafana-renovate-config//presets/labels",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -146,7 +146,8 @@
       "automerge": true,
       "groupName": "auto-merged gitHub actions",
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
-      "matchManagers": ["github-actions"]
+      "matchManagers": ["github-actions"],
+      "matchFiles": [".github/workflows/**"]
     }
   ],
   "vulnerabilityAlerts": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,7 +47,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/packages/create-plugin/templates/github/workflows/.*\\.ya?ml$/"],
+      "managerFilePatterns": ["/(^|/)templates/github/workflows/.*\\.ya?ml$/"],
       "matchStrings": [
         "uses:\\s+(?<depName>[^@]+)@(?<currentValue>\\S+)"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,7 +48,7 @@
     },
     {
       "customType": "regex",
-      "managerFilePatterns": ["/(^|/)templates/github/workflows/.*\\.ya?ml$/"],
+      "managerFilePatterns": ["/(^|/)packages/create-plugin/templates/github/workflows/.*\\.ya?ml$/"],
       "matchStrings": [
         "uses:\\s+(?<depName>[^@]+)@(?<currentValue>\\S+)"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -137,7 +137,7 @@
     {
       "automerge": false,
       "groupName": "create-plugin template github actions",
-      "labels": ["ci", "github_actions", "dependencies", "create-plugin"],
+      "labels": ["release", "patch", "create-plugin"],
       "reviewers": ["sunker"],
       "matchDatasources": ["github-actions"],
       "matchFiles": ["packages/create-plugin/templates/github/workflows/**"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -143,7 +143,7 @@
     },
     {
       "automerge": false,
-      "groupName": "auto-merged gitHub actions",
+      "groupName": "auto-merged github actions",
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
       "matchManagers": ["github-actions"],
       "matchFiles": [".github/workflows/**"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
   "ignorePresets": [
+    "github>grafana/grafana-renovate-config//presets/github-actions",
     "github>grafana/grafana-renovate-config//presets/base",
     "github>grafana/grafana-renovate-config//presets/automerge",
     "github>grafana/grafana-renovate-config//presets/labels",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,7 +49,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/packages/create-plugin/templates/github/workflows/.*\\.ya?ml$/"],
       "matchStrings": [
-        "uses:\\s+(?<depName>[^@\\s]+)@(?<currentValue>[^\\s#]+)"
+        "uses:\\s+(?<depName>[^@]+)@(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "github-actions"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,11 +25,6 @@
   "skipInstalls": false,
   "reviewers": ["team:grafana/plugins-platform-frontend"],
   "enabledManagers": ["custom.regex", "npm", "github-actions"],
-  // Extends the github-actions manager to include create-plugin workflow templates
-  // See: https://docs.renovatebot.com/modules/manager/#extending-a-managers-default-managerfilepatterns
-  "github-actions": {
-    "managerFilePatterns": ["/(^|/)packages/create-plugin/templates/github/workflows/.+\\.ya?ml$/"]
-  },
   "postUpdateOptions": ["npmDedupe"],
   "labels": ["dependencies", "javascript", "no-changelog"],
   "customManagers": [
@@ -49,6 +44,14 @@
       ],
       "depNameTemplate": "grafana/grafana-enterprise",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/packages/create-plugin/templates/github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": [
+        "uses:\\s+(?<depName>[^@\\s]+)@(?<currentValue>[^\\s#]+)"
+      ],
+      "datasourceTemplate": "github-actions"
     }
   ],
   "packageRules": [
@@ -131,11 +134,17 @@
       "matchPackageNames": ["!/^@?docusaurus/", "!/@grafana/*/"]
     },
     {
-      // disable automerge temporarily until we know the action can update create-plugin hbs templates.
       "automerge": false,
+      "groupName": "create-plugin template github actions",
+      "labels": ["ci", "github_actions", "dependencies", "create-plugin"],
+      "reviewers": ["sunker"],
+      "matchDatasources": ["github-actions"],
+      "matchFiles": ["packages/create-plugin/templates/github/workflows/**"]
+    },
+    {
+      "automerge": true,
       "groupName": "auto-merged gitHub actions",
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
-      "reviewers": ["jackw"],
       "matchManagers": ["github-actions"]
     }
   ],


### PR DESCRIPTION
**What this PR does / why we need it**:

GitHub Actions workflow templates in `packages/create-plugin/templates/github/workflows/` use Handlebars syntax, which causes the standard `github-actions` manager to fail with yaml parsing errors. We attempted to use `managerFilePatterns` to limit the `github-actions` manager scope, but this doesn't solve the underlying issue (the manager still tries to parse the templates as valid yaml).

This PR adds a custom regex manager to extract gh action dependencies from the template files, and adds a separate package rule so workflow templates and repository workflows can have different labels. 

I haven't been able to verify that this works, so for now I've disabled auto merging for both of these rules. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
