### PR TITLE
renovate: add release label to create-plugin template workflow updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -131,12 +131,20 @@
       "matchPackageNames": ["!/^@?docusaurus/", "!/@grafana/*/"]
     },
     {
-      // disable automerge temporarily until we know the action can update create-plugin hbs templates.
+      "automerge": false,
+      "groupName": "create-plugin template github actions",
+      "labels": ["release", "patch", "create-plugin"],
+      "matchDatasources": ["github-actions"],
+      "matchFiles": ["packages/create-plugin/templates/github/workflows/**"],
+      "pinDigests": false
+    },
+    {
       "automerge": false,
       "groupName": "auto-merged gitHub actions",
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
-      "reviewers": ["jackw"],
-      "matchManagers": ["github-actions"]
+      "matchManagers": ["github-actions"],
+      "matchFiles": [".github/workflows/**"],
+      "pinDigests": true
     }
   ],
   "vulnerabilityAlerts": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -134,7 +134,7 @@
       "automerge": false,
       "groupName": "create-plugin template github actions",
       "labels": ["release", "patch", "create-plugin"],
-      "matchDatasources": ["github-actions"],
+      "matchManagers": ["github-actions"],
       "matchFiles": ["packages/create-plugin/templates/github/workflows/**"],
       "pinDigests": false
     },
@@ -142,7 +142,7 @@
       "automerge": false,
       "groupName": "auto-merged gitHub actions",
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
-      "matchDatasources": ["github-actions"],
+      "matchManagers": ["github-actions"],
       "matchFiles": [".github/workflows/**"],
       "pinDigests": true
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -142,7 +142,7 @@
       "automerge": false,
       "groupName": "auto-merged gitHub actions",
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
-      "matchManagers": ["github-actions"],
+      "matchDatasources": ["github-actions"],
       "matchFiles": [".github/workflows/**"],
       "pinDigests": true
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -143,8 +143,7 @@
       "groupName": "auto-merged gitHub actions",
       "labels": ["ci", "github_actions", "dependencies", "no-changelog"],
       "matchManagers": ["github-actions"],
-      "matchFiles": [".github/workflows/**"],
-      "pinDigests": true
+      "matchFiles": [".github/workflows/**"]
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
**What this PR does / why we need it**:

Separates renovate package rules for gh action deps so that updates to create-plugin workflow templates get the `release` label, while repository workflow updates get the `no-changelog` label. Also configures templates to use semantic version tags (easier for devs to reason about) and repo workflows to use commit hashes (more secure - we also have Zizmor that adds corresponding tag name as a comment).

Disabling automerge until we've seen this working as expected for some time. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
