### PR TITLE
Create plugin: fix permissions issue in cp-update workflow 

### DIFF
--- a/docusaurus/docs/set-up/set-up-github.md
+++ b/docusaurus/docs/set-up/set-up-github.md
@@ -89,11 +89,11 @@ The workflow contains the following steps:
 
 The create plugin update (`cp-update.yml`) workflow automates keeping your plugin's development environment and dependencies up to date. It periodically checks the latest version of create-plugin listed on the npm registry and compares it to the version used by your plugin. If there's a newer version available, the workflow runs the `create-plugin update` command, updates the frontend dependency lockfile, then creates a PR with the changes for review.
 
-This workflow requires content, pull request and workflow write access to your plugin's repo to push changes and open PRs. Choose from the following two options:
+This workflow requires content, pull request and workflow write access to your plugin's repo to push changes and open PRs.
 
 ### Add a personal access token
 
-To use this workflow you must create a GitHub [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with access to the plugin repository and permission to read and write `contents`, `pull requests` and `workflows`. After you create the token, add it to the plugin repository action secrets as GH_PAT_TOKEN then pass it to the action:
+To use this workflow you must create a GitHub [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with access to the plugin repository and permission to read and write `contents`, `pull requests` and `workflows`. After you create the token, add it to the plugin repository action secrets as `GH_PAT_TOKEN` then pass it to the action:
 
 ```yaml
 name: Create Plugin Update

--- a/docusaurus/docs/set-up/set-up-github.md
+++ b/docusaurus/docs/set-up/set-up-github.md
@@ -91,7 +91,7 @@ The create plugin update (`cp-update.yml`) workflow automates keeping your plugi
 
 This workflow requires content, pull request and workflow write access to your plugin's repo to push changes and open PRs. Choose from the following two options:
 
-### Add the personal access token
+### Add a personal access token
 
 To use this workflow you must create a GitHub [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with access to the plugin repository and permission to read and write `contents`, `pull requests` and `workflows`. After you create the token, add it to the plugin repository action secrets as GH_PAT_TOKEN then pass it to the action:
 
@@ -107,7 +107,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/plugin-actions/create-plugin-update@main
+      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v1.1.0
         with:
           token: ${{ secrets.GH_PAT_TOKEN }}
 ```

--- a/docusaurus/docs/set-up/set-up-github.md
+++ b/docusaurus/docs/set-up/set-up-github.md
@@ -89,34 +89,11 @@ The workflow contains the following steps:
 
 The create plugin update (`cp-update.yml`) workflow automates keeping your plugin's development environment and dependencies up to date. It periodically checks the latest version of create-plugin listed on the npm registry and compares it to the version used by your plugin. If there's a newer version available, the workflow runs the `create-plugin update` command, updates the frontend dependency lockfile, then creates a PR with the changes for review.
 
-This workflow requires content and pull request write access to your plugin's repo to push changes and open PRs. Choose from the following two options:
+This workflow requires content, pull request and workflow write access to your plugin's repo to push changes and open PRs. Choose from the following two options:
 
-### Use the default access token
+### Add the personal access token
 
-To use this option you must allow [github actions to create and approve pull requests](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#preventing-github-actions-from-creating-or-approving-pull-requests) within your repository settings and use the `permissions` property in the workflow to elevate the default access token permissions like so:
-
-```yaml
-name: Create Plugin Update
-
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 1 * *' # run once a month on the 1st day
-
-permissions:
-  contents: write
-  pull-requests: write
-
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: grafana/plugin-actions/create-plugin-update@main
-```
-
-### Use a personal access token
-
-To use this option, you must create a GitHub [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with access to the plugin repository and permission to read and write both `contents` and `pull requests`. After you create the token, add it to the plugin repository action secrets and then pass it to the action:
+To use this workflow you must create a GitHub [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with access to the plugin repository and permission to read and write `contents`, `pull requests` and `workflows`. After you create the token, add it to the plugin repository action secrets as GH_PAT_TOKEN then pass it to the action:
 
 ```yaml
 name: Create Plugin Update

--- a/docusaurus/website/docusaurus.config.ts
+++ b/docusaurus/website/docusaurus.config.ts
@@ -30,7 +30,6 @@ const config: Config = {
   url: PORTAL_URL,
   baseUrl: 'developers/plugin-tools/',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
   onBrokenAnchors: 'throw',
   favicon: 'img/favicon.png',
   // GitHub pages deployment config.
@@ -50,6 +49,11 @@ const config: Config = {
     v4: {
       removeLegacyPostBuildHeadAttribute: true,
       useCssCascadeLayers: false,
+    },
+  },
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
     },
   },
   plugins: [

--- a/packages/create-plugin/templates/github/workflows/cp-update.yml
+++ b/packages/create-plugin/templates/github/workflows/cp-update.yml
@@ -5,22 +5,16 @@ on:
   schedule:
     - cron: '0 0 1 * *' # run once a month on the 1st day
 
-# To use the default github token with the following elevated permissions make sure to check:
-# **Allow GitHub Actions to create and approve pull requests** in https://github.com/ORG_NAME/REPO_NAME/settings/actions.
-# Alternatively create a fine-grained personal access token for your repository with
-# `contents: read and write` and `pull requests: read and write` and pass it to the action.
-
-permissions:
-  contents: write
-  pull-requests: write
+# To use this workflow please create a fine-grained personal access token for your repository with:
+# `contents: read and write`
+# `pull requests: read and write`
+# `workflows: read and write`
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v1.1.0
-        # Uncomment to use a fine-grained personal access token instead of default github token
-        # (For more info on how to generate the token see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
-        # with:
-          # Make sure to save the token in your repository secrets
-          # token: ${{ secrets.GH_PAT_TOKEN }}
+        with:
+          # Make sure to save the token in your repository secrets as `GH_PAT_TOKEN`
+          token: ${{ secrets.GH_PAT_TOKEN }}

--- a/packages/create-plugin/templates/github/workflows/cp-update.yml
+++ b/packages/create-plugin/templates/github/workflows/cp-update.yml
@@ -1,3 +1,4 @@
+{{!-- /* 🚨 The `${{ }}` Github workflow expressions need to be escaped so they are not being interpreted by Handlebars. (this comment is going to be removed after scaffolding) 🚨 */ --}}
 name: Create Plugin Update
 
 on:
@@ -17,4 +18,4 @@ jobs:
       - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v1.1.0
         with:
           # Make sure to save the token in your repository secrets as `GH_PAT_TOKEN`
-          token: ${{ secrets.GH_PAT_TOKEN }}
+          token: $\{{ secrets.GH_PAT_TOKEN }}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Due to migrations touching github workflows we are seeing permission issues with the cp-update workflow not being able to push to repos. This PR updates the scaffolded workflow to only mention usage of a GH personal access token and adds mention of the necessary workflows permissions. 


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.0.2-canary.2281.19166475357.0
  npm install @grafana/create-plugin@6.1.8-canary.2281.19166475357.0
  npm install @grafana/eslint-plugin-plugins@0.5.4-canary.2281.19166475357.0
  npm install @grafana/plugin-meta-extractor@0.10.2-canary.2281.19166475357.0
  # or 
  yarn add website@5.0.2-canary.2281.19166475357.0
  yarn add @grafana/create-plugin@6.1.8-canary.2281.19166475357.0
  yarn add @grafana/eslint-plugin-plugins@0.5.4-canary.2281.19166475357.0
  yarn add @grafana/plugin-meta-extractor@0.10.2-canary.2281.19166475357.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
