### PR TITLE
Create plugin: use react 18.3.x

### DIFF
--- a/packages/create-plugin/CONTRIBUTING.md
+++ b/packages/create-plugin/CONTRIBUTING.md
@@ -222,6 +222,9 @@ describe('Migration - append profile to webpack', () => {
 });
 ```
 
+> [!TIP]
+> A lot of the code used by migrations has debug messaging. You can output this in tests to help debugging by using `DEBUG="create-plugin:migrations" npm run test -w @grafana/create-plugin`
+
 #### How to test a migration locally
 
 To test a migration locally you'll need a plugin to test on.

--- a/packages/create-plugin/src/migrations/migrations.ts
+++ b/packages/create-plugin/src/migrations/migrations.ts
@@ -37,7 +37,7 @@ export default {
     },
     '005-react-18-3': {
       version: '6.1.7-beta.1',
-      description: 'Update React 18.0.0 to 18.3.1.',
+      description: 'Update React and ReactDOM 18.x versions to ^18.3.0 to surface React 19 compatibility issues.',
       migrationScript: './scripts/005-react-18-3.js',
     },
   },

--- a/packages/create-plugin/src/migrations/migrations.ts
+++ b/packages/create-plugin/src/migrations/migrations.ts
@@ -36,7 +36,7 @@ export default {
       migrationScript: './scripts/004-eslint9-flat-config.js',
     },
     '005-react-18-3': {
-      version: '6.1.7-beta.1',
+      version: '6.1.9',
       description: 'Update React and ReactDOM 18.x versions to ^18.3.0 to surface React 19 compatibility issues.',
       migrationScript: './scripts/005-react-18-3.js',
     },

--- a/packages/create-plugin/src/migrations/migrations.ts
+++ b/packages/create-plugin/src/migrations/migrations.ts
@@ -10,6 +10,8 @@ type Migrations = {
   migrations: Record<string, MigrationMeta>;
 };
 
+// Do not use LEGACY_UPDATE_CUTOFF_VERSION for new migrations. It was used to force migrations to run
+// for those written before the switch to updates as migrations.
 export default {
   migrations: {
     '001-update-grafana-compose-extend': {
@@ -33,7 +35,10 @@ export default {
       description: 'Migrate eslint config to flat config format and update devDependencies to latest versions.',
       migrationScript: './scripts/004-eslint9-flat-config.js',
     },
-    // Do not use LEGACY_UPDATE_CUTOFF_VERSION for new migrations. It is only used above to force migrations to run
-    // for those written before the switch to updates as migrations.
+    '005-react-18-3': {
+      version: '6.1.7-beta.1',
+      description: 'Update React 18.0.0 to 18.3.1.',
+      migrationScript: './scripts/005-react-18-3.js',
+    },
   },
 } as Migrations;

--- a/packages/create-plugin/src/migrations/scripts/005-react-18-3.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/005-react-18-3.test.ts
@@ -44,7 +44,46 @@ describe('005-react-18-3', () => {
     expect(context.getFile('./package.json')).toBe(initialPackageJson);
   });
 
-  it('should not downgrade React 19.0.0 to 18.3.1', async () => {
+  it('should update React 18.0.0 to ^18.3.0', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './package.json',
+      JSON.stringify({
+        dependencies: {
+          react: '^18.0.0',
+        },
+      })
+    );
+
+    await migrate(context);
+
+    const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
+    expect(updatedPackageJson.dependencies.react).toBe('^18.3.0');
+    expect(updatedPackageJson.devDependencies?.['@types/react']).toBe('^18.3.0');
+  });
+
+  it('should not update React if version is already 18.3.0 or higher', async () => {
+    const context = new Context('/virtual');
+    const packageJson = {
+      dependencies: {
+        react: '^18.3.0',
+        'react-dom': '^18.3.0',
+      },
+      devDependencies: {
+        '@types/react': '^18.3.0',
+        '@types/react-dom': '^18.3.0',
+      },
+    };
+    context.addFile('./package.json', JSON.stringify(packageJson, null, 2));
+
+    await migrate(context);
+
+    const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
+    expect(updatedPackageJson.dependencies.react).toBe('^18.3.0');
+    expect(updatedPackageJson.dependencies['react-dom']).toBe('^18.3.0');
+  });
+
+  it('should not downgrade React 19.0.0 to 18.3.0', async () => {
     const context = new Context('/virtual');
     const packageJson = {
       dependencies: {
@@ -67,47 +106,6 @@ describe('005-react-18-3', () => {
     expect(updatedPackageJson.devDependencies['@types/react-dom']).toBe('^19.0.0');
   });
 
-  it('should update React 18.0.0 to 18.3.1', async () => {
-    const context = new Context('/virtual');
-    context.addFile(
-      './package.json',
-      JSON.stringify({
-        dependencies: {
-          react: '^18.0.0',
-        },
-      })
-    );
-
-    await migrate(context);
-
-    const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
-    expect(updatedPackageJson.dependencies.react).toBe('^18.3.1');
-    expect(updatedPackageJson.devDependencies?.['@types/react']).toBe('^18.3.1');
-  });
-
-  it('should not update React if version is already 18.3.1 or higher', async () => {
-    const context = new Context('/virtual');
-    const packageJson = {
-      dependencies: {
-        react: '^18.3.1',
-        'react-dom': '^18.3.1',
-      },
-      devDependencies: {
-        '@types/react': '^18.3.1',
-        '@types/react-dom': '^18.3.1',
-      },
-    };
-    context.addFile('./package.json', JSON.stringify(packageJson, null, 2));
-
-    await migrate(context);
-
-    // Since the versions are already 18.3.1, the migration should still run
-    // but the versions should remain 18.3.1
-    const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
-    expect(updatedPackageJson.dependencies.react).toBe('^18.3.1');
-    expect(updatedPackageJson.dependencies['react-dom']).toBe('^18.3.1');
-  });
-
   it('should handle version ranges correctly', async () => {
     const context = new Context('/virtual');
     context.addFile(
@@ -123,8 +121,8 @@ describe('005-react-18-3', () => {
     await migrate(context);
 
     const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
-    expect(updatedPackageJson.dependencies.react).toBe('^18.3.1');
-    expect(updatedPackageJson.dependencies['react-dom']).toBe('^18.3.1');
+    expect(updatedPackageJson.dependencies.react).toBe('^18.3.0');
+    expect(updatedPackageJson.dependencies['react-dom']).toBe('^18.3.0');
   });
 
   it('should be idempotent', async () => {

--- a/packages/create-plugin/src/migrations/scripts/005-react-18-3.test.ts
+++ b/packages/create-plugin/src/migrations/scripts/005-react-18-3.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { Context } from '../context.js';
+import migrate from './005-react-18-3.js';
+
+describe('005-react-18-3', () => {
+  it('should not modify anything if package.json does not exist', async () => {
+    const context = new Context('/virtual');
+    await migrate(context);
+    expect(context.listChanges()).toEqual({});
+  });
+
+  it('should not modify anything if there are no React dependencies', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './package.json',
+      JSON.stringify({
+        dependencies: {
+          lodash: '^4.17.21',
+        },
+      })
+    );
+    const initialChanges = context.listChanges();
+    await migrate(context);
+    expect(context.listChanges()).toEqual(initialChanges);
+  });
+
+  it('should not update React if version is below 18.0.0', async () => {
+    const context = new Context('/virtual');
+    const packageJson = {
+      dependencies: {
+        react: '^17.0.2',
+        'react-dom': '^17.0.2',
+      },
+      devDependencies: {
+        '@types/react': '^17.0.0',
+        '@types/react-dom': '^17.0.0',
+      },
+    };
+    context.addFile('./package.json', JSON.stringify(packageJson, null, 2));
+    const initialPackageJson = context.getFile('./package.json');
+
+    await migrate(context);
+
+    expect(context.getFile('./package.json')).toBe(initialPackageJson);
+  });
+
+  it('should not downgrade React 19.0.0 to 18.3.1', async () => {
+    const context = new Context('/virtual');
+    const packageJson = {
+      dependencies: {
+        react: '^19.0.0',
+        'react-dom': '^19.0.0',
+      },
+      devDependencies: {
+        '@types/react': '^19.0.0',
+        '@types/react-dom': '^19.0.0',
+      },
+    };
+    context.addFile('./package.json', JSON.stringify(packageJson, null, 2));
+
+    await migrate(context);
+
+    const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
+    expect(updatedPackageJson.dependencies.react).toBe('^19.0.0');
+    expect(updatedPackageJson.dependencies['react-dom']).toBe('^19.0.0');
+    expect(updatedPackageJson.devDependencies['@types/react']).toBe('^19.0.0');
+    expect(updatedPackageJson.devDependencies['@types/react-dom']).toBe('^19.0.0');
+  });
+
+  it('should update React 18.0.0 to 18.3.1', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './package.json',
+      JSON.stringify({
+        dependencies: {
+          react: '^18.0.0',
+        },
+      })
+    );
+
+    await migrate(context);
+
+    const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
+    expect(updatedPackageJson.dependencies.react).toBe('^18.3.1');
+    expect(updatedPackageJson.devDependencies?.['@types/react']).toBe('^18.3.1');
+  });
+
+  it('should not update React if version is already 18.3.1 or higher', async () => {
+    const context = new Context('/virtual');
+    const packageJson = {
+      dependencies: {
+        react: '^18.3.1',
+        'react-dom': '^18.3.1',
+      },
+      devDependencies: {
+        '@types/react': '^18.3.1',
+        '@types/react-dom': '^18.3.1',
+      },
+    };
+    context.addFile('./package.json', JSON.stringify(packageJson, null, 2));
+
+    await migrate(context);
+
+    // Since the versions are already 18.3.1, the migration should still run
+    // but the versions should remain 18.3.1
+    const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
+    expect(updatedPackageJson.dependencies.react).toBe('^18.3.1');
+    expect(updatedPackageJson.dependencies['react-dom']).toBe('^18.3.1');
+  });
+
+  it('should handle version ranges correctly', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './package.json',
+      JSON.stringify({
+        dependencies: {
+          react: '~18.1.0',
+          'react-dom': '18.2.0',
+        },
+      })
+    );
+
+    await migrate(context);
+
+    const updatedPackageJson = JSON.parse(context.getFile('./package.json') || '{}');
+    expect(updatedPackageJson.dependencies.react).toBe('^18.3.1');
+    expect(updatedPackageJson.dependencies['react-dom']).toBe('^18.3.1');
+  });
+
+  it('should be idempotent', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      './package.json',
+      JSON.stringify({
+        dependencies: {
+          react: '^18.2.0',
+          'react-dom': '^18.2.0',
+        },
+        devDependencies: {
+          '@types/react': '^18.2.0',
+          '@types/react-dom': '^18.2.0',
+        },
+      })
+    );
+    await expect(migrate).toBeIdempotent(context);
+  });
+});

--- a/packages/create-plugin/src/migrations/scripts/005-react-18-3.ts
+++ b/packages/create-plugin/src/migrations/scripts/005-react-18-3.ts
@@ -6,12 +6,12 @@ export default function migrate(context: Context) {
     const packageJson = JSON.parse(context.getFile('package.json') || '{}');
     if (packageJson.dependencies?.react) {
       if (isVersionGreater(packageJson.dependencies.react, '18.0.0', true)) {
-        addDependenciesToPackageJson(context, { react: '^18.3.1' }, { '@types/react': '^18.3.1' });
+        addDependenciesToPackageJson(context, { react: '^18.3.0' }, { '@types/react': '^18.3.0' });
       }
     }
     if (packageJson.dependencies?.['react-dom']) {
       if (isVersionGreater(packageJson.dependencies['react-dom'], '18.0.0', true)) {
-        addDependenciesToPackageJson(context, { 'react-dom': '^18.3.1' }, { '@types/react-dom': '^18.3.1' });
+        addDependenciesToPackageJson(context, { 'react-dom': '^18.3.0' }, { '@types/react-dom': '^18.3.0' });
       }
     }
   }

--- a/packages/create-plugin/src/migrations/scripts/005-react-18-3.ts
+++ b/packages/create-plugin/src/migrations/scripts/005-react-18-3.ts
@@ -1,0 +1,19 @@
+import { Context } from '../context.js';
+import { addDependenciesToPackageJson, isVersionGreater } from '../utils.js';
+
+export default function migrate(context: Context) {
+  if (context.doesFileExist('package.json')) {
+    const packageJson = JSON.parse(context.getFile('package.json') || '{}');
+    if (packageJson.dependencies?.react) {
+      if (isVersionGreater(packageJson.dependencies.react, '18.0.0', true)) {
+        addDependenciesToPackageJson(context, { react: '^18.3.1' }, { '@types/react': '^18.3.1' });
+      }
+    }
+    if (packageJson.dependencies?.['react-dom']) {
+      if (isVersionGreater(packageJson.dependencies['react-dom'], '18.0.0', true)) {
+        addDependenciesToPackageJson(context, { 'react-dom': '^18.3.1' }, { '@types/react-dom': '^18.3.1' });
+      }
+    }
+  }
+  return context;
+}

--- a/packages/create-plugin/src/migrations/utils.ts
+++ b/packages/create-plugin/src/migrations/utils.ts
@@ -8,7 +8,7 @@ import { MigrationMeta } from './migrations.js';
 import { output } from '../utils/utils.console.js';
 import { getPackageManagerSilentInstallCmd, getPackageManagerWithFallback } from '../utils/utils.packageManager.js';
 import { execSync } from 'node:child_process';
-import { clean, coerce, gt } from 'semver';
+import { clean, coerce, gt, gte } from 'semver';
 
 export function printChanges(context: Context, key: string, migration: MigrationMeta) {
   const changes = context.listChanges();
@@ -263,8 +263,13 @@ const DIST_TAGS = {
 
 /**
  * Compares two version strings to determine if the incoming version is greater
+ *
+ * @param incomingVersion - The incoming version to compare.
+ * @param existingVersion - The existing version to compare.
+ * @param orEqualTo - Whether to include the existing version in the comparison.
+ *
  */
-export function isVersionGreater(incomingVersion: string, existingVersion: string): boolean {
+export function isVersionGreater(incomingVersion: string, existingVersion: string, orEqualTo = false) {
   const incomingIsDistTag = incomingVersion in DIST_TAGS;
   const existingIsDistTag = existingVersion in DIST_TAGS;
 
@@ -286,6 +291,10 @@ export function isVersionGreater(incomingVersion: string, existingVersion: strin
   // If either version can't be parsed as semver, default to treating the incoming version as greater.
   if (!incomingSemver || !existingSemver) {
     return true;
+  }
+
+  if (orEqualTo) {
+    return gte(incomingSemver, existingSemver);
   }
 
   return gt(incomingSemver, existingSemver);

--- a/packages/create-plugin/src/migrations/utils.ts
+++ b/packages/create-plugin/src/migrations/utils.ts
@@ -266,7 +266,7 @@ const DIST_TAGS = {
  *
  * @param incomingVersion - The incoming version to compare.
  * @param existingVersion - The existing version to compare.
- * @param orEqualTo - Whether to include the existing version in the comparison.
+ * @param orEqualTo - Whether to check for greater than or equal to (>=) instead of just greater than (>).
  *
  */
 export function isVersionGreater(incomingVersion: string, existingVersion: string, orEqualTo = false) {

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -29,7 +29,9 @@
     "@testing-library/jest-dom": "6.1.4",
     "@testing-library/react": "14.0.0",
     "@types/jest": "^29.5.0",
-    "@types/node": "^20.8.7",{{#if isAppType}}{{#unless useReactRouterV6}}
+    "@types/node": "^20.8.7",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",{{#if isAppType}}{{#unless useReactRouterV6}}
     "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/unless}}{{/if}}
     "@types/testing-library__jest-dom": "5.14.8",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
@@ -77,8 +79,8 @@
     "@grafana/ui": "^12.2.1",
     "@grafana/schema": "^12.2.1",{{#if_eq pluginType "scenesapp" }}
     "@grafana/scenes": "{{ scenesVersion }}",{{/if_eq}}
-    "react": "18.2.0",
-    "react-dom": "18.2.0"{{#if isAppType}},
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"{{#if isAppType}},
     "react-router-dom": "^{{ reactRouterVersion }}",
     "rxjs": "7.8.2"{{/if}}
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

We want to move all plugins to use 18.3.x so devs get deprecation warnings via eslint config for any usage of React APIs that were renamed / removed in React 19. This PR addresses this with:

- [x] Updating package.json template to use react 18.3.x deps
- [x] Adds a migration to update react deps to 18.3.x for any plugin that currently uses >=18.0.0 < 19.0.0


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #2264

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.2.0-canary.2283.19289604632.0
  npm install @grafana/plugin-meta-extractor@0.11.0-canary.2283.19289604632.0
  # or 
  yarn add @grafana/create-plugin@6.2.0-canary.2283.19289604632.0
  yarn add @grafana/plugin-meta-extractor@0.11.0-canary.2283.19289604632.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
