### PR TITLE
CI: stop auto from inserting release notes from self-hosted renovate

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -16,6 +16,12 @@
       }
     ],
     [
+      "omit-release-notes",
+      {
+        "username": ["renovate-sh-app[bot]"]
+      }
+    ],
+    [
       "slack",
       {
         "atTarget": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@auto-it/all-contributors": "11.3.0",
         "@auto-it/first-time-contributor": "11.3.0",
         "@auto-it/omit-commits": "11.3.0",
+        "@auto-it/omit-release-notes": "11.3.0",
         "@auto-it/slack": "11.3.0",
         "@grafana/eslint-config": "^9.0.0",
         "@playwright/test": "^1.56.1",
@@ -535,6 +536,19 @@
     },
     "node_modules/@auto-it/omit-commits": {
       "version": "11.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@auto-it/core": "11.3.0",
+        "fp-ts": "^2.5.3",
+        "io-ts": "^2.1.2",
+        "tslib": "2.1.0"
+      }
+    },
+    "node_modules/@auto-it/omit-release-notes": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@auto-it/omit-release-notes/-/omit-release-notes-11.3.0.tgz",
+      "integrity": "sha512-82nXQ8rqYflssrv4vq3ZtKgrVCX4qkevbHzLMUhf97JlPa1OeMid7kcsmNoYs6maWhnD22ayNGdbUhZRZHvBlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -36684,6 +36698,7 @@
       "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@auto-it/all-contributors": "11.3.0",
     "@auto-it/first-time-contributor": "11.3.0",
     "@auto-it/omit-commits": "11.3.0",
+    "@auto-it/omit-release-notes": "11.3.0",
     "@auto-it/slack": "11.3.0",
     "@grafana/eslint-config": "^9.0.0",
     "@playwright/test": "^1.56.1",
@@ -82,7 +83,7 @@
     ],
     "*.{css,md,json}": "prettier --write"
   },
-  "overrides": {    
+  "overrides": {
     "webpack-dev-server": "^5.2.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

We keep seeing broken changelogs appearing in releases due to renovate using `## Release notes` in it's PR description. Auto looks out for these as "[additional release notes](https://intuit.github.io/auto/docs/generated/changelog#additional-release-notes)". By default auto and its plugins ignores a load of bots via the [bot-list](https://github.com/intuit/auto/blob/main/packages/bot-list/src/index.ts) package but since we moved to a self hosted renovate bot it's no longer matching.

This PR adds the `omit-release-notes` plugin along with the sh renovate bot username to auto settings to solve this.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
