### PR TITLE
Docs: Made the DS tutorial more explicit

### DIFF
--- a/docusaurus/docs/tutorials/build-a-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-plugin.md
@@ -104,7 +104,7 @@ Let's see how to create and return a data frame from the `query` method. In this
    });
    ```
 
-   `refId` needs to be set to tell Grafana which query that generated this date frame.
+   `refId` needs to be set to tell Grafana which query that generated this data frame.
 
 1. Finally, return the data frame. Your query function should look something like this:
 

--- a/docusaurus/docs/tutorials/build-a-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-plugin.md
@@ -70,7 +70,7 @@ Let's see how to create and return a data frame from the `query` method. In this
 
 1. Create a couple of helper variables for testing purposes.
 
-   The math here only generates mock test data. It should be replaced later with real values fetched from the data source you want to connect to Grafana.
+   The math here only generates mock test data. Replace it later with real values fetched from the data source you want to connect to Grafana.
 
    ```ts title="src/datasource.ts"
    // duration of the time range, in milliseconds.

--- a/docusaurus/docs/tutorials/build-a-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-plugin.md
@@ -70,7 +70,7 @@ Let's see how to create and return a data frame from the `query` method. In this
 
 1. Create a couple of helper variables.
 
-   Don't worry about the math used to calculate the values!
+   The math here only generates mock test data. It should be replaced later with real values fetched from the data source you want to connect to Grafana.
 
    ```ts title="src/datasource.ts"
    // duration of the time range, in milliseconds.

--- a/docusaurus/docs/tutorials/build-a-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-plugin.md
@@ -96,7 +96,7 @@ Let's see how to create and return a data frame from the `query` method. In this
 
    ```ts title="src/datasource.ts"
    const frame = createDataFrame({
-     refId: query.refId,
+     refId: target.refId,
      fields: [
        { name: 'time', type: FieldType.time, values: timestamps },
        { name: 'value', type: FieldType.number, values: values },
@@ -127,7 +127,7 @@ Let's see how to create and return a data frame from the `query` method. In this
       }
 
       return createDataFrame({
-        refId: query.refId,
+        refId: target.refId,
         fields: [
           {
             name: 'time',
@@ -158,8 +158,8 @@ Finally, implement the health check function:
    ```ts title="src/datasource.ts"
    async testDatasource() {
      return {
-       status: '200',
-       statusText: 'Success',
+       status: 'success',
+       message: 'Success',
      };
    }
    ```

--- a/docusaurus/docs/tutorials/build-a-data-source-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-data-source-plugin.md
@@ -68,7 +68,7 @@ Let's see how to create and return a data frame from the `query` method. In this
    }
    ```
 
-1. Create a couple of helper variables.
+1. Create a couple of helper variables for testing purposes.
 
    The math here only generates mock test data. It should be replaced later with real values fetched from the data source you want to connect to Grafana.
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR refactors the data source plugin tutorial to make the instructions more explicit and easier to follow. Instead of using lodash/defaults and the frame.add() method, it teaches developers to create arrays for timestamps and values upfront, then pass them to the data frame fields. The tutorial flow has been reorganized to build up to a complete working example.

Key changes:

- Removes the lodash/defaults dependency and defaultQuery pattern from the tutorial
- Changes from using frame.add() to pre-populating arrays with values
- Adds a complete code example showing the final query function implementation
- Corrects the testDatasource status field to use a string instead of a number


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
