### PR TITLE
Renovate: Skip e2e-selectors management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,7 @@
     "react-dom",
     "lerna",
     "@grafana/scenes",
+    "@grafana/e2e-selectors",
     "@libs/output",
     "@libs/version"
   ],
@@ -61,8 +62,7 @@
       "matchUpdateTypes": ["patch"],
       "matchPackageNames": [
         "/@grafana/*/",
-        "/grafana/grafana-enterprise/",
-        "!@grafana/e2e-selectors"
+        "/grafana/grafana-enterprise/"
       ],
       "minimumReleaseAge": null
     },
@@ -74,7 +74,6 @@
       "matchPackageNames": [
         "/@grafana/*/",
         "/grafana/grafana-enterprise/",
-        "!@grafana/e2e-selectors",
         "!@grafana/eslint-config",
         "!@grafana/scenes"
       ],
@@ -101,8 +100,7 @@
         "!/^@?docusaurus/",
         "!/^@auto-it/",
         "!/^auto/",
-        "!/@grafana/*/",
-        "!@grafana/e2e-selectors"
+        "!/@grafana/*/"
       ],
       "rangeStrategy": "bump"
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that bumping the e2e-selectors package in plugin-e2e is handled in the [bump-e2e-selectors.yml](https://github.com/grafana/plugin-tools/blob/main/.github/workflows/bump-e2e-selectors.yml) workflow, there's no need for renovate to manage it.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**: