### PR TITLE
chore: only support react router v6 for new plugin scaffolds

### DIFF
--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -49,7 +49,6 @@ export const EXTRA_TEMPLATE_VARIABLES = {
 };
 
 export const DEFAULT_FEATURE_FLAGS = {
-  useReactRouterV6: true,
   bundleGrafanaUI: false,
   useExperimentalRspack: false,
   useExperimentalUpdates: true,

--- a/packages/create-plugin/src/types.ts
+++ b/packages/create-plugin/src/types.ts
@@ -22,9 +22,7 @@ export type TemplateData = {
   isNPM: boolean;
   version: string;
   bundleGrafanaUI: boolean;
-  useReactRouterV6: boolean;
   scenesVersion: string;
-  reactRouterVersion: string;
   useExperimentalRspack: boolean;
   pluginExecutable?: string;
   frontendBundler: 'webpack' | 'rspack';

--- a/packages/create-plugin/src/utils/tests/utils.config.test.ts
+++ b/packages/create-plugin/src/utils/tests/utils.config.test.ts
@@ -94,7 +94,6 @@ describe('getConfig', () => {
       const userConfigPath = path.join(tmpDir, '.cprc.json');
       const userConfig: UserConfig = {
         features: {
-          useReactRouterV6: true,
           bundleGrafanaUI: true,
         },
       };
@@ -118,7 +117,6 @@ describe('getConfig', () => {
       };
       const userConfig: UserConfig = {
         features: {
-          useReactRouterV6: false,
           bundleGrafanaUI: false,
         },
       };

--- a/packages/create-plugin/src/utils/utils.config.ts
+++ b/packages/create-plugin/src/utils/utils.config.ts
@@ -11,10 +11,6 @@ import { EOL } from 'node:os';
 
 export type FeatureFlags = {
   bundleGrafanaUI?: boolean;
-
-  // If set to true, the plugin will be scaffolded with React Router v6. Defaults to true.
-  // (Attention! We always scaffold new projects with React Router v6, so if you are changing this to `false` manually you will need to make changes to the React code as well.)
-  useReactRouterV6?: boolean;
   useExperimentalRspack?: boolean;
   useExperimentalUpdates?: boolean;
 };

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -96,7 +96,6 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
   const { features } = getConfig();
   const currentVersion = CURRENT_APP_VERSION;
   const bundleGrafanaUI = features.bundleGrafanaUI ?? DEFAULT_FEATURE_FLAGS.bundleGrafanaUI;
-  const getReactRouterVersion = () => (features.useReactRouterV6 ? '6.22.0' : '5.2.0');
   const isAppType = (pluginType: string) => pluginType === PLUGIN_TYPES.app || pluginType === PLUGIN_TYPES.scenes;
   const isNPM = (packageManagerName: string) => packageManagerName === 'npm';
   const frontendBundler = features.useExperimentalRspack ? 'rspack' : 'webpack';
@@ -122,9 +121,7 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
       isNPM: isNPM(packageManagerName),
       version: currentVersion,
       bundleGrafanaUI,
-      useReactRouterV6: features.useReactRouterV6 ?? DEFAULT_FEATURE_FLAGS.useReactRouterV6,
-      reactRouterVersion: getReactRouterVersion(),
-      scenesVersion: features.useReactRouterV6 ? '^6.10.4' : '^5.41.3',
+      scenesVersion: '^6.10.4',
       useExperimentalRspack: Boolean(features.useExperimentalRspack),
       frontendBundler,
     };
@@ -148,9 +145,7 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
       isNPM: isNPM(packageManagerName),
       version: currentVersion,
       bundleGrafanaUI,
-      useReactRouterV6: features.useReactRouterV6 ?? DEFAULT_FEATURE_FLAGS.useReactRouterV6,
-      reactRouterVersion: getReactRouterVersion(),
-      scenesVersion: features.useReactRouterV6 ? '^6.10.4' : '^5.41.3',
+      scenesVersion: '^6.10.4',
       pluginExecutable: pluginJson.executable,
       useExperimentalRspack: Boolean(features.useExperimentalRspack),
       frontendBundler,

--- a/packages/create-plugin/templates/common/.config/bundler/externals.ts
+++ b/packages/create-plugin/templates/common/.config/bundler/externals.ts
@@ -22,15 +22,14 @@ export const externals: ExternalsType = [
   'redux',
   'rxjs',
   'i18next',
-  'react-router',{{#unless useReactRouterV6}}
-  'react-router-dom',{{/unless}}
+  'react-router',
   'd3',
   'angular',{{#unless bundleGrafanaUI}}
   /^@grafana\/ui/i,{{/unless}}
   /^@grafana\/runtime/i,
   /^@grafana\/data/i,{{#if bundleGrafanaUI}}
   'react-inlinesvg',{{/if}}
-  
+
   // Mark legacy SDK imports as external if their name starts with the "grafana/" prefix
   ({ request }: ExternalItemFunctionData, callback: (error?: Error, result?: string) => void) => {
     const prefix = 'grafana/';

--- a/packages/create-plugin/templates/common/.cprc.json
+++ b/packages/create-plugin/templates/common/.cprc.json
@@ -1,7 +1,6 @@
 {
   "features": {
     "bundleGrafanaUI": {{ bundleGrafanaUI }},
-    "useReactRouterV6": {{ useReactRouterV6 }},
     "useExperimentalRspack": {{ useExperimentalRspack }}
   }
 }

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -31,8 +31,7 @@
     "@types/jest": "^29.5.0",
     "@types/node": "^20.8.7",
     "@types/react": "^18.3.0",
-    "@types/react-dom": "^18.3.0",{{#if isAppType}}{{#unless useReactRouterV6}}
-    "@types/react-router-dom": "^{{ reactRouterVersion }}",{{/unless}}{{/if}}
+    "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",{{#unless useExperimentalRspack}}
     "copy-webpack-plugin": "^11.0.0",{{/unless}}
@@ -80,7 +79,7 @@
     "@grafana/scenes": "{{ scenesVersion }}",{{/if_eq}}
     "react": "^18.3.0",
     "react-dom": "^18.3.0"{{#if isAppType}},
-    "react-router-dom": "^{{ reactRouterVersion }}",
+    "react-router-dom": "^6.22.0",
     "rxjs": "7.8.2"{{/if}}
   },
   "packageManager": "{{ packageManagerName }}@{{ packageManagerVersion }}"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR removes the feature toggle for react router v6. It's [default value has been true](https://github.com/grafana/plugin-tools/pull/710) for 22 months now and the scaffolded templates require code changes to downgrade to v5.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.7.0-canary.2360.20344510513.0
  # or 
  yarn add @grafana/create-plugin@6.7.0-canary.2360.20344510513.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
