### PR TITLE
Plugin E2E: Bump e2e selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5531,9 +5531,9 @@
       "license": "0BSD"
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "12.2.0-17311094888",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.2.0-17311094888.tgz",
-      "integrity": "sha512-2yxxdaBQ1o/FkUFsnV+hSlvvFdrq98qrO+PQ74w0hWeUcxfCZHJYaJxWRdQjdWr1ZbjVF0C3xjBIn3uyYB/aBg==",
+      "version": "12.4.0-19715147905",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-19715147905.tgz",
+      "integrity": "sha512-YydLAENcpdCqX8X4TVExPuPflgPZ5ffuzU2yFWNLQmcqzF2yG39xs5yUqTdNY3B7IztJIjt5draCRxsOr7glTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.0",
@@ -37976,7 +37976,7 @@
       "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "^12.2.0-255920",
+        "@grafana/e2e-selectors": "^12.4.0-19715147905",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -42,7 +42,7 @@
     "dotenv": "^17.2.3"
   },
   "dependencies": {
-    "@grafana/e2e-selectors": "^12.2.0-255920",
+    "@grafana/e2e-selectors": "^12.4.0-19715147905",
     "semver": "^7.5.4",
     "uuid": "^13.0.0",
     "yaml": "^2.3.4"


### PR DESCRIPTION
**What this PR does / why we need it**:

Manually bumping the e2e-selectors package as the automatic flow is currently now working. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.1.1-canary.2329.19716177684.0
  npm install @grafana/plugin-e2e@3.0.2-canary.2329.19716177684.0
  # or 
  yarn add website@5.1.1-canary.2329.19716177684.0
  yarn add @grafana/plugin-e2e@3.0.2-canary.2329.19716177684.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
