### PR TITLE
Plugin E2E: Add workflow to bump @grafana/e2e-selectors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -67,20 +67,6 @@
       "minimumReleaseAge": null
     },
     {
-      "automerge": true,
-      "groupName": "e2e-selector dependencies",
-      "groupSlug": "plugin-e2e-selectors",
-      "labels": ["dependencies", "javascript", "patch", "release"],
-      "matchPackageNames": ["@grafana/e2e-selectors"],
-      "followTag": "modified",
-      "rangeStrategy": "bump",
-      "matchFileNames": [
-        "packages/plugin-e2e/package.json",
-        "package-lock.json"
-      ],
-      "minimumReleaseAge": null
-    },
-    {
       "groupName": "grafana dependencies",
       "groupSlug": "all-grafana",
       "labels": ["dependencies", "javascript", "release", "patch"],

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -61,7 +61,7 @@ jobs:
             Automated update of `@grafana/e2e-selectors` to version `${{ inputs.version }}`.
 
             Triggered by grafana/grafana when changes were detected in the e2e-selectors package.
-          branch: bump-e2e-selectors-${{ inputs.version }}
+          branch: bump-e2e-selectors
           delete-branch: true
           labels: |
             dependencies

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   bump:
     name: Bump e2e-selectors version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     permissions:
       contents: read
       id-token: write
@@ -22,6 +22,7 @@ jobs:
         id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
         with:
+          # Secrets placed in the ci/repo/grafana/plugin-tools in vault
           repo_secrets: |
             GITHUB_APP_ID=plugins-platform-bot-app:app_id
             GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
@@ -34,15 +35,17 @@ jobs:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
 
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
 
-      - name: Setup Node.js
+      - name: Setup nodejs
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Update @grafana/e2e-selectors
         run: |

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -66,6 +66,7 @@ jobs:
           branch: bump-e2e-selectors
           base: main
           delete-branch: true
+          sign-commits: true
           labels: |
             dependencies
             release

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -1,0 +1,66 @@
+name: Bump @grafana/e2e-selectors
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of @grafana/e2e-selectors to update to (e.g., 12.4.0-19890644192)'
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  bump:
+    name: Bump e2e-selectors version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Get secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        with:
+          repo_secrets: |
+            GITHUB_APP_ID=plugins-platform-bot-app:app_id
+            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
+          export_env: false
+
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
+          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Update @grafana/e2e-selectors
+        run: |
+          npm install @grafana/e2e-selectors@${{ inputs.version }} --workspace=@grafana/plugin-e2e --save-exact
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          commit-message: 'plugin-e2e: bump @grafana/e2e-selectors to ${{ inputs.version }}'
+          title: 'Plugin E2E: Bump @grafana/e2e-selectors to ${{ inputs.version }}'
+          body: |
+            Automated update of `@grafana/e2e-selectors` to version `${{ inputs.version }}`.
+
+            Triggered by grafana/grafana when changes were detected in the e2e-selectors package.
+          branch: bump-e2e-selectors-${{ inputs.version }}
+          delete-branch: true
+          labels: |
+            dependencies
+            release
+            patch

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -62,6 +62,7 @@ jobs:
 
             Triggered by grafana/grafana when changes were detected in the e2e-selectors package.
           branch: bump-e2e-selectors
+          base: main
           delete-branch: true
           labels: |
             dependencies

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -48,8 +48,10 @@ jobs:
           cache: 'npm'
 
       - name: Update @grafana/e2e-selectors
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          npm install @grafana/e2e-selectors@${{ inputs.version }} --workspace=@grafana/plugin-e2e --save-exact
+          npm install "@grafana/e2e-selectors@${VERSION}" --workspace=@grafana/plugin-e2e --save-exact
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -15,8 +15,8 @@ jobs:
     name: Bump e2e-selectors version
     runs-on: ubuntu-x64
     permissions:
-      contents: read
-      id-token: write
+      contents: write
+      pull-requests: write
     steps:
       - name: Get secrets
         id: get-secrets


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a workflow that can be triggered by grafana/grafana when the e2e-selectors package changes. This replaces the previous approach of following the `modified` npm dist-tag, which stopped working after grafana migrated to OIDC Trusted Publishing.

When triggered, the workflow updates the `@grafana/e2e-selectors` dependency in plugin-e2e and creates a PR. This PR also removes the Renovate package rule for e2e-selectors. 

Corresponding Grafana pr: https://github.com/grafana/grafana/pull/115218

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
