### PR TITLE
Playwright: Bumping deploy-reports action

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -112,7 +112,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish report
-        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@376226a5245b6b8bbb95127241c430ef8d6aa643 # deploy-report-pages/v1.0.1
+        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@5da62466881cdba091672353cf3c72ca348d01b1 # deploy-report-pages/v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           retention-days: 7

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/packages/create-plugin/templates/github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/workflows/ci.yml
@@ -247,7 +247,7 @@ jobs:
           # required for playwright-gh-pages
           persist-credentials: true
       - name: Publish report
-        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@deploy-report-pages/v1.0.1
+        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@deploy-report-pages/v1.1.0
         with:
           github-token: $\{{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR manually bumps the action that deploys playwright reports to GH pages to version 1.1.0. This version uses an orphan branch approach to create a fresh `gh-pages` branch with zero history for each deployment. This prevents accumulation of large commits over time.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.1.0-canary.2319.19627830170.0
  npm install @grafana/create-plugin@6.3.0-canary.2319.19627830170.0
  npm install @grafana/eslint-plugin-plugins@0.6.0-canary.2319.19627830170.0
  npm install @grafana/plugin-meta-extractor@0.11.0-canary.2319.19627830170.0
  # or 
  yarn add website@5.1.0-canary.2319.19627830170.0
  yarn add @grafana/create-plugin@6.3.0-canary.2319.19627830170.0
  yarn add @grafana/eslint-plugin-plugins@0.6.0-canary.2319.19627830170.0
  yarn add @grafana/plugin-meta-extractor@0.11.0-canary.2319.19627830170.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
