### PR TITLE
CI: Fix permissions for bump-e2e-selectors workflow

### DIFF
--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Get secrets
         id: get-secrets


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds `id-token: write` permission to enable OIDC token generation for Vault authentication. Required for the `get-vault-secrets` action to retrieve secrets.

See CI error here: https://github.com/grafana/plugin-tools/actions/runs/20328697310/job/58399023504

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
