### PR TITLE
fix: only migrate eslint if plugin depends on eslint < 9.0.0

### DIFF
--- a/packages/create-plugin/src/codemods/migrations/scripts/004-eslint9-flat-config.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/004-eslint9-flat-config.ts
@@ -6,7 +6,7 @@ import minimist from 'minimist';
 import { dirname, relative, resolve } from 'node:path';
 import * as recast from 'recast';
 import type { Context } from '../../context.js';
-import { addDependenciesToPackageJson, migrationsDebug } from '../../utils.js';
+import { addDependenciesToPackageJson, isVersionGreater, migrationsDebug } from '../../utils.js';
 
 type Imports = Map<string, { name?: string; bindings?: string[] }>;
 
@@ -23,7 +23,8 @@ const devDependenciesToUpdate = {
 };
 
 export default function migrate(context: Context): Context {
-  const needsMigration = context.doesFileExist('.eslintrc');
+  const packageJson = JSON.parse(context.getFile('package.json') || '');
+  const needsMigration = isVersionGreater(devDependenciesToUpdate.eslint, packageJson.devDependencies?.eslint);
   if (!needsMigration) {
     return context;
   }


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The eslint migration was checking for existence of .eslintrc to decide if it should make changes or not. However certain eslint plugins (import f.ex) have rules that rely on the existence of an .eslintrc file even if the project uses a flat config. This PR addresses this by switching out the logic to check if the plugin is using eslint 9.0.0 rather than check for files.

[internal slack conversation](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1764665131238559)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.4.3-canary.2338.19856422969.0
  # or 
  yarn add @grafana/create-plugin@6.4.3-canary.2338.19856422969.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
