### PR TITLE
feat: support yarn v1

### DIFF
--- a/packages/react-detect/src/commands/detect19.ts
+++ b/packages/react-detect/src/commands/detect19.ts
@@ -39,6 +39,7 @@ export async function detect19(argv: minimist.ParsedArgs) {
       title: 'Error during detection',
       body: [(error as Error).message],
     });
+    process.exit(1);
   }
 }
 

--- a/packages/react-detect/src/commands/detect19.ts
+++ b/packages/react-detect/src/commands/detect19.ts
@@ -6,32 +6,40 @@ import { jsonReporter } from '../reporters/json.js';
 import { consoleReporter } from '../reporters/console.js';
 import { extractAllSources } from '../source-extractor.js';
 import { analyzeSourceFiles } from '../analyzer.js';
+import { output } from '../utils/output.js';
 /**
  * Main detect command for finding React 19 breaking changes
  */
 export async function detect19(argv: minimist.ParsedArgs) {
-  const pluginRoot = argv.pluginRoot || process.cwd();
+  try {
+    const pluginRoot = argv.pluginRoot || process.cwd();
 
-  const allMatches = await getAllMatches(pluginRoot);
-  const depContext = new DependencyContext();
-  await depContext.loadDependencies(pluginRoot);
+    const allMatches = await getAllMatches(pluginRoot);
+    const depContext = new DependencyContext();
+    await depContext.loadDependencies(pluginRoot);
 
-  const matchesWithRootDependency = allMatches.map((match) => {
-    if (match.type === 'dependency' && match.packageName) {
-      return { ...match, rootDependency: depContext.findRootDependency(match.packageName) };
+    const matchesWithRootDependency = allMatches.map((match) => {
+      if (match.type === 'dependency' && match.packageName) {
+        return { ...match, rootDependency: depContext.findRootDependency(match.packageName) };
+      }
+      return match;
+    });
+
+    const results = generateAnalysisResults(matchesWithRootDependency, pluginRoot, depContext);
+
+    if (argv.json) {
+      jsonReporter(results);
+    } else {
+      consoleReporter(results);
     }
-    return match;
-  });
 
-  const results = generateAnalysisResults(matchesWithRootDependency, pluginRoot, depContext);
-
-  if (argv.json) {
-    jsonReporter(results);
-  } else {
-    consoleReporter(results);
+    process.exit(results.summary.totalIssues > 0 ? 1 : 0);
+  } catch (error) {
+    output.error({
+      title: 'Error during detection',
+      body: [(error as Error).message],
+    });
   }
-
-  process.exit(results.summary.totalIssues > 0 ? 1 : 0);
 }
 
 async function getAllMatches(pluginRoot: string) {

--- a/packages/react-detect/src/utils/analyzer.ts
+++ b/packages/react-detect/src/utils/analyzer.ts
@@ -47,6 +47,7 @@ export function hasReactComponent(ast: TSESTree.Program): boolean {
 
   walk(ast, (node) => {
     if (
+      node &&
       node.type === 'ClassDeclaration' &&
       node.superClass?.type === 'MemberExpression' &&
       node.superClass.object.type === 'Identifier' &&
@@ -71,7 +72,7 @@ export function hasFunctionComponentPattern(ast: TSESTree.Program): boolean {
 
   let found = false;
   walk(ast, (node) => {
-    if (node.type === 'FunctionDeclaration' || node.type === 'ArrowFunctionExpression') {
+    if (node && (node.type === 'FunctionDeclaration' || node.type === 'ArrowFunctionExpression')) {
       found = true;
     }
   });
@@ -84,6 +85,7 @@ function hasReactImport(ast: TSESTree.Program): boolean {
 
   walk(ast, (node) => {
     if (
+      node &&
       node.type === 'ImportDeclaration' &&
       node.source.type === 'Literal' &&
       (node.source.value === 'react' || node.source.value === 'react-dom')
@@ -99,7 +101,7 @@ function hasJSX(ast: TSESTree.Program): boolean {
   let found = false;
 
   walk(ast, (node) => {
-    if (node.type === 'JSXElement' || node.type === 'JSXFragment') {
+    if (node && (node.type === 'JSXElement' || node.type === 'JSXFragment')) {
       found = true;
     }
   });
@@ -111,7 +113,12 @@ function hasHooks(ast: TSESTree.Program): boolean {
   let found = false;
 
   walk(ast, (node) => {
-    if (node.type === 'CallExpression' && node.callee.type === 'Identifier' && node.callee.name.startsWith('use')) {
+    if (
+      node &&
+      node.type === 'CallExpression' &&
+      node.callee.type === 'Identifier' &&
+      node.callee.name.startsWith('use')
+    ) {
       found = true;
     }
   });

--- a/packages/react-detect/src/utils/dependencies.ts
+++ b/packages/react-detect/src/utils/dependencies.ts
@@ -37,7 +37,7 @@ export class DependencyContext {
           pruneCycles: false,
         });
       } else if (lockfile === 'yarn.lock') {
-        if (lockfileContent.includes('# yarn lockfile v1')) {
+        if (/#\s*yarn lockfile v1/i.test(lockfileContent)) {
           this.depGraph = await parseYarnLockV1Project(pkgJsonContentString, lockfileContent, {
             includeDevDeps: true,
             includeOptionalDeps: true,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
I tried running react-detect on a community plugin and quickly realised yarn 1 lock files were erroring due to cli trying to parse them as yarn v2+ lock files:

```
/Users/jackwestbrook/.npm/_npx/aed3466c12a3bbf9/node_modules/js-yaml/lib/loader.js:199
  return new YAMLException(message, mark);
         ^
YAMLException: bad indentation of a mapping entry (14:15)

 11 |   version "3.2.0"
 12 |   resolved "https://registry.yarnpkg.com/@asa ...
 13 |   integrity sha512-K1A6z8tS3XsmCMM86xoWdn7Fkd ...
 14 |   dependencies:
```

I also spotted ast related errors due to analyzer expecting a node (which can be`null`):

```
Failed to analyze webpack://grafana-dbo11y-app/node_modules/@xyflow/react/dist/esm/index.js: TypeError: Cannot read properties of null (reading 'type')
    at file:///Users/jackwestbrook/.npm/_npx/aed3466c12a3bbf9/node_modules/@grafana/react-detect/dist/utils/analyzer.js:63:14
```

This PR addresses both these issues along with pretty printing top level errors related to source maps missing.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/react-detect@0.3.0-canary.2395.21023152965.0
  # or 
  yarn add @grafana/react-detect@0.3.0-canary.2395.21023152965.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
