### PR TITLE
Feat: use latest create-plugin-update workflow

### DIFF
--- a/docusaurus/docs/set-up/set-up-github.md
+++ b/docusaurus/docs/set-up/set-up-github.md
@@ -111,7 +111,7 @@ jobs:
   createplugin-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v1.1.0
+      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v2.0.1
         with:
           token: ${{ secrets.GH_PAT_TOKEN }}
 ```
@@ -147,7 +147,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v1.1.0
+      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v2.0.1
         with:
           token: ${{ steps.generate_token.outputs.token }}
 ```

--- a/packages/create-plugin/templates/github/workflows/cp-update.yml
+++ b/packages/create-plugin/templates/github/workflows/cp-update.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v1.1.0
+      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v2.0.1
         with:
           # Make sure to save the token in your repository secrets as `GH_PAT_TOKEN`
           token: $\{{ secrets.GH_PAT_TOKEN }}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When scaffolding plugins we need to use the latest version of cp-update workflow to resolve:

- [x] permission issues with editing workflow files
- [x] make sure npm deps are available before running update command 
- [x] alignment with docs 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.0.3-canary.2299.19328231512.0
  npm install @grafana/create-plugin@6.1.10-canary.2299.19328231512.0
  # or 
  yarn add website@5.0.3-canary.2299.19328231512.0
  yarn add @grafana/create-plugin@6.1.10-canary.2299.19328231512.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
