### PR TITLE
chore: updates path to json schema file

### DIFF
--- a/docusaurus/website/scripts/download-schema.sh
+++ b/docusaurus/website/scripts/download-schema.sh
@@ -7,7 +7,7 @@
 set -e
 
 # Define variables
-SCHEMA_URL="https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json"
+SCHEMA_URL="https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developer-resources/plugins/plugin.schema.json"
 OUTPUT_FILE="$(dirname "$0")/plugin.schema.json"
 
 echo "Downloading Grafana plugin schema..."

--- a/packages/create-plugin/fixtures/test-template/src/plugin.json
+++ b/packages/create-plugin/fixtures/test-template/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developer-resources/plugins/plugin.schema.json",
   "type": "app",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ pluginId }}",

--- a/packages/create-plugin/templates/app/src/plugin.json
+++ b/packages/create-plugin/templates/app/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developer-resources/plugins/plugin.schema.json",
   "type": "app",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ pluginId }}",{{#if hasBackend}}

--- a/packages/create-plugin/templates/datasource/src/plugin.json
+++ b/packages/create-plugin/templates/datasource/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developer-resources/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ pluginId }}",

--- a/packages/create-plugin/templates/panel/src/plugin.json
+++ b/packages/create-plugin/templates/panel/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developer-resources/plugins/plugin.schema.json",
   "type": "panel",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ pluginId }}",

--- a/packages/create-plugin/templates/scenes-app/src/plugin.json
+++ b/packages/create-plugin/templates/scenes-app/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developer-resources/plugins/plugin.schema.json",
   "type": "app",
   "name": "{{ titleCase pluginName }}",
   "id": "{{ pluginId }}",{{#if hasBackend}}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the reference to the Grafana plugin schema URL across several plugin template and fixture files to reflect its new location. This ensures that all generated plugins and related scripts use the latest schema definition from the correct path.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.0.5-canary.2311.19490397871.0
  npm install @grafana/create-plugin@6.1.13-canary.2311.19490397871.0
  # or 
  yarn add website@5.0.5-canary.2311.19490397871.0
  yarn add @grafana/create-plugin@6.1.13-canary.2311.19490397871.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
