### PR TITLE
Create Plugin: Bump plugin-e2e

### DIFF
--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
-    "@grafana/plugin-e2e": "^3.0.3",
+    "@grafana/plugin-e2e": "^3.0.4",
     "@grafana/tsconfig": "^2.0.1",
     "@playwright/test": "^1.52.0",{{#if useExperimentalRspack}}
     "@rspack/core": "^1.3.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

Manually bump plugin.e2e after [this change](https://github.com/grafana/plugin-tools/pull/2341). This should fix [broken tests](https://github.com/grafana/grafana-plugin-examples/actions/runs/20164712692/job/57887837424).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.4.4-canary.2343.20167055941.0
  # or 
  yarn add @grafana/create-plugin@6.4.4-canary.2343.20167055941.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
