### PR TITLE
Refactor: replace chalk with nodes styletext function

### DIFF
--- a/libs/output/package.json
+++ b/libs/output/package.json
@@ -5,9 +5,6 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
-  "peerDependencies": {
-    "chalk": "^5.0.0"
-  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "lint": "eslint ./src",

--- a/libs/output/src/index.ts
+++ b/libs/output/src/index.ts
@@ -1,21 +1,22 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import { EOL } from 'os';
 
 type Colors = 'red' | 'cyan' | 'green' | 'yellow' | 'gray';
 
 type TaskStatus = 'success' | 'failure' | 'skipped';
 
-function isCI() {
-  return (
-    (process.env.CI && process.env.CI !== 'false') || // Drone CI plus others
-    process.env.GITHUB_ACTIONS === 'true' // GitHub Actions
-  );
-}
+// TODO: check to see if we still need this
+// function isCI() {
+//   return (
+//     (process.env.CI && process.env.CI !== 'false') || // Drone CI plus others
+//     process.env.GITHUB_ACTIONS === 'true' // GitHub Actions
+//   );
+// }
 
-if (isCI()) {
-  // Disable coloring when running in CI environments.
-  chalk.level = 0;
-}
+// if (isCI()) {
+//   // Disable coloring when running in CI environments.
+//   process.env.NODE_DISABLE_COLORS = 'true';
+// }
 
 export class Output {
   private appName: string;
@@ -39,7 +40,7 @@ export class Output {
   }
 
   addHorizontalLine(color: Colors) {
-    const separator = chalk.dim[color](this.separator);
+    const separator = styleText(['dim', color], this.separator);
     this.write(`${separator}${EOL}`);
   }
 
@@ -58,20 +59,20 @@ export class Output {
   private getStatusIcon(taskStatus: TaskStatus) {
     switch (taskStatus) {
       case 'success':
-        return chalk.green('✓');
+        return styleText(['green'], '✓');
       case 'failure':
-        return chalk.red('⨯');
+        return styleText(['red'], '⨯');
       case 'skipped':
-        return chalk.yellow('−');
+        return styleText(['yellow'], '−');
     }
   }
 
   private addPrefix(color: Colors, text: string) {
-    const namePrefix = chalk.reset.inverse.bold[color](` ${this.appName} `);
+    const namePrefix = styleText(['reset', 'inverse', 'bold', color], ` ${this.appName} `);
     if (!this.appVersion) {
       return `${namePrefix} ${text}`;
     }
-    const nameAndVersionPrefix = chalk.reset.inverse.bold[color](` ${this.appName}@${this.appVersion} `);
+    const nameAndVersionPrefix = styleText(['reset', 'inverse', 'bold', color], ` ${this.appName}@${this.appVersion} `);
     return `${nameAndVersionPrefix} ${text}`;
   }
 
@@ -97,13 +98,13 @@ export class Output {
     withPrefix?: boolean;
   }) {
     this.addNewLine();
-    this.writeTitle('red', chalk.red.bold(title), withPrefix);
+    this.writeTitle('red', styleText(['red', 'bold'], title), withPrefix);
     this.writeBody(body);
 
     if (link) {
       this.addNewLine();
-      this.write(`${chalk.gray('Learn more about this error: ')}
-  ${chalk.cyan(link)}`);
+      this.write(`${styleText(['gray'], 'Learn more about this error: ')}
+  ${styleText(['cyan'], link)}`);
     }
     this.addNewLine();
   }
@@ -120,12 +121,12 @@ export class Output {
     withPrefix?: boolean;
   }) {
     this.addNewLine();
-    this.writeTitle('yellow', chalk.yellow.bold(title), withPrefix);
+    this.writeTitle('yellow', styleText(['yellow', 'bold'], title), withPrefix);
     this.writeBody(body);
 
     if (link) {
       this.addNewLine();
-      this.write(`${chalk.gray('Learn more about this warning: ')}
+      this.write(`${styleText(['gray'], 'Learn more about this warning: ')}
   ${this.formatUrl(link)}`);
     }
     this.addNewLine();
@@ -133,14 +134,14 @@ export class Output {
 
   success({ title, body, withPrefix = true }: { title: string; body?: string[]; withPrefix?: boolean }) {
     this.addNewLine();
-    this.writeTitle('green', chalk.green.bold(title), withPrefix);
+    this.writeTitle('green', styleText(['green', 'bold'], title), withPrefix);
     this.writeBody(body);
     this.addNewLine();
   }
 
   log({ title, body, withPrefix = true }: { title: string; body?: string[]; withPrefix?: boolean }) {
     this.addNewLine();
-    this.writeTitle('cyan', chalk.cyan.bold(title), withPrefix);
+    this.writeTitle('cyan', styleText(['cyan', 'bold'], title), withPrefix);
     this.writeBody(body);
     this.addNewLine();
   }
@@ -158,11 +159,11 @@ export class Output {
   }
 
   formatCode(code: string) {
-    return chalk.italic.cyan(code);
+    return styleText(['italic', 'cyan'], code);
   }
 
   formatUrl(url: string) {
-    return chalk.reset.blue.underline(url);
+    return styleText(['reset', 'blue', 'underline'], url);
   }
 
   statusList(status: TaskStatus, list: string[]) {

--- a/libs/output/src/index.ts
+++ b/libs/output/src/index.ts
@@ -5,19 +5,6 @@ type Colors = 'red' | 'cyan' | 'green' | 'yellow' | 'gray';
 
 type TaskStatus = 'success' | 'failure' | 'skipped';
 
-// TODO: check to see if we still need this
-// function isCI() {
-//   return (
-//     (process.env.CI && process.env.CI !== 'false') || // Drone CI plus others
-//     process.env.GITHUB_ACTIONS === 'true' // GitHub Actions
-//   );
-// }
-
-// if (isCI()) {
-//   // Disable coloring when running in CI environments.
-//   process.env.NODE_DISABLE_COLORS = 'true';
-// }
-
 export class Output {
   private appName: string;
   private appVersion?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -325,10 +325,7 @@
     },
     "libs/output": {
       "name": "@libs/output",
-      "version": "1.0.2",
-      "peerDependencies": {
-        "chalk": "^5.0.0"
-      }
+      "version": "1.0.2"
     },
     "libs/version": {
       "name": "@libs/version",
@@ -13862,7 +13859,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -37821,7 +37817,6 @@
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@ivanmaxlogiudice/gitignore": "^0.0.2",
-        "chalk": "^5.3.0",
         "change-case": "^5.4.0",
         "debug": "^4.3.4",
         "enquirer": "^2.4.1",
@@ -38099,7 +38094,6 @@
       "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^5.3.0",
         "find-up": "^8.0.0",
         "minimist": "^1.2.2",
         "proxy-agent": "6.5.0"

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@babel/parser": "^7.28.5",
     "@ivanmaxlogiudice/gitignore": "^0.0.2",
-    "chalk": "^5.3.0",
     "change-case": "^5.4.0",
     "debug": "^4.3.4",
     "enquirer": "^2.4.1",

--- a/packages/create-plugin/src/codemods/utils.ts
+++ b/packages/create-plugin/src/codemods/utils.ts
@@ -2,7 +2,7 @@ import { dirname, join } from 'node:path';
 import { createRequire } from 'node:module';
 import { Context } from './context.js';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import { output } from '../utils/utils.console.js';
 import { getPackageManagerSilentInstallCmd, getPackageManagerWithFallback } from '../utils/utils.packageManager.js';
 import { execSync } from 'node:child_process';
@@ -15,11 +15,11 @@ export function printChanges(context: Context, key: string, description: string)
 
   for (const [filePath, { changeType }] of Object.entries(changes)) {
     if (changeType === 'add') {
-      lines.push(`${chalk.green('ADD')} ${filePath}`);
+      lines.push(`${styleText(['green'], 'ADD')} ${filePath}`);
     } else if (changeType === 'update') {
-      lines.push(`${chalk.yellow('UPDATE')} ${filePath}`);
+      lines.push(`${styleText(['yellow'], 'UPDATE')} ${filePath}`);
     } else if (changeType === 'delete') {
-      lines.push(`${chalk.red('DELETE')} ${filePath}`);
+      lines.push(`${styleText(['red'], 'DELETE')} ${filePath}`);
     }
   }
 

--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import { glob } from 'glob';
 import minimist from 'minimist';
 import { mkdir, readdir, writeFile } from 'node:fs/promises';
@@ -26,7 +26,7 @@ export const generate = async (argv: minimist.ParsedArgs) => {
   if (exportPathIsPopulated && !IS_DEV) {
     output.error({
       title: 'Aborting plugin scaffold.',
-      body: [`Directory ${chalk.bold(exportPath)} exists and contains files.`],
+      body: [`Directory ${styleText(['bold'], exportPath)} exists and contains files.`],
     });
     process.exit(1);
   }
@@ -200,7 +200,7 @@ async function execPostScaffoldFunction<T>(fn: AsyncFunction<T>, ...args: Parame
   try {
     const resultMsg = await fn.apply(undefined, args);
     if (resultMsg) {
-      console.log(`${chalk.green('✔︎')} ${resultMsg}`);
+      console.log(`${styleText(['green'], '✔︎')} ${resultMsg}`);
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/packages/create-plugin/src/commands/generate/print-success-message.ts
+++ b/packages/create-plugin/src/commands/generate/print-success-message.ts
@@ -1,5 +1,5 @@
 import { machine } from 'node:os';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import { TemplateData } from '../../types.js';
 import { output } from '../../utils/utils.console.js';
 import { normalizeId } from '../../utils/utils.handlebars.js';
@@ -11,16 +11,16 @@ export function printGenerateSuccessMessage(answers: TemplateData) {
 
   const commands = output.bulletList([
     output.formatCode(`cd ./${directory}`),
-    `${output.formatCode(packageManagerName + ' install')} ${chalk.dim('to install frontend dependencies')}`,
-    `${output.formatCode(packageManagerName + ' exec playwright install chromium')} ${chalk.dim('to install e2e test dependencies')}`,
-    `${output.formatCode(packageManagerName + ' run dev')} ${chalk.dim('to build (and watch) the plugin frontend code')}`,
+    `${output.formatCode(packageManagerName + ' install')} ${styleText(['dim'], 'to install frontend dependencies')}`,
+    `${output.formatCode(packageManagerName + ' exec playwright install chromium')} ${styleText(['dim'], 'to install e2e test dependencies')}`,
+    `${output.formatCode(packageManagerName + ' run dev')} ${styleText(['dim'], 'to build (and watch) the plugin frontend code')}`,
     ...(answers.hasBackend
       ? [
-          `${getBackendCmd()} ${chalk.dim('to build the plugin backend code. Rerun this command every time you edit your backend files')}`,
+          `${getBackendCmd()} ${styleText(['dim'], 'to build the plugin backend code. Rerun this command every time you edit your backend files')}`,
         ]
       : []),
-    `${output.formatCode('docker compose up')} ${chalk.dim('to start a grafana development server')}`,
-    `Open ${output.formatUrl('http://localhost:3000')} ${chalk.dim('in your browser to begin developing your plugin')}`,
+    `${output.formatCode('docker compose up')} ${styleText(['dim'], 'to start a grafana development server')}`,
+    `Open ${output.formatUrl('http://localhost:3000')} ${styleText(['dim'], 'in your browser to begin developing your plugin')}`,
   ]);
 
   output.log({
@@ -29,7 +29,8 @@ export function printGenerateSuccessMessage(answers: TemplateData) {
       'Run the following commands to get started:',
       ...commands,
       '',
-      chalk.italic(
+      styleText(
+        ['italic'],
         `Note: We strongly recommend creating a new Git repository by running ${output.formatCode('git init')} in ./${directory} before continuing.`
       ),
       '',

--- a/packages/create-plugin/src/commands/migrate.command.ts
+++ b/packages/create-plugin/src/commands/migrate.command.ts
@@ -18,7 +18,7 @@ import {
   writePackageManagerInPackageJson,
 } from '../utils/utils.npm.js';
 import { getPackageManagerWithFallback } from '../utils/utils.packageManager.js';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 export const migrate = async () => {
   try {
@@ -161,7 +161,7 @@ export const migrate = async () => {
     output.success({
       title: 'Migration completed successfully.',
       body: [
-        chalk.bold("What's next?"),
+        styleText(['bold'], "What's next?"),
         ...nextSteps,
         'See instructions on how to customize your configuration here: https://grafana.com/developers/plugin-tools/how-to-guides/extend-configurations',
       ],

--- a/packages/create-plugin/src/utils/utils.console.ts
+++ b/packages/create-plugin/src/utils/utils.console.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import Enquirer from 'enquirer';
 import { Output } from '@libs/output';
 import { CURRENT_APP_VERSION } from './utils.version.js';
@@ -14,7 +14,7 @@ export async function confirmPrompt(message: string): Promise<boolean> {
   const question: Record<string, boolean> = await prompt({
     name: 'confirmPrompt',
     type: 'confirm',
-    message: chalk.bold(message),
+    message: styleText(['bold'], message),
   });
 
   return question['confirmPrompt'];
@@ -25,7 +25,7 @@ export async function selectPrompt(message: string, choices: string[]): Promise<
     name: 'selectPrompt',
     type: 'select',
     choices,
-    message: chalk.bold(message),
+    message: styleText(['bold'], message),
   });
 
   return question['selectPrompt'];

--- a/packages/sign-plugin/package.json
+++ b/packages/sign-plugin/package.json
@@ -25,7 +25,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "chalk": "^5.3.0",
     "find-up": "^8.0.0",
     "minimist": "^1.2.2",
     "proxy-agent": "6.5.0"

--- a/packages/sign-plugin/src/commands/sign.command.ts
+++ b/packages/sign-plugin/src/commands/sign.command.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 import minimist from 'minimist';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
@@ -18,7 +18,7 @@ export const sign = async (argv: minimist.ParsedArgs) => {
     output.error({
       title: 'Plugin directory not found.',
       body: [
-        `Directory ${chalk.bold(pluginDistDir)} not found.`,
+        `Directory ${styleText(['bold'], pluginDistDir)} not found.`,
         'Make sure to build the plugin before attempting to sign it.',
       ],
     });

--- a/packages/sign-plugin/src/utils/manifest.ts
+++ b/packages/sign-plugin/src/utils/manifest.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { postData } from './request.js';
 import { output } from './utils.output.js';
-import chalk from 'chalk';
+import { styleText } from 'node:util';
 
 const MANIFEST_FILE = 'MANIFEST.txt';
 
@@ -112,7 +112,7 @@ export async function signManifest(manifest: ManifestInfo): Promise<string> {
       output.error({
         title: 'Error signing manifest.',
         body: [
-          `Server responded with status code ${chalk.yellow(info.status)} along with:`,
+          `Server responded with status code ${styleText(['yellow'], info.status.toString())} along with:`,
           ...output.bulletList(dataAsArray),
         ],
       });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
What's better than new node features? New node features that replace 3rd party deps! 🥳 

This PR replaces all usage of chalk in create-plugin and sign-plugin with nodes own styleText function.

| Before | After |
| --- | --- |
| <img width="1029" height="531" alt="Screenshot 2025-12-17 at 07 46 22" src="https://github.com/user-attachments/assets/2135941f-68f3-4af8-a51c-aaa1c0e1c99f" /> | <img width="1041" height="527" alt="Screenshot 2025-12-17 at 07 45 47" src="https://github.com/user-attachments/assets/5aae5ff0-db98-41f9-86ee-eb507613a1c3" /> |



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @libs/output@1.0.3-canary.2349.20294543760.0
  npm install @grafana/create-plugin@6.5.2-canary.2349.20294543760.0
  npm install @grafana/sign-plugin@3.2.1-canary.2349.20294543760.0
  # or 
  yarn add @libs/output@1.0.3-canary.2349.20294543760.0
  yarn add @grafana/create-plugin@6.5.2-canary.2349.20294543760.0
  yarn add @grafana/sign-plugin@3.2.1-canary.2349.20294543760.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
