### PR TITLE
Create Plugin: Remove g/ui bundling code from templates

### DIFF
--- a/packages/create-plugin/src/constants.ts
+++ b/packages/create-plugin/src/constants.ts
@@ -49,7 +49,6 @@ export const EXTRA_TEMPLATE_VARIABLES = {
 };
 
 export const DEFAULT_FEATURE_FLAGS = {
-  bundleGrafanaUI: false,
   useExperimentalRspack: false,
   useExperimentalUpdates: true,
 };

--- a/packages/create-plugin/src/types.ts
+++ b/packages/create-plugin/src/types.ts
@@ -21,7 +21,6 @@ export type TemplateData = {
   isAppType: boolean;
   isNPM: boolean;
   version: string;
-  bundleGrafanaUI: boolean;
   scenesVersion: string;
   useExperimentalRspack: boolean;
   pluginExecutable?: string;

--- a/packages/create-plugin/src/utils/tests/utils.config.test.ts
+++ b/packages/create-plugin/src/utils/tests/utils.config.test.ts
@@ -46,13 +46,13 @@ describe('getConfig', () => {
 
     it('should override default feature flags via cli args', async () => {
       mocks.argv = {
-        'feature-flags': 'bundleGrafanaUI',
+        'feature-flags': 'useExperimentalRspack',
       };
       const config = getConfig(tmpDir);
 
       expect(config).toEqual({
         version: CURRENT_APP_VERSION,
-        features: { ...DEFAULT_FEATURE_FLAGS, bundleGrafanaUI: true },
+        features: { ...DEFAULT_FEATURE_FLAGS, useExperimentalRspack: true },
       });
     });
   });
@@ -94,7 +94,7 @@ describe('getConfig', () => {
       const userConfigPath = path.join(tmpDir, '.cprc.json');
       const userConfig: UserConfig = {
         features: {
-          bundleGrafanaUI: true,
+          useExperimentalRspack: true,
         },
       };
 
@@ -106,28 +106,6 @@ describe('getConfig', () => {
         version: CURRENT_APP_VERSION,
         features: userConfig.features,
       });
-    });
-
-    it('should give back the correct config when config files exist', async () => {
-      const rootConfigPath = path.join(tmpDir, '.config', '.cprc.json');
-      const userConfigPath = path.join(tmpDir, '.cprc.json');
-      const rootConfig: CreatePluginConfig = {
-        version: '1.0.0',
-        features: {},
-      };
-      const userConfig: UserConfig = {
-        features: {
-          bundleGrafanaUI: false,
-        },
-      };
-
-      await fs.mkdir(path.dirname(rootConfigPath), { recursive: true });
-      await fs.writeFile(rootConfigPath, JSON.stringify(rootConfig));
-      await fs.writeFile(userConfigPath, JSON.stringify(userConfig));
-
-      const config = getConfig(tmpDir);
-
-      expect(config).toEqual({ ...rootConfig, ...userConfig });
     });
   });
 });

--- a/packages/create-plugin/src/utils/utils.config.ts
+++ b/packages/create-plugin/src/utils/utils.config.ts
@@ -10,7 +10,6 @@ import { writeFile } from 'node:fs/promises';
 import { EOL } from 'node:os';
 
 export type FeatureFlags = {
-  bundleGrafanaUI?: boolean;
   useExperimentalRspack?: boolean;
   useExperimentalUpdates?: boolean;
 };

--- a/packages/create-plugin/src/utils/utils.templates.ts
+++ b/packages/create-plugin/src/utils/utils.templates.ts
@@ -1,10 +1,4 @@
-import {
-  DEFAULT_FEATURE_FLAGS,
-  EXPORT_PATH_PREFIX,
-  EXTRA_TEMPLATE_VARIABLES,
-  PLUGIN_TYPES,
-  TEMPLATE_PATHS,
-} from '../constants.js';
+import { EXPORT_PATH_PREFIX, EXTRA_TEMPLATE_VARIABLES, PLUGIN_TYPES, TEMPLATE_PATHS } from '../constants.js';
 import { GenerateCliArgs, TemplateData } from '../types.js';
 import { filterOutCommonFiles, isFile, isFileStartingWith } from './utils.files.js';
 import {
@@ -95,7 +89,6 @@ export function renderTemplateFromFile(templateFile: string, data?: any) {
 export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
   const { features } = getConfig();
   const currentVersion = CURRENT_APP_VERSION;
-  const bundleGrafanaUI = features.bundleGrafanaUI ?? DEFAULT_FEATURE_FLAGS.bundleGrafanaUI;
   const isAppType = (pluginType: string) => pluginType === PLUGIN_TYPES.app || pluginType === PLUGIN_TYPES.scenes;
   const isNPM = (packageManagerName: string) => packageManagerName === 'npm';
   const frontendBundler = features.useExperimentalRspack ? 'rspack' : 'webpack';
@@ -120,7 +113,6 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
       isAppType: isAppType(cliArgs.pluginType),
       isNPM: isNPM(packageManagerName),
       version: currentVersion,
-      bundleGrafanaUI,
       scenesVersion: '^6.10.4',
       useExperimentalRspack: Boolean(features.useExperimentalRspack),
       frontendBundler,
@@ -144,7 +136,6 @@ export function getTemplateData(cliArgs?: GenerateCliArgs): TemplateData {
       isAppType: isAppType(pluginJson.type),
       isNPM: isNPM(packageManagerName),
       version: currentVersion,
-      bundleGrafanaUI,
       scenesVersion: '^6.10.4',
       pluginExecutable: pluginJson.executable,
       useExperimentalRspack: Boolean(features.useExperimentalRspack),

--- a/packages/create-plugin/templates/common/.cprc.json
+++ b/packages/create-plugin/templates/common/.cprc.json
@@ -1,6 +1,5 @@
 {
   "features": {
-    "bundleGrafanaUI": {{ bundleGrafanaUI }},
     "useExperimentalRspack": {{ useExperimentalRspack }}
   }
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR removes the code that handles grafana/ui bundling from the create-plugin templates, as this can now be done through an add script (see https://github.com/grafana/plugin-tools/pull/2356). 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
