### PR TITLE
plugins-e2e: fix visualization lookup flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5531,9 +5531,9 @@
       "license": "0BSD"
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "12.4.0-19715147905",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-19715147905.tgz",
-      "integrity": "sha512-YydLAENcpdCqX8X4TVExPuPflgPZ5ffuzU2yFWNLQmcqzF2yG39xs5yUqTdNY3B7IztJIjt5draCRxsOr7glTQ==",
+      "version": "12.4.0-19890644192",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-19890644192.tgz",
+      "integrity": "sha512-rahz7ZwpUgxPpo853xb+SWiTzYfyQL2oIK1nngPXwcfC5ww0er1AxQ1OnVjObLpKrzFzuI8WszXSdXk9N8G4Sw==",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.0",
@@ -37996,7 +37996,7 @@
       "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "^12.4.0-19715147905",
+        "@grafana/e2e-selectors": "^12.4.0-19890644192",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -42,7 +42,7 @@
     "dotenv": "^17.2.3"
   },
   "dependencies": {
-    "@grafana/e2e-selectors": "^12.4.0-19715147905",
+    "@grafana/e2e-selectors": "^12.4.0-19890644192",
     "semver": "^7.5.4",
     "uuid": "^13.0.0",
     "yaml": "^2.3.4"

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -95,8 +95,16 @@ export class PanelEditPage extends GrafanaPage {
     }
     await this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker).click();
     await this.getByGrafanaSelector(this.ctx.selectors.components.PluginVisualization.item(visualization)).click();
+    if (semver.lte(this.ctx.grafanaVersion, '12.3.0')) {
+      await expect(
+        this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker),
+        `Could not set visualization to ${visualization}. Ensure the panel is installed.`
+      ).toHaveText(visualization);
+      return;
+    }
+
     await expect(
-      this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker),
+      this.getByGrafanaSelector('data-testid Panel editor OptionsPane header'),
       `Could not set visualization to ${visualization}. Ensure the panel is installed.`
     ).toHaveText(visualization);
   }
@@ -119,7 +127,10 @@ export class PanelEditPage extends GrafanaPage {
    * Returns the name of the visualization currently selected in the panel editor
    */
   getVisualizationName(): Locator {
-    return this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker);
+    if (semver.lte(this.ctx.grafanaVersion, '12.3.0')) {
+      return this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker);
+    }
+    return this.getByGrafanaSelector('data-testid Panel editor OptionsPane header');
   }
 
   /**

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -104,7 +104,7 @@ export class PanelEditPage extends GrafanaPage {
     }
 
     await expect(
-      this.getByGrafanaSelector('data-testid Panel editor OptionsPane header'),
+      this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.OptionsPane.header),
       `Could not set visualization to ${visualization}. Ensure the panel is installed.`
     ).toHaveText(visualization);
   }
@@ -130,7 +130,7 @@ export class PanelEditPage extends GrafanaPage {
     if (semver.lte(this.ctx.grafanaVersion, '12.3.0')) {
       return this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker);
     }
-    return this.getByGrafanaSelector('data-testid Panel editor OptionsPane header');
+    return this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.OptionsPane.header);
   }
 
   /**

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -95,16 +95,12 @@ export class PanelEditPage extends GrafanaPage {
     }
     await this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker).click();
     await this.getByGrafanaSelector(this.ctx.selectors.components.PluginVisualization.item(visualization)).click();
-    if (semver.lte(this.ctx.grafanaVersion, '12.3.0')) {
-      await expect(
-        this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker),
-        `Could not set visualization to ${visualization}. Ensure the panel is installed.`
-      ).toHaveText(visualization);
-      return;
-    }
 
+    const vizSelector = semver.lte(this.ctx.grafanaVersion, '12.3.0')
+      ? this.ctx.selectors.components.PanelEditor.toggleVizPicker
+      : this.ctx.selectors.components.PanelEditor.OptionsPane.header;
     await expect(
-      this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.OptionsPane.header),
+      this.getByGrafanaSelector(vizSelector),
       `Could not set visualization to ${visualization}. Ensure the panel is installed.`
     ).toHaveText(visualization);
   }
@@ -127,10 +123,10 @@ export class PanelEditPage extends GrafanaPage {
    * Returns the name of the visualization currently selected in the panel editor
    */
   getVisualizationName(): Locator {
-    if (semver.lte(this.ctx.grafanaVersion, '12.3.0')) {
-      return this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker);
-    }
-    return this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.OptionsPane.header);
+    const vizSelector = semver.lte(this.ctx.grafanaVersion, '12.3.0')
+      ? this.ctx.selectors.components.PanelEditor.toggleVizPicker
+      : this.ctx.selectors.components.PanelEditor.OptionsPane.header;
+    return this.getByGrafanaSelector(vizSelector);
   }
 
   /**


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the logic for selecting and verifying the visualization name in the `PanelEditPage` class to support changes introduced in Grafana version 12.3.0 and above. The main theme is improved compatibility with newer Grafana UI selectors.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.0.3-canary.2339.19920190312.0
  # or 
  yarn add @grafana/plugin-e2e@3.0.3-canary.2339.19920190312.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
