### PR TITLE
Plugin-e2e: Fix toggle viz selector for Grafana < 12.4.0

### DIFF
--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -96,7 +96,7 @@ export class PanelEditPage extends GrafanaPage {
     await this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker).click();
     await this.getByGrafanaSelector(this.ctx.selectors.components.PluginVisualization.item(visualization)).click();
 
-    const vizSelector = semver.lte(this.ctx.grafanaVersion, '12.3.0')
+    const vizSelector = semver.lt(this.ctx.grafanaVersion, '12.4.0')
       ? this.ctx.selectors.components.PanelEditor.toggleVizPicker
       : this.ctx.selectors.components.PanelEditor.OptionsPane.header;
     await expect(
@@ -123,7 +123,7 @@ export class PanelEditPage extends GrafanaPage {
    * Returns the name of the visualization currently selected in the panel editor
    */
   getVisualizationName(): Locator {
-    const vizSelector = semver.lte(this.ctx.grafanaVersion, '12.3.0')
+    const vizSelector = semver.lt(this.ctx.grafanaVersion, '12.4.0')
       ? this.ctx.selectors.components.PanelEditor.toggleVizPicker
       : this.ctx.selectors.components.PanelEditor.OptionsPane.header;
     return this.getByGrafanaSelector(vizSelector);


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates version checks in the `PanelEditPage` class to ensure compatibility with Grafana versions 12.4.0 and above. The changes adjust the logic for selecting visualization-related UI elements based on the Grafana version.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.4.5-canary.2350.20292287699.0
  npm install @grafana/plugin-e2e@3.0.5-canary.2350.20292287699.0
  # or 
  yarn add @grafana/create-plugin@6.4.5-canary.2350.20292287699.0
  yarn add @grafana/plugin-e2e@3.0.5-canary.2350.20292287699.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
