### PR TITLE
chore: add search tracking on dev portal

### DIFF
--- a/.github/workflows/deploy-to-developer-portal-dev.yml
+++ b/.github/workflows/deploy-to-developer-portal-dev.yml
@@ -1,6 +1,5 @@
 name: Deploy to Developer Portal DEV Bucket
 
-
 on:
   workflow_dispatch:
     inputs:
@@ -37,12 +36,15 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run tests
+        run: npm run docs:test:ci
 
       - name: Build documentation website
         run: DEV_PORTAL_ENV=dev npm run docs:build

--- a/.github/workflows/deploy-to-developer-portal-prod.yml
+++ b/.github/workflows/deploy-to-developer-portal-prod.yml
@@ -1,6 +1,5 @@
 name: Deploy to Developer Portal PROD Bucket
 
-
 on:
   push:
     branches:
@@ -37,12 +36,15 @@ jobs:
       - name: Setup nodejs
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Run tests
+        run: npm run docs:test:ci
 
       - name: Build documentation website
         run: npm run docs:build

--- a/docusaurus/website/package.json
+++ b/docusaurus/website/package.json
@@ -14,9 +14,12 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "lint": "eslint --cache '../docs/**/*.{md,mdx}'",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "test": "vitest",
+    "test:ci": "vitest --run"
   },
   "dependencies": {
+    "@coffeeandfun/remove-pii": "^2.0.0",
     "@docusaurus/core": "^3.9.2",
     "@docusaurus/plugin-client-redirects": "^3.9.2",
     "@docusaurus/preset-classic": "^3.9.2",
@@ -24,6 +27,7 @@
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "cookiejs": "^2.1.2",
+    "debounce": "^1.2.1",
     "docusaurus-lunr-search": "^3.6.0",
     "gridsome-remark-figure-caption": "1.2.2",
     "prism-react-renderer": "^2.1.0",
@@ -35,6 +39,7 @@
     "@docusaurus/module-type-aliases": "^3.9.2",
     "@docusaurus/remark-plugin-npm2yarn": "^3.9.2",
     "@docusaurus/tsconfig": "^3.9.2",
+    "@types/debounce": "^1.2.4",
     "dotenv": "^17.2.3",
     "raw-loader": "^4.0.2",
     "typescript": "^5.9.3"

--- a/docusaurus/website/package.json
+++ b/docusaurus/website/package.json
@@ -42,7 +42,8 @@
     "@types/debounce": "^1.2.4",
     "dotenv": "^17.2.3",
     "raw-loader": "^4.0.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.4"
   },
   "browserslist": {
     "production": [

--- a/docusaurus/website/src/theme/tracking/constants.ts
+++ b/docusaurus/website/src/theme/tracking/constants.ts
@@ -1,0 +1,3 @@
+export const SEARCH_TRACKING_SOURCE = 'developers_plugin_tools_search';
+export const SEARCH_TRACKING_DEBOUNCE = 150;
+export const SEARCH_TRACKING_MAX_LENGTH = 256;

--- a/docusaurus/website/src/theme/tracking/index.ts
+++ b/docusaurus/website/src/theme/tracking/index.ts
@@ -1,8 +1,10 @@
 import { getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';
+import { RudderStack } from './types';
+import { initSearchTracking } from './search';
 
 declare global {
   interface Window {
-    rudderanalytics: any;
+    rudderanalytics: RudderStack;
   }
 }
 
@@ -19,7 +21,7 @@ export const isFaroSetup = (config: FaroConfig) =>
   config && config.url && config.appName && config.environment && config.version;
 
 // Enqueue all rudderstack requests until it is loaded and consent is granted
-let rudderstack = {};
+let rudderstack: Partial<RudderStack> = {};
 let rudderQueue = [];
 const rudderMethods = ['page', 'track', 'identify', 'reset'];
 for (const method of rudderMethods) {
@@ -47,41 +49,45 @@ export function startTracking(
   faroConfig: FaroConfig,
   shouldTrack: boolean
 ) {
-  if (shouldTrack) {
-    if (isRudderstackSetup(rudderStackConfig)) {
-      const { writeKey, url, configUrl } = rudderStackConfig;
+  if (!shouldTrack) {
+    return;
+  }
 
-      const initRudderstack = async () => {
-        rudderId = await window.rudderanalytics.getAnonymousId();
+  if (isRudderstackSetup(rudderStackConfig)) {
+    const { writeKey, url, configUrl } = rudderStackConfig;
 
-        window.rudderanalytics.load(writeKey, url, { configUrl });
-        rudderstack = window.rudderanalytics;
+    const initRudderstack = async () => {
+      rudderId = await window.rudderanalytics.getAnonymousId();
 
-        // send any queued requests
-        for (const [method, ...args] of rudderQueue) {
-          rudderstack[method](...args);
-        }
-        // clean up afterwards so trackPage
-        rudderQueue = undefined;
-      };
+      window.rudderanalytics.load(writeKey, url, { configUrl });
+      rudderstack = window.rudderanalytics;
 
-      const el = document.createElement('script');
-      el.async = true;
-      el.src = rudderStackConfig.sdkUrl;
-      el.onload = initRudderstack;
-      document.getElementsByTagName('head')[0].appendChild(el);
-    }
-    if (isFaroSetup(faroConfig)) {
-      initializeFaro({
-        url: faroConfig.url,
-        app: {
-          name: faroConfig.appName,
-          version: faroConfig.version,
-          environment: faroConfig.environment,
-        },
-        instrumentations: [...getWebInstrumentations()],
-      });
-    }
+      // send any queued requests
+      for (const [method, ...args] of rudderQueue) {
+        rudderstack[method](...args);
+      }
+      // clean up afterwards so trackPage
+      rudderQueue = undefined;
+      initSearchTracking(rudderstack);
+    };
+
+    const el = document.createElement('script');
+    el.async = true;
+    el.src = rudderStackConfig.sdkUrl;
+    el.onload = initRudderstack;
+    document.getElementsByTagName('head')[0].appendChild(el);
+  }
+
+  if (isFaroSetup(faroConfig)) {
+    initializeFaro({
+      url: faroConfig.url,
+      app: {
+        name: faroConfig.appName,
+        version: faroConfig.version,
+        environment: faroConfig.environment,
+      },
+      instrumentations: [...getWebInstrumentations()],
+    });
   }
 }
 

--- a/docusaurus/website/src/theme/tracking/logger.ts
+++ b/docusaurus/website/src/theme/tracking/logger.ts
@@ -1,0 +1,7 @@
+import { faro, LogLevel } from '@grafana/faro-web-sdk';
+import { SEARCH_TRACKING_SOURCE } from './constants';
+
+export function log(message: string, level: LogLevel) {
+  const context = { source: SEARCH_TRACKING_SOURCE };
+  faro?.api?.pushLog([message], { level, context });
+}

--- a/docusaurus/website/src/theme/tracking/search.test.ts
+++ b/docusaurus/website/src/theme/tracking/search.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LogLevel } from '@grafana/faro-web-sdk';
+import { removePII, validatePIICompliance } from '@coffeeandfun/remove-pii';
+import { log } from './logger';
+import { SEARCH_TRACKING_MAX_LENGTH, SEARCH_TRACKING_SOURCE } from './constants';
+import { initSearchTracking, processSearchTerm, setTrackFn, trackSearch } from './search';
+import { RudderStack } from './types';
+
+vi.mock('@theme-original/SearchBar/lunar-search', () => ({ default: vi.fn() }));
+vi.mock('@coffeeandfun/remove-pii', () => ({ removePII: vi.fn(), validatePIICompliance: vi.fn() }));
+vi.mock('./logger', () => ({ log: vi.fn() }));
+
+beforeEach(() => {
+  setTrackFn();
+  vi.clearAllMocks();
+  vi.mocked(validatePIICompliance).mockReturnValue({ isCompliant: true, violationCount: 0 });
+  vi.mocked(removePII).mockImplementation((str) => str);
+  vi.mocked(log).mockImplementation(() => {});
+});
+
+describe('processSearchTerm', () => {
+  it('should truncate the input if its larger than threshold', () => {
+    const input = 'a'.repeat(SEARCH_TRACKING_MAX_LENGTH) + 10;
+
+    const result = processSearchTerm(input);
+
+    expect(result).toEqual('a'.repeat(SEARCH_TRACKING_MAX_LENGTH));
+    expect(validatePIICompliance).toHaveBeenCalledExactlyOnceWith(result);
+    expect(removePII).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('should log and remove PII if the input contains PII', () => {
+    const input = 'searching for somonee@test.org';
+    vi.mocked(validatePIICompliance).mockReturnValue({ isCompliant: false, violationCount: 1 });
+    vi.mocked(removePII).mockReturnValue('searching for [email removed]');
+
+    const result = processSearchTerm(input);
+
+    expect(result).toEqual('searching for [email removed]');
+    expect(validatePIICompliance).toHaveBeenCalledExactlyOnceWith(input);
+    expect(removePII).toHaveBeenCalledExactlyOnceWith(input);
+    expect(log).toHaveBeenCalledExactlyOnceWith(`PII detected: 1 violations`, LogLevel.DEBUG);
+  });
+
+  it('should sanitize string', () => {
+    const input = `<script>alert('xss)</script>`;
+
+    const result = processSearchTerm(input);
+
+    expect(result).toEqual('&lt;script&gt;alert(&#x27;xss)&lt;&#x2F;script&gt;');
+    expect(validatePIICompliance).toHaveBeenCalledExactlyOnceWith(input);
+    expect(removePII).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
+  });
+});
+
+describe('trackSearch', () => {
+  it('should log warning if trackFn is not set', () => {
+    setTrackFn();
+
+    trackSearch('', 0);
+
+    expect(log).toHaveBeenCalledExactlyOnceWith(`RudderStack not initialized, skipping search tracking`, LogLevel.WARN);
+  });
+
+  it('should call trackFn when trackFn is set', () => {
+    const mock = vi.fn();
+    setTrackFn(mock);
+
+    trackSearch('plugin', 5);
+
+    expect(log).not.toHaveBeenCalled();
+    expect(mock).toHaveBeenCalledExactlyOnceWith(SEARCH_TRACKING_SOURCE, {
+      searchTerm: 'plugin',
+      searchResultCount: 5,
+    });
+  });
+});
+
+describe('initSearchTracking', () => {
+  it.each([
+    { rudder: undefined, msg: 'RudderStack not initialized, skipping search tracking', level: LogLevel.WARN },
+    { rudder: null, msg: 'RudderStack not initialized, skipping search tracking', level: LogLevel.WARN },
+    { rudder: {}, msg: 'RudderStack not initialized, skipping search tracking', level: LogLevel.WARN },
+    {
+      rudder: { track: undefined },
+      msg: 'RudderStack not initialized, skipping search tracking',
+      level: LogLevel.WARN,
+    },
+    {
+      rudder: { track: null },
+      msg: 'RudderStack not initialized, skipping search tracking',
+      level: LogLevel.WARN,
+    },
+    {
+      rudder: { track: vi.fn() },
+      msg: 'Search tracking initialized successfully',
+      level: LogLevel.DEBUG,
+    },
+  ])(`should log $msg with level $level when rudderstack object is $rudder`, ({ rudder, msg, level }) => {
+    initSearchTracking(rudder as Partial<RudderStack>);
+
+    expect(log).toHaveBeenCalledExactlyOnceWith(msg, level);
+  });
+
+  it('should log debug message if called twice', () => {
+    const rudder = { track: vi.fn() } as Partial<RudderStack>;
+
+    initSearchTracking(rudder);
+    initSearchTracking(rudder);
+
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenNthCalledWith(1, 'Search tracking initialized successfully', LogLevel.DEBUG);
+    expect(log).toHaveBeenNthCalledWith(2, 'Search tracking already initialized', LogLevel.DEBUG);
+  });
+});

--- a/docusaurus/website/src/theme/tracking/search.test.ts
+++ b/docusaurus/website/src/theme/tracking/search.test.ts
@@ -20,7 +20,7 @@ beforeEach(() => {
 
 describe('processSearchTerm', () => {
   it('should truncate the input if its larger than threshold', () => {
-    const input = 'a'.repeat(SEARCH_TRACKING_MAX_LENGTH) + 10;
+    const input = 'a'.repeat(SEARCH_TRACKING_MAX_LENGTH + 10);
 
     const result = processSearchTerm(input);
 
@@ -31,7 +31,7 @@ describe('processSearchTerm', () => {
   });
 
   it('should log and remove PII if the input contains PII', () => {
-    const input = 'searching for somonee@test.org';
+    const input = 'searching for someone@test.org';
     vi.mocked(validatePIICompliance).mockReturnValue({ isCompliant: false, violationCount: 1 });
     vi.mocked(removePII).mockReturnValue('searching for [email removed]');
 

--- a/docusaurus/website/src/theme/tracking/search.ts
+++ b/docusaurus/website/src/theme/tracking/search.ts
@@ -1,0 +1,87 @@
+import { LogLevel } from '@grafana/faro-web-sdk';
+import lunarSearch from '@theme-original/SearchBar/lunar-search';
+import debounce from 'debounce';
+import { removePII, validatePIICompliance } from '@coffeeandfun/remove-pii';
+import { RudderStack } from './types';
+import { log } from './logger';
+import { SEARCH_TRACKING_DEBOUNCE, SEARCH_TRACKING_MAX_LENGTH, SEARCH_TRACKING_SOURCE } from './constants';
+
+let trackFn: RudderStack['track'] | undefined;
+const originalSearch = lunarSearch.prototype.search;
+
+// exported for test reasons
+export function processSearchTerm(str: string): string {
+  const stringValue = String(str).trim();
+  const truncated =
+    stringValue.length > SEARCH_TRACKING_MAX_LENGTH
+      ? stringValue.substring(0, SEARCH_TRACKING_MAX_LENGTH)
+      : stringValue;
+
+  const compliance = validatePIICompliance(truncated);
+  const redacted = compliance.isCompliant ? truncated : removePII(truncated);
+
+  if (!compliance.isCompliant) {
+    log(`PII detected: ${compliance.violationCount} violations`, LogLevel.DEBUG);
+  }
+
+  const sanitized = redacted
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\//g, '&#x2F;')
+    .replace(/\\/g, '&#x5C;')
+    .replace(/`/g, '&#96;');
+
+  return sanitized;
+}
+
+// exported for test reasons
+export function trackSearch(input: string, searchResultCount: number) {
+  if (!trackFn) {
+    log('RudderStack not initialized, skipping search tracking', LogLevel.WARN);
+    return;
+  }
+
+  const searchTerm = processSearchTerm(input);
+  trackFn(SEARCH_TRACKING_SOURCE, { searchTerm, searchResultCount });
+}
+
+const debounced = debounce(trackSearch, SEARCH_TRACKING_DEBOUNCE);
+
+async function searchWithTracking(input: string) {
+  try {
+    const searchResults = await originalSearch.call(this, input);
+    const searchResultCount = searchResults.length;
+    debounced(input, searchResultCount);
+    return searchResults;
+  } catch (error) {
+    log(`Search with tracking failed: ${error instanceof Error ? error.message : String(error)}`, LogLevel.ERROR);
+    throw error;
+  }
+}
+
+export function initSearchTracking(rudder: Partial<RudderStack>) {
+  if (trackFn) {
+    log('Search tracking already initialized', LogLevel.DEBUG);
+    return;
+  }
+
+  if (!rudder?.track) {
+    log('RudderStack not initialized, skipping search tracking', LogLevel.WARN);
+    return;
+  }
+
+  trackFn = rudder.track.bind(rudder);
+  lunarSearch.prototype.search = searchWithTracking;
+  log('Search tracking initialized successfully', LogLevel.DEBUG);
+}
+
+export function setTrackFn(track: RudderStack['track'] | undefined = undefined) {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error('Do not call setTrackFn outside of tests');
+  }
+
+  trackFn = track;
+}

--- a/docusaurus/website/src/theme/tracking/types.ts
+++ b/docusaurus/website/src/theme/tracking/types.ts
@@ -1,0 +1,6 @@
+export interface RudderStack {
+  track(event: string, properties: Record<string, any>): void;
+  page(properties?: Record<string, any>): void;
+  getAnonymousId(): Promise<string>;
+  load(writeKey: string, url: string, options: { configUrl: string }): void;
+}

--- a/docusaurus/website/src/types/index.d.ts
+++ b/docusaurus/website/src/types/index.d.ts
@@ -1,0 +1,23 @@
+declare module '@coffeeandfun/remove-pii' {
+  /**
+   * Validation compliance result
+   */
+  export interface PIIComplianceResult {
+    isCompliant: boolean;
+    violationCount: number;
+  }
+
+  /**
+   * Removes personally identifiable information (PII) from text
+   * @param text - The text to sanitize
+   * @returns Cleaned text with PII removed
+   */
+  export function removePII(text: string): string;
+
+  /**
+   * Validates if text is PII-compliant and provides detailed compliance information
+   * @param text - The text to validate
+   * @returns Detailed compliance validation result
+   */
+  export function validatePIICompliance(text: string): PIIComplianceResult;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,10 +102,122 @@
         "@types/debounce": "^1.2.4",
         "dotenv": "^17.2.3",
         "raw-loader": "^4.0.2",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.4"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "docusaurus/website/node_modules/@vitest/expect": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.4.tgz",
+      "integrity": "sha512-0ioMscWJtfpyH7+P82sGpAi3Si30OVV73jD+tEqXm5+rIx9LgnfdaOn45uaFkKOncABi/PHL00Yn0oW/wK4cXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.4",
+        "@vitest/utils": "4.0.4",
+        "chai": "^6.0.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "docusaurus/website/node_modules/@vitest/mocker": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.4.tgz",
+      "integrity": "sha512-UTtKgpjWj+pvn3lUM55nSg34098obGhSHH+KlJcXesky8b5wCUgg7s60epxrS6yAG8slZ9W8T9jGWg4PisMf5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.19"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "docusaurus/website/node_modules/@vitest/pretty-format": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.4.tgz",
+      "integrity": "sha512-lHI2rbyrLVSd1TiHGJYyEtbOBo2SDndIsN3qY4o4xe2pBxoJLD6IICghNCvD7P+BFin6jeyHXiUICXqgl6vEaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "docusaurus/website/node_modules/@vitest/runner": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.4.tgz",
+      "integrity": "sha512-99EDqiCkncCmvIZj3qJXBZbyoQ35ghOwVWNnQ5nj0Hnsv4Qm40HmrMJrceewjLVvsxV/JSU4qyx2CGcfMBmXJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "docusaurus/website/node_modules/@vitest/snapshot": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.4.tgz",
+      "integrity": "sha512-XICqf5Gi4648FGoBIeRgnHWSNDp+7R5tpclGosFaUUFzY6SfcpsfHNMnC7oDu/iOLBxYfxVzaQpylEvpgii3zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.4",
+        "magic-string": "^0.30.19",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "docusaurus/website/node_modules/@vitest/spy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.4.tgz",
+      "integrity": "sha512-G9L13AFyYECo40QG7E07EdYnZZYCKMTSp83p9W8Vwed0IyCG1GnpDLxObkx8uOGPXfDpdeVf24P1Yka8/q1s9g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "docusaurus/website/node_modules/@vitest/utils": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.4.tgz",
+      "integrity": "sha512-4bJLmSvZLyVbNsYFRpPYdJViG9jZyRvMZ35IF4ymXbRZoS+ycYghmwTGiscTXduUg2lgKK7POWIyXJNute1hjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.4",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "docusaurus/website/node_modules/dotenv": {
@@ -119,6 +231,97 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "docusaurus/website/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "docusaurus/website/node_modules/vitest": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.4.tgz",
+      "integrity": "sha512-hV31h0/bGbtmDQc0KqaxsTO1v4ZQeF8ojDFuy4sZhFadwAqqvJA0LDw68QUocctI5EDpFMql/jVWKuPYHIf2Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.4",
+        "@vitest/mocker": "4.0.4",
+        "@vitest/pretty-format": "4.0.4",
+        "@vitest/runner": "4.0.4",
+        "@vitest/snapshot": "4.0.4",
+        "@vitest/spy": "4.0.4",
+        "@vitest/utils": "4.0.4",
+        "debug": "^4.4.3",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.19",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.4",
+        "@vitest/browser-preview": "4.0.4",
+        "@vitest/browser-webdriverio": "4.0.4",
+        "@vitest/ui": "4.0.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "libs/output": {
@@ -4543,13 +4746,13 @@
       "license": "0BSD"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-pJdKGq/1iquWYtv1RRSljZklxHCOCAJFJrImO5ZLKPJVJlVUcs8yFwNQlqS0Lo8xT1VAXXTCZocF9n26FWEKsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.0.4",
+        "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
       }
     },
@@ -4559,9 +4762,9 @@
       "license": "0BSD"
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-      "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.0.tgz",
+      "integrity": "sha512-oAYoQnCYaQZKVS53Fq23ceWMRxq5EhQsE0x0RdQ55jT7wagMu5k+fS39v1fiSLrtrLQlXwVINenqhLMtTrV/1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4574,9 +4777,9 @@
       "license": "0BSD"
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5307,19 +5510,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@grafana/data/node_modules/marked": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.0.0.tgz",
-      "integrity": "sha512-MUKMXDjsD/eptB7GPzxo4xcnLS6oo7/RHimUMHEDRhUooPwmN9BEpMl7AEOJv3bmso169wHI2wUF9VQgL7zfmA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/@grafana/data/node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -5650,9 +5840,9 @@
       }
     },
     "node_modules/@grafana/levitate/node_modules/log-symbols/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -5671,21 +5861,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@grafana/levitate/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@grafana/levitate/node_modules/node-fetch": {
@@ -5761,9 +5936,9 @@
       }
     },
     "node_modules/@grafana/levitate/node_modules/ora/node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -5797,9 +5972,9 @@
       }
     },
     "node_modules/@grafana/levitate/node_modules/pretty-ms": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
-      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^4.0.0"
@@ -5840,9 +6015,9 @@
       }
     },
     "node_modules/@grafana/levitate/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -5867,16 +6042,15 @@
       }
     },
     "node_modules/@grafana/levitate/node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "license": "ISC",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
         "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
+        "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
       "engines": {
@@ -6299,9 +6473,9 @@
       }
     },
     "node_modules/@inquirer/external-editor/node_modules/chardet": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
-      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6556,7 +6730,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.1",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6585,7 +6761,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -6738,9 +6916,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -7695,9 +7873,9 @@
       }
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -8553,9 +8731,9 @@
       }
     },
     "node_modules/@npmcli/metavuln-calculator/node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -8563,9 +8741,9 @@
       }
     },
     "node_modules/@npmcli/metavuln-calculator/node_modules/p-map": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8615,9 +8793,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.0.tgz",
-      "integrity": "sha512-gEf705MZLrDPkbbhi8PnoO4ZwYgKoNL+ISZ3AjZMht2r3N5tuTwncyDi6Fv2/qDnMmZxgs0yI8WDOyR8q3G+SQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8628,9 +8806,9 @@
       }
     },
     "node_modules/@npmcli/package-json/node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -9498,7 +9676,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.2",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9948,17 +10128,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.6.0.tgz",
       "integrity": "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rspack/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -11279,6 +11448,7 @@
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -12591,7 +12761,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13349,9 +13521,9 @@
       }
     },
     "node_modules/boxen/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -13393,9 +13565,9 @@
       }
     },
     "node_modules/boxen/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13605,9 +13777,9 @@
       "license": "ISC"
     },
     "node_modules/cacache/node_modules/p-map": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13635,11 +13807,11 @@
       }
     },
     "node_modules/cacache/node_modules/tar": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz",
-      "integrity": "sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -13839,9 +14011,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.0.tgz",
-      "integrity": "sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -15030,9 +15202,9 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -16526,7 +16698,9 @@
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
-      "version": "10.4.0",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
     "node_modules/emojilib": {
@@ -19060,10 +19234,10 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-      "license": "ISC",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },
@@ -20550,7 +20724,9 @@
       }
     },
     "node_modules/http-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -20732,11 +20908,11 @@
       }
     },
     "node_modules/ignore-walk/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },
@@ -22044,9 +22220,9 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -23057,9 +23233,9 @@
       }
     },
     "node_modules/libnpmpublish/node_modules/ci-info": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
-      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
       "dev": true,
       "funding": [
         {
@@ -23906,7 +24082,9 @@
       }
     },
     "node_modules/log-update/node_modules/ansi-escapes": {
-      "version": "7.0.0",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
+      "integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23974,7 +24152,9 @@
       }
     },
     "node_modules/log-update/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24133,9 +24313,9 @@
       }
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -24153,9 +24333,9 @@
       }
     },
     "node_modules/make-fetch-happen/node_modules/p-map": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -24212,9 +24392,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.6.tgz",
-      "integrity": "sha512-Y07CUOE+HQXbVDCGl3LXggqJDbXDP2pArc2C1N1RRMN0ONiShoSsIInMd5Gsxupe7fKLpgimTV+HOJ9r7bA+pg==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.0.0.tgz",
+      "integrity": "sha512-MUKMXDjsD/eptB7GPzxo4xcnLS6oo7/RHimUMHEDRhUooPwmN9BEpMl7AEOJv3bmso169wHI2wUF9VQgL7zfmA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -24222,7 +24402,7 @@
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/marked-mangle": {
@@ -24292,9 +24472,9 @@
       }
     },
     "node_modules/mdast-util-find-and-replace/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -24603,9 +24783,9 @@
       }
     },
     "node_modules/mdast-util-phrasing/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -27486,11 +27666,11 @@
       }
     },
     "node_modules/node-gyp/node_modules/tar": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz",
-      "integrity": "sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -27673,9 +27853,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/hosted-git-info": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.0.tgz",
-      "integrity": "sha512-gEf705MZLrDPkbbhi8PnoO4ZwYgKoNL+ISZ3AjZMht2r3N5tuTwncyDi6Fv2/qDnMmZxgs0yI8WDOyR8q3G+SQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -27686,9 +27866,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -28505,7 +28685,9 @@
       }
     },
     "node_modules/pac-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -28643,16 +28825,16 @@
       }
     },
     "node_modules/pacote/node_modules/@sigstore/sign": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.0.0.tgz",
-      "integrity": "sha512-5+IadiqPzRRMfvftHONzpeH2EzlDNuBiTMC3Lx7+9tLqn/4xbWVfSZA+YaOzKCn86k5BWfJ+aGO9v+pQmIyxqQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.0.1.tgz",
+      "integrity": "sha512-KFNGy01gx9Y3IBPG/CergxR9RZpN43N+lt3EozEfeoyqm8vEiLxwRl3ZO5sPx3Obv1ix/p7FWOlPc2Jgwfp9PA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
         "@sigstore/core": "^3.0.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.0",
+        "make-fetch-happen": "^15.0.2",
         "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1"
       },
@@ -28737,9 +28919,9 @@
       }
     },
     "node_modules/pacote/node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -28747,9 +28929,9 @@
       }
     },
     "node_modules/pacote/node_modules/p-map": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
-      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -28778,11 +28960,11 @@
       }
     },
     "node_modules/pacote/node_modules/tar": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz",
-      "integrity": "sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+      "integrity": "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -29082,7 +29264,9 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -29096,7 +29280,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.1.0",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
@@ -31147,7 +31333,9 @@
       }
     },
     "node_modules/proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -32028,18 +32216,6 @@
         "regjsparser": "bin/parser"
       }
     },
-    "node_modules/regjsparser/node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/rehype-parse": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-7.0.1.tgz",
@@ -32412,10 +32588,12 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -32778,7 +32956,9 @@
       }
     },
     "node_modules/rollup-plugin-delete/node_modules/p-map": {
-      "version": "7.0.3",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -33065,9 +33245,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -33869,7 +34049,9 @@
       }
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -34229,7 +34411,9 @@
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -35802,9 +35986,9 @@
       }
     },
     "node_modules/unified-engine/node_modules/@types/node": {
-      "version": "22.19.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.0.tgz",
-      "integrity": "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -36099,9 +36283,9 @@
       }
     },
     "node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -36113,9 +36297,9 @@
       }
     },
     "node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -36126,9 +36310,9 @@
       }
     },
     "node_modules/unist-util-visit/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -36175,7 +36359,9 @@
       }
     },
     "node_modules/unplugin-utils/node_modules/picomatch": {
-      "version": "4.0.2",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -36255,9 +36441,9 @@
       }
     },
     "node_modules/update-notifier/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -36324,9 +36510,9 @@
       }
     },
     "node_modules/update-notifier/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -37558,9 +37744,9 @@
       }
     },
     "node_modules/widest-line/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -37610,7 +37796,9 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "9.0.0",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -37664,7 +37852,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -37674,7 +37864,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -38085,7 +38277,9 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "1.2.1",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20"
@@ -38354,9 +38548,9 @@
       }
     },
     "packages/plugin-types-bundler/node_modules/@types/node": {
-      "version": "22.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.11.tgz",
-      "integrity": "sha512-Gd33J2XIrXurb+eT2ktze3rJAfAp9ZNjlBdh4SVgyrKEOADwCbdUDaK7QgJno8Ue4kcajscsKqu6n8OBG3hhCQ==",
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
     "docusaurus/website": {
       "version": "5.0.2",
       "dependencies": {
+        "@coffeeandfun/remove-pii": "^2.0.0",
         "@docusaurus/core": "^3.9.2",
         "@docusaurus/plugin-client-redirects": "^3.9.2",
         "@docusaurus/preset-classic": "^3.9.2",
@@ -86,6 +87,7 @@
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "cookiejs": "^2.1.2",
+        "debounce": "^1.2.1",
         "docusaurus-lunr-search": "^3.6.0",
         "gridsome-remark-figure-caption": "1.2.2",
         "prism-react-renderer": "^2.1.0",
@@ -97,6 +99,7 @@
         "@docusaurus/module-type-aliases": "^3.9.2",
         "@docusaurus/remark-plugin-npm2yarn": "^3.9.2",
         "@docusaurus/tsconfig": "^3.9.2",
+        "@types/debounce": "^1.2.4",
         "dotenv": "^17.2.3",
         "raw-loader": "^4.0.2",
         "typescript": "^5.9.3"
@@ -2321,6 +2324,12 @@
       "version": "7.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@coffeeandfun/remove-pii": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@coffeeandfun/remove-pii/-/remove-pii-2.0.0.tgz",
+      "integrity": "sha512-1CWFlq0MH2k9nX9d+Lz+T0GGmUH5VzyrGLlo70PnJ1gTvkTt/jNCFAJsymiHqk49tAwzhbUcmwsjhkjpk9nXzw==",
+      "license": "ISC"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -11259,6 +11268,13 @@
       "dependencies": {
         "@types/d3-color": "*"
       }
+    },
+    "node_modules/@types/debounce": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.4.tgz",
+      "integrity": "sha512-jBqiORIzKDOToaF63Fm//haOCHuwQuLa2202RK4MozpA6lh93eCBc+/8+wZn5OzjJt3ySdc+74SXWXB55Ewtyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "docs": "nx start website",
     "docs:clear": "nx clear website",
     "docs:build": "nx build website",
+    "docs:test": "nx test website",
+    "docs:test:ci": "nx test:ci website",
     "lint": "nx run-many --target=lint --parallel",
     "lint:fix": "nx run-many --target=lint:fix --parallel",
     "lint:packages": "nx run-many --target=lint:package --parallel",


### PR DESCRIPTION
**What this PR does / why we need it**:

I explored a few different approaches for adding search tracking to the plugin-tools website:

### 1. Swizzling the plugin
Docusaurus supports a mechanism called [*swizzling*](https://docusaurus.io/docs/swizzling/), which allows customizing internal components. It provides two main options: `Wrap` and `Eject`.  
- Running the command on the current [search plugin](https://github.com/praveenn77/docusaurus-lunr-search) marked both approaches as unsafe.  
- The **Wrap** option isn’t helpful since the plugin doesn’t expose any relevant internals for our use case.  
- The **Eject** option would give us full control by bringing the plugin source into our codebase, but it would also mean we’d be responsible for maintaining our own fork of the Docusaurus search plugin which is not ideal long term.

### 2. Listening to DOM changes
I tried using a `MutationObserver` to detect search-related updates ([example here](https://github.com/grafana/plugin-tools/pull/2288)). This worked to some extent but felt more like a workaround than a maintainable solution.

### 3. Monkey patching the search function
The current approach involves overriding the plugin’s [`search`](https://github.com/praveenn77/docusaurus-lunr-search/blob/main/src/theme/SearchBar/lunar-search.js#L123) function to inject tracking logic.  
While this method is effective, it comes with the risk of breaking if the plugin author renames, refactors, or removes that function in future releases.

This PR implements the `Monkey patching the search function` approach. Let me know what you think 🙏 

Dashboard: https://ops.grafana-ops.net/goto/ff3vuau0th81sa?orgId=1

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #2254

**Special notes for your reviewer**:

To test this PR: 
1. navigate to https://grafana-dev.com/developers/plugin-tools/
2. accept the cookies, without consent the tracking shouldn't be triggered
3. use the search (with out without PII)
4. because of CORS the rudderstack `track` and `page` fail on  https://grafana-dev.com/developers/plugin-tools/ so you'll see a lot more events being called but that has to be because rudderstack has builtin retries
5. investigate a `track` call and it should contain the correct information
<img width="1688" height="1287" alt="image" src="https://github.com/user-attachments/assets/53a644e0-2c20-4adb-9954-f7c6d816d8dd" />

