### PR TITLE
fix: remove unused Compiler type import from Webpack plugin

### DIFF
--- a/packages/create-plugin/templates/common/.config/webpack/BuildModeWebpackPlugin.ts
+++ b/packages/create-plugin/templates/common/.config/webpack/BuildModeWebpackPlugin.ts
@@ -1,4 +1,4 @@
-import webpack, { type Compiler } from 'webpack';
+import webpack from 'webpack';
 
 const PLUGIN_NAME = 'BuildModeWebpack';
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes an unused type import that can cause tsc to error if run over the file:

```
.config/webpack/BuildModeWebpackPlugin.ts:1:24 - error TS6133: 'Compiler' is declared but its value is never read.

1 import webpack, { type Compiler } from 'webpack';
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.7.1-canary.2370.20798217827.0
  # or 
  yarn add @grafana/create-plugin@6.7.1-canary.2370.20798217827.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
