### PR TITLE
fix: stop eslint migration stripping extra chars from plugin name

### DIFF
--- a/packages/create-plugin/src/codemods/migrations/scripts/004-eslint9-flat-config.test.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/004-eslint9-flat-config.test.ts
@@ -139,9 +139,10 @@ describe('004-eslint9-flat-config', () => {
               'plugin:react/recommended',
               'prettier',
             ],
-            plugins: ['simple-import-sort'],
+            plugins: ['simple-import-sort', '@grafana/eslint-plugin-plugins'],
             rules: {
               'simple-import-sort/imports': 'error',
+              '@grafana/plugins/import-is-compatible': 'warn',
             },
             overrides: [
               {
@@ -163,6 +164,7 @@ describe('004-eslint9-flat-config', () => {
         import react from "eslint-plugin-react";
         import prettier from "eslint-config-prettier/flat";
         import simpleImportSort from "eslint-plugin-simple-import-sort";
+        import grafanaEslintPluginPlugins from "@grafana/eslint-plugin-plugins";
 
         export default defineConfig([
           js.configs.recommended,
@@ -173,10 +175,12 @@ describe('004-eslint9-flat-config', () => {
           {
             plugins: {
               "simple-import-sort": simpleImportSort,
+              "@grafana/plugins": grafanaEslintPluginPlugins,
             },
 
             rules: {
               "simple-import-sort/imports": "error",
+              "@grafana/plugins/import-is-compatible": "warn",
             },
           },
           {

--- a/packages/create-plugin/src/codemods/migrations/scripts/004-eslint9-flat-config.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/004-eslint9-flat-config.ts
@@ -340,12 +340,12 @@ function getPluginVarName(pluginName: string) {
 
 function getPluginShortName(pluginName: string) {
   if (pluginName.startsWith('@')) {
-    let match = pluginName.match(/^@([^/]+)\/eslint-plugin$/);
+    let match = new RegExp(`^(@[^/]+)\/eslint-plugin$`, 'u').exec(pluginName);
 
     if (match) {
       return match[1];
     }
-    match = pluginName.match(/^@([^/]+)\/eslint-plugin-(.+)$/);
+    match = new RegExp(`^(@[^/]+)\/eslint-plugin-(.+)$`, 'u').exec(pluginName);
 
     if (match) {
       return `${match[1]}/${match[2]}`;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
getPluginShortName is stripping `@` from the front of plugin names resulting in broken configs due to the plugin name and the rules not matching.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.4.5-canary.2348.20275461487.0
  # or 
  yarn add @grafana/create-plugin@6.4.5-canary.2348.20275461487.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
