### PR TITLE
chore: change debounce time for searches

### DIFF
--- a/docusaurus/website/src/theme/tracking/constants.ts
+++ b/docusaurus/website/src/theme/tracking/constants.ts
@@ -1,3 +1,3 @@
 export const SEARCH_TRACKING_SOURCE = 'developers_plugin_tools_search';
-export const SEARCH_TRACKING_DEBOUNCE = 150;
+export const SEARCH_TRACKING_DEBOUNCE = 400;
 export const SEARCH_TRACKING_MAX_LENGTH = 256;


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request makes a minor adjustment to the search tracking debounce timing in the `docusaurus/website/src/theme/tracking/constants.ts` file. The debounce interval has been increased from 150ms to 400ms to reduce the frequency of search tracking events.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
