### PR TITLE
Plugin E2E: Bump e2e-selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5531,9 +5531,9 @@
       "license": "0BSD"
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "12.4.0-19890644192",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-19890644192.tgz",
-      "integrity": "sha512-rahz7ZwpUgxPpo853xb+SWiTzYfyQL2oIK1nngPXwcfC5ww0er1AxQ1OnVjObLpKrzFzuI8WszXSdXk9N8G4Sw==",
+      "version": "12.4.0-20165274911",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-12.4.0-20165274911.tgz",
+      "integrity": "sha512-XdVINEnfZFdzP6mXlTMNj2ivc+a7qiIi3psZ9GhzBlGEeFtqFrtJWCpn/9owPmGRe5lBs4NS9J9Ch3NoGAV8/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.0",
@@ -37996,7 +37996,7 @@
       "version": "3.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "^12.4.0-19890644192",
+        "@grafana/e2e-selectors": "12.4.0-20165274911",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -42,7 +42,7 @@
     "dotenv": "^17.2.3"
   },
   "dependencies": {
-    "@grafana/e2e-selectors": "^12.4.0-19890644192",
+    "@grafana/e2e-selectors": "12.4.0-20165274911",
     "semver": "^7.5.4",
     "uuid": "^13.0.0",
     "yaml": "^2.3.4"


### PR DESCRIPTION
**What this PR does / why we need it**:

Manually bump the e2e-selectors as the automatic flow is currently broken. This should fix [broken tests](https://github.com/grafana/grafana-plugin-examples/actions/runs/20164712692/job/57887837424).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.0.4-canary.2341.20165906180.0
  # or 
  yarn add @grafana/plugin-e2e@3.0.4-canary.2341.20165906180.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
