### PR TITLE
feat: allow skipping dependency and build tooling analysis

### DIFF
--- a/packages/react-detect/README.md
+++ b/packages/react-detect/README.md
@@ -21,3 +21,5 @@ npx @grafana/react-detect
 
 - `--pluginRoot`: Pass the root directory of the plugin. Defaults to the current working directory.
 - `--json`: Output the results as json.
+- `--skipBuildTooling`: Skip webpack configuration checks (jsx-runtime externalization). Useful when build config is missing or not applicable.
+- `--skipDependencies`: Skip dependency tree analysis. Useful when lockfile is missing or for faster analysis of source code only.

--- a/packages/react-detect/src/bin/run.ts
+++ b/packages/react-detect/src/bin/run.ts
@@ -4,7 +4,15 @@ import minimist from 'minimist';
 import { detect19 } from '../commands/detect19.js';
 
 const args = process.argv.slice(2);
-const argv = minimist(args);
+const argv = minimist(args, {
+  boolean: ['json', 'skipBuildTooling', 'skipDependencies'],
+  string: ['pluginRoot'],
+  default: {
+    json: false,
+    skipBuildTooling: false,
+    skipDependencies: false,
+  },
+});
 
 const commands: Record<string, (argv: minimist.ParsedArgs) => Promise<void>> = {
   detect19,

--- a/packages/react-detect/src/commands/detect19.ts
+++ b/packages/react-detect/src/commands/detect19.ts
@@ -49,7 +49,10 @@ export async function detect19(argv: minimist.ParsedArgs) {
             return match;
           });
 
-    const results = generateAnalysisResults(matchesWithRootDependency, pluginRoot, depContext);
+    const results = generateAnalysisResults(matchesWithRootDependency, pluginRoot, depContext, {
+      skipBuildTooling,
+      skipDependencies,
+    });
 
     if (argv.json) {
       jsonReporter(results);

--- a/packages/react-detect/src/commands/detect19.ts
+++ b/packages/react-detect/src/commands/detect19.ts
@@ -13,17 +13,41 @@ import { output } from '../utils/output.js';
 export async function detect19(argv: minimist.ParsedArgs) {
   try {
     const pluginRoot = argv.pluginRoot || process.cwd();
+    const skipDependencies = argv.skipDependencies || false;
+    const skipBuildTooling = argv.skipBuildTooling || false;
 
     const allMatches = await getAllMatches(pluginRoot);
-    const depContext = new DependencyContext();
-    await depContext.loadDependencies(pluginRoot);
 
-    const matchesWithRootDependency = allMatches.map((match) => {
-      if (match.type === 'dependency' && match.packageName) {
-        return { ...match, rootDependency: depContext.findRootDependency(match.packageName) };
+    // Conditionally load dependencies
+    let depContext: DependencyContext | null = null;
+    if (!skipDependencies) {
+      depContext = new DependencyContext();
+      try {
+        await depContext.loadDependencies(pluginRoot);
+      } catch (error) {
+        // Log warning but continue with null context
+        output.warning({
+          title: 'Failed to load dependencies',
+          body: [
+            (error as Error).message,
+            'Continuing without dependency analysis.',
+            'Use --skipDependencies to suppress this warning.',
+          ],
+        });
+        depContext = null;
       }
-      return match;
-    });
+    }
+
+    // Enrich matches with root dependency only if we have context
+    const matchesWithRootDependency =
+      depContext === null
+        ? allMatches
+        : allMatches.map((match) => {
+            if (match.type === 'dependency' && match.packageName) {
+              return { ...match, rootDependency: depContext.findRootDependency(match.packageName) };
+            }
+            return match;
+          });
 
     const results = generateAnalysisResults(matchesWithRootDependency, pluginRoot, depContext);
 

--- a/packages/react-detect/src/reporters/console.ts
+++ b/packages/react-detect/src/reporters/console.ts
@@ -16,6 +16,27 @@ const summaryMsg = [
 ];
 
 export function consoleReporter(results: PluginAnalysisResults) {
+  if (!results.summary.analyzedBuildTooling || !results.summary.analyzedDependencies) {
+    const skippedFeatures: string[] = [];
+    if (!results.summary.analyzedBuildTooling) {
+      skippedFeatures.push('Build tooling analysis (webpack config checks)');
+    }
+    if (!results.summary.analyzedDependencies) {
+      skippedFeatures.push('Dependency tree analysis (lockfile parsing)');
+    }
+
+    output.warning({
+      title: 'Analysis Skipped',
+      body: [
+        'The following analyses were skipped:',
+        ...output.bulletList(skippedFeatures),
+        '',
+        'Results may be incomplete. Remove skip flags for full analysis.',
+      ],
+    });
+    output.addHorizontalLine('yellow');
+  }
+
   if (results.summary.totalIssues === 0) {
     output.success({
       title: 'No React 19 breaking changes detected.',

--- a/packages/react-detect/src/types/reporters.ts
+++ b/packages/react-detect/src/types/reporters.ts
@@ -32,6 +32,8 @@ export interface PluginAnalysisResults {
     dependencyIssuesCount: number;
     status: 'action_required' | 'no_action_required';
     affectedDependencies: string[];
+    analyzedBuildTooling: boolean;
+    analyzedDependencies: boolean;
   };
   issues: {
     critical: AnalysisResult[];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The react-detect package relies on the entire source and build tooling config to be available. This isn't an issue for plugin devs running the tool locally but we need to run it against plugins that don't have public repo / source code.

This PR adds two flags so we can skip the checks that rely on access to the plugins repo / source code.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-meta-extractor@0.12.0-canary.2397.21030655812.0
  npm install @grafana/react-detect@0.4.0-canary.2397.21030655812.0
  # or 
  yarn add @grafana/plugin-meta-extractor@0.12.0-canary.2397.21030655812.0
  yarn add @grafana/react-detect@0.4.0-canary.2397.21030655812.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
