### PR TITLE
Plugin E2E: OpenFeature support

### DIFF
--- a/packages/plugin-e2e/src/fixtures/bootData.ts
+++ b/packages/plugin-e2e/src/fixtures/bootData.ts
@@ -1,0 +1,41 @@
+import { PlaywrightTestArgs, TestFixture } from '@playwright/test';
+
+interface BootData {
+  version: string;
+  namespace: string;
+}
+
+type BootDataFixture = TestFixture<BootData, PlaywrightTestArgs>;
+
+/**
+ * Internal fixture that fetches boot data from Grafana.
+ * This fixture is not exposed in the test API - it's only used by other fixtures
+ * to consolidate boot data fetching to avoid creating multiple temporary pages.
+ */
+export const bootData: BootDataFixture = async ({ context }, use) => {
+  const version = process.env.GRAFANA_VERSION ?? '';
+  let namespace = '';
+
+  // creates a temporary page to avoid circular dependencies between fixtures
+  const tempPage = await context.newPage();
+  try {
+    await tempPage.goto('/');
+    const bootDataSettings = await tempPage.evaluate(() => {
+      return {
+        version: window.grafanaBootData.settings.buildInfo.version,
+        namespace: window.grafanaBootData.settings.namespace,
+      };
+    });
+
+    // plugins may override version in CI via env var
+    const finalVersion = version || bootDataSettings.version;
+    namespace = bootDataSettings.namespace || 'default';
+
+    await use({ version: finalVersion, namespace });
+  } catch (error) {
+    console.error('@grafana/plugin-e2e: Failed to fetch boot data', error);
+    await use({ version: version || '', namespace: 'default' });
+  } finally {
+    await tempPage.close();
+  }
+};

--- a/packages/plugin-e2e/src/fixtures/getOpenFeatureFlag.ts
+++ b/packages/plugin-e2e/src/fixtures/getOpenFeatureFlag.ts
@@ -1,0 +1,34 @@
+import { TestFixture } from '@playwright/test';
+import { PlaywrightArgs } from '../types';
+
+type GetBooleanOpenFeatureFlagFixture = TestFixture<(flagKey: string) => Promise<boolean>, PlaywrightArgs>;
+
+export const getBooleanOpenFeatureFlag: GetBooleanOpenFeatureFlagFixture = async (
+  { page, selectors, namespace },
+  use
+) => {
+  await use(async (flagKey: string) => {
+    try {
+      const url = selectors.apis.OpenFeature.ofrepSinglePath(namespace, flagKey);
+      const response = await page.request.get(url);
+
+      if (!response.ok()) {
+        throw new Error(`Failed to fetch OpenFeature flag "${flagKey}": ${response.status()} ${response.statusText()}`);
+      }
+
+      const body = await response.json();
+      const value = body.value;
+
+      if (typeof value !== 'boolean') {
+        throw new Error(
+          `Expected boolean value for flag "${flagKey}", but got ${typeof value}. Use a different getter for non-boolean flags.`
+        );
+      }
+
+      return value;
+    } catch (error) {
+      console.error(`@grafana/plugin-e2e: Failed to get OpenFeature flag "${flagKey}"`, error);
+      throw error;
+    }
+  });
+};

--- a/packages/plugin-e2e/src/fixtures/grafanaVersion.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaVersion.ts
@@ -2,11 +2,17 @@ import { PlaywrightTestArgs, TestFixture } from '@playwright/test';
 
 type GrafanaVersion = TestFixture<string, PlaywrightTestArgs>;
 
-export const grafanaVersion: GrafanaVersion = async ({ page }, use) => {
+export const grafanaVersion: GrafanaVersion = async ({ context }, use) => {
   let grafanaVersion = process.env.GRAFANA_VERSION ?? '';
   if (!grafanaVersion) {
-    await page.goto('/');
-    grafanaVersion = await page.evaluate('window.grafanaBootData.settings.buildInfo.version');
+    // Create a temporary page to fetch the version without depending on the page fixture
+    const tempPage = await context.newPage();
+    try {
+      await tempPage.goto('/');
+      grafanaVersion = await tempPage.evaluate('window.grafanaBootData.settings.buildInfo.version');
+    } finally {
+      await tempPage.close();
+    }
   }
 
   await use(grafanaVersion.replace(/\-.*/, ''));

--- a/packages/plugin-e2e/src/fixtures/grafanaVersion.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaVersion.ts
@@ -4,6 +4,9 @@ import { PlaywrightArgs } from '../types';
 type GrafanaVersion = TestFixture<string, PlaywrightArgs>;
 
 export const grafanaVersion: GrafanaVersion = async ({ bootData }, use) => {
+  // plugins may override version in CI via env var
+  const version = process.env.GRAFANA_VERSION || bootData.version || '';
+
   // strip version suffix (e.g., "11.0.0-pre" -> "11.0.0")
-  await use(bootData.version.replace(/\-.*/, ''));
+  await use(version.replace(/\-.*/, ''));
 };

--- a/packages/plugin-e2e/src/fixtures/grafanaVersion.ts
+++ b/packages/plugin-e2e/src/fixtures/grafanaVersion.ts
@@ -1,19 +1,9 @@
-import { PlaywrightTestArgs, TestFixture } from '@playwright/test';
+import { TestFixture } from '@playwright/test';
+import { PlaywrightArgs } from '../types';
 
-type GrafanaVersion = TestFixture<string, PlaywrightTestArgs>;
+type GrafanaVersion = TestFixture<string, PlaywrightArgs>;
 
-export const grafanaVersion: GrafanaVersion = async ({ context }, use) => {
-  let grafanaVersion = process.env.GRAFANA_VERSION ?? '';
-  if (!grafanaVersion) {
-    // Create a temporary page to fetch the version without depending on the page fixture
-    const tempPage = await context.newPage();
-    try {
-      await tempPage.goto('/');
-      grafanaVersion = await tempPage.evaluate('window.grafanaBootData.settings.buildInfo.version');
-    } finally {
-      await tempPage.close();
-    }
-  }
-
-  await use(grafanaVersion.replace(/\-.*/, ''));
+export const grafanaVersion: GrafanaVersion = async ({ bootData }, use) => {
+  // strip version suffix (e.g., "11.0.0-pre" -> "11.0.0")
+  await use(bootData.version.replace(/\-.*/, ''));
 };

--- a/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
+++ b/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
@@ -3,14 +3,36 @@ import { PlaywrightArgs } from '../types';
 
 type FeatureToggleFixture = TestFixture<<T = object>(featureToggle: keyof T) => Promise<boolean>, PlaywrightArgs>;
 
-export const isFeatureToggleEnabled: FeatureToggleFixture = async ({ page }, use) => {
+/**
+ * Checks if a legacy feature toggle is enabled.
+ * This only checks window.grafanaBootData.settings.featureToggles (legacy system).
+ * For OpenFeature flags, use getBooleanOpenFeatureFlag instead.
+ */
+export const isLegacyFeatureToggleEnabled: FeatureToggleFixture = async ({ page }, use) => {
   await use(async <T = object>(featureToggle: keyof T) => {
     const featureToggles: T = await page.evaluate('window.grafanaBootData.settings.featureToggles');
     return Boolean(featureToggles[featureToggle]);
   });
 };
 
-export const isFeatureEnabled = async (page: Page, featureToggle: string) => {
+/**
+ * @deprecated Use isLegacyFeatureToggleEnabled instead. This fixture only checks legacy feature toggles
+ * (window.grafanaBootData.settings.featureToggles). For OpenFeature flags, use getBooleanOpenFeatureFlag.
+ */
+export const isFeatureToggleEnabled: FeatureToggleFixture = isLegacyFeatureToggleEnabled;
+
+/**
+ * Checks if a legacy feature toggle is enabled.
+ * This only checks window.grafanaBootData.settings.featureToggles (legacy system).
+ * For OpenFeature flags, use getBooleanOpenFeatureFlag instead.
+ */
+export const isLegacyFeatureEnabled = async (page: Page, featureToggle: string) => {
   const featureToggles: Record<string, string> = await page.evaluate('window.grafanaBootData.settings.featureToggles');
   return Boolean(featureToggles[featureToggle]);
 };
+
+/**
+ * @deprecated Use isLegacyFeatureEnabled instead. This function only checks legacy feature toggles
+ * (window.grafanaBootData.settings.featureToggles). For OpenFeature flags, use getBooleanOpenFeatureFlag.
+ */
+export const isFeatureEnabled = isLegacyFeatureEnabled;

--- a/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
+++ b/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
@@ -3,11 +3,6 @@ import { PlaywrightArgs } from '../types';
 
 type FeatureToggleFixture = TestFixture<<T = object>(featureToggle: keyof T) => Promise<boolean>, PlaywrightArgs>;
 
-/**
- * Checks if a legacy feature toggle is enabled.
- * This only checks window.grafanaBootData.settings.featureToggles (legacy system).
- * For OpenFeature flags, use getBooleanOpenFeatureFlag instead.
- */
 export const isLegacyFeatureToggleEnabled: FeatureToggleFixture = async ({ page }, use) => {
   await use(async <T = object>(featureToggle: keyof T) => {
     const featureToggles: T = await page.evaluate('window.grafanaBootData.settings.featureToggles');
@@ -15,24 +10,11 @@ export const isLegacyFeatureToggleEnabled: FeatureToggleFixture = async ({ page 
   });
 };
 
-/**
- * @deprecated Use isLegacyFeatureToggleEnabled instead. This fixture only checks legacy feature toggles
- * (window.grafanaBootData.settings.featureToggles). For OpenFeature flags, use getBooleanOpenFeatureFlag.
- */
 export const isFeatureToggleEnabled: FeatureToggleFixture = isLegacyFeatureToggleEnabled;
 
-/**
- * Checks if a legacy feature toggle is enabled.
- * This only checks window.grafanaBootData.settings.featureToggles (legacy system).
- * For OpenFeature flags, use getBooleanOpenFeatureFlag instead.
- */
 export const isLegacyFeatureEnabled = async (page: Page, featureToggle: string) => {
   const featureToggles: Record<string, string> = await page.evaluate('window.grafanaBootData.settings.featureToggles');
   return Boolean(featureToggles[featureToggle]);
 };
 
-/**
- * @deprecated Use isLegacyFeatureEnabled instead. This function only checks legacy feature toggles
- * (window.grafanaBootData.settings.featureToggles). For OpenFeature flags, use getBooleanOpenFeatureFlag.
- */
 export const isFeatureEnabled = isLegacyFeatureEnabled;

--- a/packages/plugin-e2e/src/fixtures/namespace.ts
+++ b/packages/plugin-e2e/src/fixtures/namespace.ts
@@ -1,0 +1,8 @@
+import { TestFixture } from '@playwright/test';
+import { PlaywrightArgs } from '../types';
+
+type Namespace = TestFixture<string, PlaywrightArgs>;
+
+export const namespace: Namespace = async ({ bootData }, use) => {
+  await use(bootData.namespace);
+};

--- a/packages/plugin-e2e/src/fixtures/namespace.ts
+++ b/packages/plugin-e2e/src/fixtures/namespace.ts
@@ -4,5 +4,6 @@ import { PlaywrightArgs } from '../types';
 type Namespace = TestFixture<string, PlaywrightArgs>;
 
 export const namespace: Namespace = async ({ bootData }, use) => {
-  await use(bootData.namespace);
+  // default to 'default' if namespace is not available
+  await use(bootData.namespace || 'default');
 };

--- a/packages/plugin-e2e/src/fixtures/openFeature.ts
+++ b/packages/plugin-e2e/src/fixtures/openFeature.ts
@@ -1,0 +1,155 @@
+import { Page, Route } from '@playwright/test';
+
+import { FeatureFlagValue, PlaywrightArgs } from '../types';
+
+/**
+ * Represents a single flag in the OFREP response
+ */
+interface OFREPFlag {
+  key: string;
+  value: FeatureFlagValue;
+  reason: string;
+  variant: string;
+}
+
+/**
+ * Represents the OFREP bulk evaluation response body
+ */
+interface OFREPBulkResponse {
+  flags: OFREPFlag[];
+}
+
+/**
+ * Delays execution for the specified number of milliseconds
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Handles the OFREP bulk evaluation endpoint by merging flags into the response
+ */
+async function handleBulkEvaluationRoute(
+  route: Route,
+  flags: Record<string, FeatureFlagValue>,
+  latency: number
+): Promise<void> {
+  try {
+    const response = await route.fetch();
+
+    if (!response.ok()) {
+      await route.fulfill({ response });
+      return;
+    }
+
+    const body: OFREPBulkResponse = await response.json();
+
+    // override existing flags with provided values
+    for (const flag of body.flags) {
+      if (flag.key in flags) {
+        flag.value = flags[flag.key];
+        flag.reason = 'STATIC';
+        flag.variant = 'playwright-override';
+      }
+    }
+
+    // add any flags not present in the original response
+    for (const [key, value] of Object.entries(flags)) {
+      const exists = body.flags.some((f) => f.key === key);
+      if (!exists) {
+        body.flags.push({
+          key,
+          value,
+          reason: 'STATIC',
+          variant: 'playwright-override',
+        });
+      }
+    }
+
+    // Apply artificial latency if specified
+    if (latency > 0) {
+      await delay(latency);
+    }
+
+    await route.fulfill({
+      response,
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('@grafana/plugin-e2e: Failed to intercept OFREP bulk evaluation', error);
+    await route.continue();
+  }
+}
+
+/**
+ * Handles the OFREP single flag evaluation endpoint by returning the override if defined
+ */
+async function handleSingleFlagRoute(
+  route: Route,
+  flags: Record<string, FeatureFlagValue>,
+  latency: number
+): Promise<void> {
+  try {
+    const url = new URL(route.request().url());
+    const flagKey = url.pathname.split('/').pop();
+
+    if (flagKey && flagKey in flags) {
+      // apply artificial latency if specified
+      if (latency > 0) {
+        await delay(latency);
+      }
+
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          key: flagKey,
+          value: flags[flagKey],
+          reason: 'STATIC',
+          variant: 'playwright-override',
+        }),
+        headers: { 'content-type': 'application/json' },
+      });
+      return;
+    }
+
+    await route.continue();
+  } catch (error) {
+    console.error('@grafana/plugin-e2e: Failed to intercept OFREP single flag evaluation', error);
+    await route.continue();
+  }
+}
+
+/**
+ * Sets up route interception for OpenFeature OFREP endpoints
+ */
+export async function setupOpenFeatureRoutes(
+  page: Page,
+  featureToggles: Record<string, boolean>,
+  openFeature: Record<string, FeatureFlagValue>,
+  latency: number,
+  selectors: PlaywrightArgs['selectors']
+): Promise<void> {
+  // merge both options - openFeature takes precedence over featureToggles
+  const mergedFlags: Record<string, FeatureFlagValue> = {
+    ...featureToggles,
+    ...openFeature,
+  };
+
+  console.log('@grafana/plugin-e2e: setting up OpenFeature OFREP interception', {
+    featureToggles,
+    openFeature,
+    mergedFlags,
+    latency,
+  });
+
+  // intercept bulk evaluation endpoint
+  await page.route(selectors.apis.OpenFeature.ofrepBulkPattern, async (route) => {
+    await handleBulkEvaluationRoute(route, mergedFlags, latency);
+  });
+
+  // intercept single flag evaluation endpoint
+  await page.route(selectors.apis.OpenFeature.ofrepSinglePattern, async (route) => {
+    await handleSingleFlagRoute(route, mergedFlags, latency);
+  });
+}

--- a/packages/plugin-e2e/src/fixtures/openFeature.ts
+++ b/packages/plugin-e2e/src/fixtures/openFeature.ts
@@ -125,31 +125,22 @@ async function handleSingleFlagRoute(
  */
 export async function setupOpenFeatureRoutes(
   page: Page,
-  featureToggles: Record<string, boolean>,
   openFeature: Record<string, FeatureFlagValue>,
   latency: number,
   selectors: PlaywrightArgs['selectors']
 ): Promise<void> {
-  // merge both options - openFeature takes precedence over featureToggles
-  const mergedFlags: Record<string, FeatureFlagValue> = {
-    ...featureToggles,
-    ...openFeature,
-  };
-
   console.log('@grafana/plugin-e2e: setting up OpenFeature OFREP interception', {
-    featureToggles,
     openFeature,
-    mergedFlags,
     latency,
   });
 
   // intercept bulk evaluation endpoint
   await page.route(selectors.apis.OpenFeature.ofrepBulkPattern, async (route) => {
-    await handleBulkEvaluationRoute(route, mergedFlags, latency);
+    await handleBulkEvaluationRoute(route, openFeature, latency);
   });
 
   // intercept single flag evaluation endpoint
   await page.route(selectors.apis.OpenFeature.ofrepSinglePattern, async (route) => {
-    await handleSingleFlagRoute(route, mergedFlags, latency);
+    await handleSingleFlagRoute(route, openFeature, latency);
   });
 }

--- a/packages/plugin-e2e/src/fixtures/page.ts
+++ b/packages/plugin-e2e/src/fixtures/page.ts
@@ -1,149 +1,10 @@
-import { Page, Route, TestFixture } from '@playwright/test';
+import { Page, TestFixture } from '@playwright/test';
 
 import { PlaywrightArgs } from '../types';
+import { setupOpenFeatureRoutes } from './openFeature';
 import { overrideGrafanaBootData } from './scripts/overrideGrafanaBootData';
 
 type PageFixture = TestFixture<Page, PlaywrightArgs>;
-
-/**
- * Represents a single flag in the OFREP response
- */
-interface OFREPFlag {
-  key: string;
-  value: boolean;
-  reason: string;
-  variant: string;
-}
-
-/**
- * Represents the OFREP bulk evaluation response body
- */
-interface OFREPBulkResponse {
-  flags: OFREPFlag[];
-}
-
-/**
- * Delays execution for the specified number of milliseconds
- */
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Handles the OFREP bulk evaluation endpoint by merging featureToggles into the response
- */
-async function handleBulkEvaluationRoute(
-  route: Route,
-  featureToggles: Record<string, boolean>,
-  latency: number
-): Promise<void> {
-  try {
-    const response = await route.fetch();
-
-    if (!response.ok()) {
-      await route.fulfill({ response });
-      return;
-    }
-
-    const body: OFREPBulkResponse = await response.json();
-
-    // Override existing flags with featureToggles values
-    for (const flag of body.flags) {
-      if (flag.key in featureToggles) {
-        flag.value = featureToggles[flag.key];
-        flag.reason = 'STATIC';
-        flag.variant = 'playwright-override';
-      }
-    }
-
-    // Add any featureToggles not present in the original response
-    for (const [key, value] of Object.entries(featureToggles)) {
-      const exists = body.flags.some((f) => f.key === key);
-      if (!exists) {
-        body.flags.push({
-          key,
-          value,
-          reason: 'STATIC',
-          variant: 'playwright-override',
-        });
-      }
-    }
-
-    // Apply artificial latency if specified
-    if (latency > 0) {
-      await delay(latency);
-    }
-
-    await route.fulfill({
-      response,
-      body: JSON.stringify(body),
-      headers: { 'content-type': 'application/json' },
-    });
-  } catch (error) {
-    console.error('@grafana/plugin-e2e: Failed to intercept OFREP bulk evaluation', error);
-    await route.continue();
-  }
-}
-
-/**
- * Handles the OFREP single flag evaluation endpoint by returning the override if defined
- */
-async function handleSingleFlagRoute(
-  route: Route,
-  featureToggles: Record<string, boolean>,
-  latency: number
-): Promise<void> {
-  try {
-    const url = new URL(route.request().url());
-    const flagKey = url.pathname.split('/').pop();
-
-    if (flagKey && flagKey in featureToggles) {
-      // Apply artificial latency if specified
-      if (latency > 0) {
-        await delay(latency);
-      }
-
-      await route.fulfill({
-        status: 200,
-        body: JSON.stringify({
-          key: flagKey,
-          value: featureToggles[flagKey],
-          reason: 'STATIC',
-          variant: 'playwright-override',
-        }),
-        headers: { 'content-type': 'application/json' },
-      });
-      return;
-    }
-
-    await route.continue();
-  } catch (error) {
-    console.error('@grafana/plugin-e2e: Failed to intercept OFREP single flag evaluation', error);
-    await route.continue();
-  }
-}
-
-/**
- * Sets up route interception for OpenFeature OFREP endpoints using featureToggles
- */
-async function setupOpenFeatureRoutes(
-  page: Page,
-  featureToggles: Record<string, boolean>,
-  latency: number,
-  selectors: PlaywrightArgs['selectors']
-): Promise<void> {
-  console.log('@grafana/plugin-e2e: setting up OpenFeature OFREP interception', { featureToggles, latency });
-
-  // Intercept bulk evaluation endpoint
-  await page.route(selectors.apis.OpenFeature.ofrepBulkPattern, async (route) => {
-    await handleBulkEvaluationRoute(route, featureToggles, latency);
-  });
-
-  // Intercept single flag evaluation endpoint
-  await page.route(selectors.apis.OpenFeature.ofrepSinglePattern, async (route) => {
-    await handleSingleFlagRoute(route, featureToggles, latency);
-  });
-}
 
 /**
  * This fixture ensures the feature toggles defined in the Playwright config are being used in Grafana frontend.
@@ -161,14 +22,12 @@ async function setupOpenFeatureRoutes(
  *   newly attached frame.
  * The script is evaluated after the document was created but before any of its scripts were run.
  */
-export const page: PageFixture = async (
-  { page, featureToggles, userPreferences, openFeatureLatency, selectors },
-  use
-) => {
+export const page: PageFixture = async ({ page, featureToggles, openFeature, userPreferences, selectors }, use) => {
   const hasFeatureToggles = Object.keys(featureToggles).length > 0;
+  const hasOpenFeature = Object.keys(openFeature.flags).length > 0;
   const hasUserPreferences = Object.keys(userPreferences).length > 0;
 
-  // Set up legacy feature toggle overrides via init script
+  // set up legacy feature toggle overrides via init script
   if (hasFeatureToggles || hasUserPreferences) {
     try {
       await page.addInitScript(overrideGrafanaBootData, { featureToggles, userPreferences });
@@ -177,10 +36,10 @@ export const page: PageFixture = async (
     }
   }
 
-  // Set up OpenFeature OFREP route interception BEFORE navigation
-  // This ensures featureToggles also work for OpenFeature-based flags
-  if (hasFeatureToggles) {
-    await setupOpenFeatureRoutes(page, featureToggles, openFeatureLatency, selectors);
+  // set up OpenFeature OFREP route interception BEFORE navigation
+  // this ensures both featureToggles and openFeature work for OpenFeature-based flags
+  if (hasFeatureToggles || hasOpenFeature) {
+    await setupOpenFeatureRoutes(page, featureToggles, openFeature.flags, openFeature.latency ?? 0, selectors);
   }
 
   await page.goto('/');

--- a/packages/plugin-e2e/src/fixtures/page.ts
+++ b/packages/plugin-e2e/src/fixtures/page.ts
@@ -1,14 +1,164 @@
-import { Page, TestFixture } from '@playwright/test';
+import { Page, Route, TestFixture } from '@playwright/test';
 
 import { PlaywrightArgs } from '../types';
 import { overrideGrafanaBootData } from './scripts/overrideGrafanaBootData';
 
 type PageFixture = TestFixture<Page, PlaywrightArgs>;
 
+/** OFREP bulk evaluation endpoint pattern */
+const OFREP_BULK_PATTERN = '**/apis/features.grafana.app/**/ofrep/v1/evaluate/flags';
+
+/** OFREP single flag evaluation endpoint pattern */
+const OFREP_SINGLE_PATTERN = '**/apis/features.grafana.app/**/ofrep/v1/evaluate/flags/*';
+
+/**
+ * Represents a single flag in the OFREP response
+ */
+interface OFREPFlag {
+  key: string;
+  value: boolean;
+  reason: string;
+  variant: string;
+}
+
+/**
+ * Represents the OFREP bulk evaluation response body
+ */
+interface OFREPBulkResponse {
+  flags: OFREPFlag[];
+}
+
+/**
+ * Delays execution for the specified number of milliseconds
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Handles the OFREP bulk evaluation endpoint by merging featureToggles into the response
+ */
+async function handleBulkEvaluationRoute(
+  route: Route,
+  featureToggles: Record<string, boolean>,
+  latency: number
+): Promise<void> {
+  try {
+    const response = await route.fetch();
+
+    if (!response.ok()) {
+      await route.fulfill({ response });
+      return;
+    }
+
+    const body: OFREPBulkResponse = await response.json();
+
+    // Override existing flags with featureToggles values
+    for (const flag of body.flags) {
+      if (flag.key in featureToggles) {
+        flag.value = featureToggles[flag.key];
+        flag.reason = 'STATIC';
+        flag.variant = 'playwright-override';
+      }
+    }
+
+    // Add any featureToggles not present in the original response
+    for (const [key, value] of Object.entries(featureToggles)) {
+      const exists = body.flags.some((f) => f.key === key);
+      if (!exists) {
+        body.flags.push({
+          key,
+          value,
+          reason: 'STATIC',
+          variant: 'playwright-override',
+        });
+      }
+    }
+
+    // Apply artificial latency if specified
+    if (latency > 0) {
+      await delay(latency);
+    }
+
+    await route.fulfill({
+      response,
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    });
+  } catch (error) {
+    console.error('@grafana/plugin-e2e: Failed to intercept OFREP bulk evaluation', error);
+    await route.continue();
+  }
+}
+
+/**
+ * Handles the OFREP single flag evaluation endpoint by returning the override if defined
+ */
+async function handleSingleFlagRoute(
+  route: Route,
+  featureToggles: Record<string, boolean>,
+  latency: number
+): Promise<void> {
+  try {
+    const url = new URL(route.request().url());
+    const flagKey = url.pathname.split('/').pop();
+
+    if (flagKey && flagKey in featureToggles) {
+      // Apply artificial latency if specified
+      if (latency > 0) {
+        await delay(latency);
+      }
+
+      await route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          key: flagKey,
+          value: featureToggles[flagKey],
+          reason: 'STATIC',
+          variant: 'playwright-override',
+        }),
+        headers: { 'content-type': 'application/json' },
+      });
+      return;
+    }
+
+    await route.continue();
+  } catch (error) {
+    console.error('@grafana/plugin-e2e: Failed to intercept OFREP single flag evaluation', error);
+    await route.continue();
+  }
+}
+
+/**
+ * Sets up route interception for OpenFeature OFREP endpoints using featureToggles
+ */
+async function setupOpenFeatureRoutes(
+  page: Page,
+  featureToggles: Record<string, boolean>,
+  latency: number
+): Promise<void> {
+  console.log('@grafana/plugin-e2e: setting up OpenFeature OFREP interception', { featureToggles, latency });
+
+  // Intercept bulk evaluation endpoint
+  await page.route(OFREP_BULK_PATTERN, async (route) => {
+    await handleBulkEvaluationRoute(route, featureToggles, latency);
+  });
+
+  // Intercept single flag evaluation endpoint
+  await page.route(OFREP_SINGLE_PATTERN, async (route) => {
+    await handleSingleFlagRoute(route, featureToggles, latency);
+  });
+}
+
 /**
  * This fixture ensures the feature toggles defined in the Playwright config are being used in Grafana frontend.
- * If Grafana version >= 10.1.0, feature toggles are read from to the 'grafana.featureToggles' key in the browser's localStorage.
- * Otherwise, feature toggles are added directly to the window.grafanaBootData.settings.featureToggles object.
+ *
+ * Feature toggles are applied in two ways:
+ * 1. Legacy: Added directly to the window.grafanaBootData.settings.featureToggles object via init script
+ * 2. OpenFeature: Intercepted and merged into OFREP API responses
+ *
+ * This dual approach ensures feature toggles work regardless of whether Grafana is using legacy toggles
+ * or the newer OpenFeature system.
  *
  * page.addInitScript adds a script which would be evaluated in one of the following scenarios:
  * - Whenever the page is navigated.
@@ -16,13 +166,23 @@ type PageFixture = TestFixture<Page, PlaywrightArgs>;
  *   newly attached frame.
  * The script is evaluated after the document was created but before any of its scripts were run.
  */
-export const page: PageFixture = async ({ page, featureToggles, userPreferences }, use) => {
-  if (Object.keys(featureToggles).length > 0 || Object.keys(userPreferences).length > 0) {
+export const page: PageFixture = async ({ page, featureToggles, userPreferences, openFeatureLatency }, use) => {
+  const hasFeatureToggles = Object.keys(featureToggles).length > 0;
+  const hasUserPreferences = Object.keys(userPreferences).length > 0;
+
+  // Set up legacy feature toggle overrides via init script
+  if (hasFeatureToggles || hasUserPreferences) {
     try {
       await page.addInitScript(overrideGrafanaBootData, { featureToggles, userPreferences });
     } catch (error) {
       console.error('Failed to set feature toggles', error);
     }
+  }
+
+  // Set up OpenFeature OFREP route interception BEFORE navigation
+  // This ensures featureToggles also work for OpenFeature-based flags
+  if (hasFeatureToggles) {
+    await setupOpenFeatureRoutes(page, featureToggles, openFeatureLatency);
   }
 
   await page.goto('/');

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -1,6 +1,13 @@
 import { test as base, expect as baseExpect, Locator } from '@playwright/test';
 
-import { AlertPageOptions, AlertVariant, ContainTextOptions, PluginFixture, PluginOptions } from './types';
+import {
+  AlertPageOptions,
+  AlertVariant,
+  ContainTextOptions,
+  InternalFixtures,
+  PluginFixture,
+  PluginOptions,
+} from './types';
 import { annotationEditPage } from './fixtures/annotationEditPage';
 import { grafanaAPIClient } from './fixtures/grafanaAPIClient';
 import { createDataSource } from './fixtures/commands/createDataSource';
@@ -20,7 +27,9 @@ import { readProvisionedDataSource } from './fixtures/commands/readProvisionedDa
 import { readProvisionedAlertRule } from './fixtures/commands/readProvisionedAlertRule';
 import { dashboardPage } from './fixtures/dashboardPage';
 import { explorePage } from './fixtures/explorePage';
+import { bootData } from './fixtures/bootData';
 import { grafanaVersion } from './fixtures/grafanaVersion';
+import { namespace } from './fixtures/namespace';
 import { isFeatureToggleEnabled } from './fixtures/isFeatureToggleEnabled';
 import { page } from './fixtures/page';
 import { panelEditPage } from './fixtures/panelEditPage';
@@ -65,9 +74,16 @@ export { AppPage } from './models/pages/AppPage';
 // types
 export * from './types';
 
-export const test = base.extend<PluginFixture, PluginOptions>({
+// first extend with internal fixtures (not exposed to tests)
+const testWithInternal = base.extend<InternalFixtures>({
+  bootData,
+});
+
+// then extend with public fixtures
+export const test = testWithInternal.extend<PluginFixture, PluginOptions>({
   selectors: e2eSelectors,
   grafanaVersion,
+  namespace,
   login,
   grafanaAPIClient,
   createDataSourceConfigPage,
@@ -115,6 +131,10 @@ declare global {
     grafanaBootData: {
       settings: {
         featureToggles: Record<string, boolean>;
+        buildInfo: {
+          version: string;
+        };
+        namespace: string;
       };
     };
   }

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -30,7 +30,7 @@ import { explorePage } from './fixtures/explorePage';
 import { bootData } from './fixtures/bootData';
 import { grafanaVersion } from './fixtures/grafanaVersion';
 import { namespace } from './fixtures/namespace';
-import { isFeatureToggleEnabled } from './fixtures/isFeatureToggleEnabled';
+import { isFeatureToggleEnabled, isLegacyFeatureToggleEnabled } from './fixtures/isFeatureToggleEnabled';
 import { page } from './fixtures/page';
 import { panelEditPage } from './fixtures/panelEditPage';
 import { selectors as e2eSelectors } from './fixtures/selectors';
@@ -74,6 +74,9 @@ export { AppPage } from './models/pages/AppPage';
 // types
 export * from './types';
 
+// helper functions
+export { isLegacyFeatureEnabled, isFeatureEnabled } from './fixtures/isFeatureToggleEnabled';
+
 // first extend with internal fixtures (not exposed to tests)
 const testWithInternal = base.extend<InternalFixtures>({
   bootData,
@@ -100,6 +103,7 @@ export const test = testWithInternal.extend<PluginFixture, PluginOptions>({
   readProvisionedAlertRule,
   readProvisionedDashboard,
   isFeatureToggleEnabled,
+  isLegacyFeatureToggleEnabled,
   createUser,
   gotoDashboardPage,
   gotoPanelEditPage,

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -31,6 +31,7 @@ import { bootData } from './fixtures/bootData';
 import { grafanaVersion } from './fixtures/grafanaVersion';
 import { namespace } from './fixtures/namespace';
 import { isFeatureToggleEnabled, isLegacyFeatureToggleEnabled } from './fixtures/isFeatureToggleEnabled';
+import { getBooleanOpenFeatureFlag } from './fixtures/getOpenFeatureFlag';
 import { page } from './fixtures/page';
 import { panelEditPage } from './fixtures/panelEditPage';
 import { selectors as e2eSelectors } from './fixtures/selectors';
@@ -104,6 +105,7 @@ export const test = testWithInternal.extend<PluginFixture, PluginOptions>({
   readProvisionedDashboard,
   isFeatureToggleEnabled,
   isLegacyFeatureToggleEnabled,
+  getBooleanOpenFeatureFlag,
   createUser,
   gotoDashboardPage,
   gotoPanelEditPage,

--- a/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
@@ -3,7 +3,7 @@ import { AlertRuleArgs, NavigateOptions, PluginTestCtx, RequestOptions } from '.
 import { GrafanaPage } from './GrafanaPage';
 import { AlertRuleQuery } from '../components/AlertRuleQuery';
 import { expect } from '@playwright/test';
-import { isFeatureEnabled } from '../../fixtures/isFeatureToggleEnabled';
+import { isLegacyFeatureEnabled } from '../../fixtures/isFeatureToggleEnabled';
 const QUERY_AND_EXPRESSION_STEP_ID = '2';
 
 export class AlertRuleEditPage extends GrafanaPage {
@@ -42,7 +42,7 @@ export class AlertRuleEditPage extends GrafanaPage {
   }
 
   async isAdvancedModeSupported() {
-    const alertingQueryAndExpressionsStepMode = await isFeatureEnabled(
+    const alertingQueryAndExpressionsStepMode = await isLegacyFeatureEnabled(
       this.ctx.page,
       'alertingQueryAndExpressionsStepMode'
     );

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -5,7 +5,7 @@ import { GrafanaPage } from './GrafanaPage';
 import { PanelEditPage } from './PanelEditPage';
 import { TimeRange } from '../components/TimeRange';
 import { Panel } from '../components/Panel';
-import { isFeatureEnabled } from '../../fixtures/isFeatureToggleEnabled';
+import { isLegacyFeatureEnabled } from '../../fixtures/isFeatureToggleEnabled';
 
 export class DashboardPage extends GrafanaPage {
   dataSourcePicker: any;
@@ -87,7 +87,7 @@ export class DashboardPage extends GrafanaPage {
   async addPanel(): Promise<PanelEditPage> {
     const { components, pages, constants } = this.ctx.selectors;
 
-    const scenesEnabled = await isFeatureEnabled(this.ctx.page, 'dashboardScene');
+    const scenesEnabled = await isLegacyFeatureEnabled(this.ctx.page, 'dashboardScene');
 
     // In scenes powered dashboards, one needs to click the edit button before adding a new panel in already existing dashboards
     if (scenesEnabled && this.dashboard?.uid) {

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -10,6 +10,7 @@ export const DEFAULT_ADMIN_USER: User = {
 export const options: Fixtures<{}, PluginOptions> = {
   userPreferences: [{}, { option: true, scope: 'worker' }],
   featureToggles: [{}, { option: true, scope: 'worker' }],
+  openFeature: [{ flags: {} }, { option: true, scope: 'worker' }],
   provisioningRootDir: [path.join(process.cwd(), 'provisioning'), { option: true, scope: 'worker' }],
   user: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
   grafanaAPICredentials: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -10,7 +10,10 @@ export const DEFAULT_ADMIN_USER: User = {
 export const options: Fixtures<{}, PluginOptions> = {
   userPreferences: [{}, { option: true, scope: 'worker' }],
   featureToggles: [{}, { option: true, scope: 'worker' }],
-  openFeatureLatency: [0, { option: true, scope: 'worker' }],
+  openFeature: [
+    { flags: {}, latency: 0 },
+    { option: true, scope: 'worker' },
+  ],
   provisioningRootDir: [path.join(process.cwd(), 'provisioning'), { option: true, scope: 'worker' }],
   user: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
   grafanaAPICredentials: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -10,7 +10,7 @@ export const DEFAULT_ADMIN_USER: User = {
 export const options: Fixtures<{}, PluginOptions> = {
   userPreferences: [{}, { option: true, scope: 'worker' }],
   featureToggles: [{}, { option: true, scope: 'worker' }],
-  openFeature: [{ flags: {} }, { option: true, scope: 'worker' }],
+  openFeatureLatency: [0, { option: true, scope: 'worker' }],
   provisioningRootDir: [path.join(process.cwd(), 'provisioning'), { option: true, scope: 'worker' }],
   user: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],
   grafanaAPICredentials: [DEFAULT_ADMIN_USER, { option: true, scope: 'worker' }],

--- a/packages/plugin-e2e/src/selectors/versionedAPIs.ts
+++ b/packages/plugin-e2e/src/selectors/versionedAPIs.ts
@@ -55,8 +55,8 @@ export const versionedAPIs = {
         `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}/ofrep/v1/evaluate/flags`,
     },
     ofrepSinglePath: {
-      '12.1.0': (namespace = 'default') =>
-        `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}/ofrep/v1/evaluate/flags`,
+      '12.1.0': (namespace = 'default', flagKey: string) =>
+        `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}/ofrep/v1/evaluate/flags/${flagKey}`,
     },
   },
 } satisfies VersionedSelectorGroup;

--- a/packages/plugin-e2e/src/selectors/versionedAPIs.ts
+++ b/packages/plugin-e2e/src/selectors/versionedAPIs.ts
@@ -43,6 +43,14 @@ export const versionedAPIs = {
       [MIN_GRAFANA_VERSION]: (pluginId: string) => `/api/plugins/${pluginId}/settings`,
     },
   },
+  OpenFeature: {
+    ofrepBulkPattern: {
+      '12.1.0': '**/apis/features.grafana.app/**/ofrep/v1/evaluate/flags',
+    },
+    ofrepSinglePattern: {
+      '12.1.0': '**/apis/features.grafana.app/**/ofrep/v1/evaluate/flags/*',
+    },
+  },
 } satisfies VersionedSelectorGroup;
 
 export type VersionedAPIs = typeof versionedAPIs;

--- a/packages/plugin-e2e/src/selectors/versionedAPIs.ts
+++ b/packages/plugin-e2e/src/selectors/versionedAPIs.ts
@@ -45,10 +45,18 @@ export const versionedAPIs = {
   },
   OpenFeature: {
     ofrepBulkPattern: {
-      '12.1.0': '**/apis/features.grafana.app/**/ofrep/v1/evaluate/flags',
+      '12.1.0': '**/apis/features.grafana.app/**/ofrep/v*/evaluate/flags',
     },
     ofrepSinglePattern: {
-      '12.1.0': '**/apis/features.grafana.app/**/ofrep/v1/evaluate/flags/*',
+      '12.1.0': '**/apis/features.grafana.app/**/ofrep/v*/evaluate/flags/*',
+    },
+    ofrepBulkPath: {
+      '12.1.0': (namespace = 'default') =>
+        `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}/ofrep/v1/evaluate/flags`,
+    },
+    ofrepSinglePath: {
+      '12.1.0': (namespace = 'default') =>
+        `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}/ofrep/v1/evaluate/flags`,
     },
   },
 } satisfies VersionedSelectorGroup;

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -276,6 +276,7 @@ export type PluginFixture = {
   /**
    * Function that checks if a feature toggle is enabled. Only works for frontend feature toggles.
    * Only works for legacy feature toggles (window.grafanaBootData.settings.featureToggles).
+   * @deprecated Use isLegacyFeatureToggleEnabled instead. For OpenFeature flags, use getBooleanOpenFeatureFlag.
    */
   isFeatureToggleEnabled<T = object>(featureToggle: keyof T): Promise<boolean>;
 
@@ -285,6 +286,22 @@ export type PluginFixture = {
    * For OpenFeature flags, use getBooleanOpenFeatureFlag instead.
    */
   isLegacyFeatureToggleEnabled<T = object>(featureToggle: keyof T): Promise<boolean>;
+
+  /**
+   * Gets the value of a boolean OpenFeature flag by calling the OFREP API.
+   * This retrieves the current flag value from Grafana's OpenFeature system.
+   *
+   * Note: This requires Grafana >= 12.1.0 (when OpenFeature OFREP was introduced).
+   *
+   * @example
+   * ```typescript
+   * test('should check OpenFeature flag', async ({ getBooleanOpenFeatureFlag }) => {
+   *   const isEnabled = await getBooleanOpenFeatureFlag('myFeatureFlag');
+   *   expect(isEnabled).toBe(true);
+   * });
+   * ```
+   */
+  getBooleanOpenFeatureFlag(flagKey: string): Promise<boolean>;
 
   /**
    * Client that allows you to use certain endpoints in the Grafana http API.

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -45,8 +45,12 @@ export type PluginOptions = {
   provisioningRootDir: string;
   /**
    * Optionally, you can add or override feature toggles.
-   * The feature toggles you specify here will work for both legacy feature toggles (via `window.grafanaBootData.settings.featureToggles`)
-   * and OpenFeature flags (via OFREP API interception).
+   * This option only supports boolean values and is primarily used for legacy feature toggles
+   * (via `window.grafanaBootData.settings.featureToggles`).
+   *
+   * **For OpenFeature-based flags, use the `openFeature` option instead.**
+   * The `openFeature` option supports multi-type values (boolean, string, number, object)
+   * as required by the OpenFeature specification.
    *
    * If you need a feature toggle to work across the entire stack, you need to enable the feature in the Grafana config.
    * Also see https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/feature-toggles
@@ -77,8 +81,14 @@ export type PluginOptions = {
    * OpenFeature configuration for flag overrides and network simulation.
    * Flags will be intercepted via OFREP API and merged with backend flags.
    *
-   * Use this instead of `featureToggles` for any feature toggle that is using the new
-   * OpenFeature system in Grafana.
+   * **Use this for any feature flags that use the OpenFeature system in Grafana (Grafana 12.1.0+).**
+   * This option supports all OpenFeature value types: boolean, string, number, and object.
+   *
+   * **Important:** This only affects frontend flag evaluation via OFREP API. It does not affect
+   * backend feature flags (GOFF) or server-side behavior. If you need feature flags to work
+   * across the entire stack, you must enable them in the Grafana configuration.
+   *
+   * For legacy boolean-only feature toggles, use the `featureToggles` option instead.
    *
    * @example
    * ```typescript
@@ -264,6 +274,7 @@ export type PluginFixture = {
 
   /**
    * Function that checks if a feature toggle is enabled. Only works for frontend feature toggles.
+   * Only works for legacy feature toggles (window.grafanaBootData.settings.featureToggles).
    */
   isFeatureToggleEnabled<T = object>(featureToggle: keyof T): Promise<boolean>;
 

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -39,25 +39,31 @@ export type PluginOptions = {
   provisioningRootDir: string;
   /**
    * Optionally, you can add or override feature toggles.
-   * The feature toggles you specify here will only work in the frontend. If you need a feature toggle to work across the entire stack, you
-   * need to need to enable the feature in the Grafana config. Also see https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/feature-toggles
+   * The feature toggles you specify here will work for both legacy feature toggles (via `window.grafanaBootData.settings.featureToggles`)
+   * and OpenFeature flags (via OFREP API interception).
    *
-   * To override feature toggles globally in the playwright.config.ts file: 
+   * If you need a feature toggle to work across the entire stack, you need to enable the feature in the Grafana config.
+   * Also see https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/feature-toggles
+   *
+   * @example
+   * ```typescript
+   * // Override feature toggles globally in playwright.config.ts
    * export default defineConfig({
-      use: {
-        featureToggles: {
-          exploreMixedDatasource: true,
-          redshiftAsyncQueryDataSupport: false
-        },
-      },
-    });
-   * 
-   * To override feature toggles for tests in a certain file:
-     test.use({
-      featureToggles: {
-        exploreMixedDatasource: true,
-      },
+   *   use: {
+   *     featureToggles: {
+   *       exploreMixedDatasource: true,
+   *       redshiftAsyncQueryDataSupport: false
+   *     },
+   *   },
    * });
+   *
+   * // Override feature toggles for tests in a specific file
+   * test.use({
+   *   featureToggles: {
+   *     exploreMixedDatasource: true,
+   *   },
+   * });
+   * ```
    */
   featureToggles: Record<string, boolean>;
 
@@ -98,7 +104,21 @@ export type PluginOptions = {
    * If no credentials are provided, the server default admin:admin credentials will be used.
    */
   grafanaAPICredentials: Credentials;
-  openFeature: OpenFeatureOption;
+
+  /**
+   * Artificial latency in milliseconds to add to OpenFeature OFREP API responses.
+   * Useful for testing how the UI behaves with slow network conditions when fetching feature flags.
+   *
+   * @default 0
+   * @example
+   * ```typescript
+   * // Simulate 500ms network latency for OpenFeature flag fetching
+   * test.use({
+   *   openFeatureLatency: 500,
+   * });
+   * ```
+   */
+  openFeatureLatency: number;
 };
 
 export type PluginFixture = {

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -81,14 +81,15 @@ export type PluginOptions = {
    * OpenFeature configuration for flag overrides and network simulation.
    * Flags will be intercepted via OFREP API and merged with backend flags.
    *
-   * **Use this for any feature flags that use the OpenFeature system in Grafana (Grafana 12.1.0+).**
-   * This option supports all OpenFeature value types: boolean, string, number, and object.
+   * Use this for any feature flags that use the OpenFeature system in Grafana.
+   * This option supports all OpenFeature value types: boolean, string, number and object.
    *
-   * **Important:** This only affects frontend flag evaluation via OFREP API. It does not affect
+   * This only affects frontend flag evaluation via OFREP API. It does not affect
    * backend feature flags (GOFF) or server-side behavior. If you need feature flags to work
    * across the entire stack, you must enable them in the Grafana configuration.
    *
-   * For legacy boolean-only feature toggles, use the `featureToggles` option instead.
+   * For legacy feature toggles (window.grafanaBootData.settings.featureToggles),
+   * use the `featureToggles` option instead.
    *
    * @example
    * ```typescript

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -280,6 +280,13 @@ export type PluginFixture = {
   isFeatureToggleEnabled<T = object>(featureToggle: keyof T): Promise<boolean>;
 
   /**
+   * Checks if a legacy feature toggle is enabled.
+   * This only checks window.grafanaBootData.settings.featureToggles (legacy system).
+   * For OpenFeature flags, use getBooleanOpenFeatureFlag instead.
+   */
+  isLegacyFeatureToggleEnabled<T = object>(featureToggle: keyof T): Promise<boolean>;
+
+  /**
    * Client that allows you to use certain endpoints in the Grafana http API.
    *
    The GrafanaAPIClient doesn't call the Grafana HTTP API on behalf of the logged in user -

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -23,6 +23,12 @@ import { VariablePage } from './models/pages/VariablePage';
 import { VersionedAPIs } from './selectors/versionedAPIs';
 import { VersionedConstants } from './selectors/versionedConstants';
 
+/**
+ * Value types supported by OpenFeature flags.
+ * Aligns with the OpenFeature specification.
+ */
+export type FeatureFlagValue = boolean | string | number | object;
+
 export type PluginOptions = {
   /**
    * When using the readProvisioning fixture, files will be read from this directory. If no directory is provided,
@@ -68,6 +74,33 @@ export type PluginOptions = {
   featureToggles: Record<string, boolean>;
 
   /**
+   * OpenFeature configuration for flag overrides and network simulation.
+   * Flags will be intercepted via OFREP API and merged with backend flags.
+   *
+   * Use this instead of `featureToggles` for any feature toggle that is using the new
+   * OpenFeature system in Grafana.
+   *
+   * @example
+   * ```typescript
+   * test.use({
+   *   openFeature: {
+   *     flags: {
+   *       enableNewUI: true,              // boolean
+   *       themeColor: "blue",             // string
+   *       maxRetries: 3,                  // number
+   *       apiConfig: { tier: "premium" }, // object
+   *     },
+   *     latency: 200, // optional: artificial latency in ms for OFREP responses
+   *   },
+   * });
+   * ```
+   */
+  openFeature: {
+    flags: Record<string, FeatureFlagValue>;
+    latency?: number;
+  };
+
+  /**
    * Optionally, you can add or override user preferences for the Grafana user.
    * The user preferences you specify here will be applied to window.grafanaBootData.user.preferences object.
    * Since all tests receive a new, isolated browser context, the user preferences will be reset for each test.
@@ -104,21 +137,6 @@ export type PluginOptions = {
    * If no credentials are provided, the server default admin:admin credentials will be used.
    */
   grafanaAPICredentials: Credentials;
-
-  /**
-   * Artificial latency in milliseconds to add to OpenFeature OFREP API responses.
-   * Useful for testing how the UI behaves with slow network conditions when fetching feature flags.
-   *
-   * @default 0
-   * @example
-   * ```typescript
-   * // Simulate 500ms network latency for OpenFeature flag fetching
-   * test.use({
-   *   openFeatureLatency: 500,
-   * });
-   * ```
-   */
-  openFeatureLatency: number;
 };
 
 export type PluginFixture = {

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -390,8 +390,8 @@ export type InternalFixtures = {
    * @internal
    */
   bootData: {
-    version: string;
-    namespace: string;
+    version: string | undefined;
+    namespace: string | undefined;
   };
 };
 

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -131,6 +131,14 @@ export type PluginFixture = {
   grafanaVersion: string;
 
   /**
+   * The Grafana namespace/tenant id that was detected when the test runner was started.
+   *
+   * The namespace will be picked from window.grafanaBootData.settings.namespace.
+   * Defaults to 'default' if not available.
+   */
+  namespace: string;
+
+  /**
    * The E2E selectors to use for the current version of Grafana.
    * See https://grafana.com/developers/plugin-tools/e2e-test-a-plugin/selecting-elements#grafana-end-to-end-selectors for more information.
    */
@@ -372,10 +380,27 @@ export type PluginTestCtx = { grafanaVersion: string; selectors: E2ESelectorGrou
 >;
 
 /**
+ * Internal fixtures that are not exposed in the test API.
+ * These fixtures can be used by other fixtures but not by tests directly.
+ */
+export type InternalFixtures = {
+  /**
+   * Boot data fetched from Grafana.
+   * Used internally by grafanaVersion and namespace fixtures.
+   * @internal
+   */
+  bootData: {
+    version: string;
+    namespace: string;
+  };
+};
+
+/**
  * Playwright args used when defining fixtures
  */
 export type PlaywrightArgs = PluginFixture &
   PluginOptions &
+  InternalFixtures &
   PlaywrightTestArgs &
   PlaywrightTestOptions &
   PlaywrightWorkerArgs &

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -98,6 +98,7 @@ export type PluginOptions = {
    * If no credentials are provided, the server default admin:admin credentials will be used.
    */
   grafanaAPICredentials: Credentials;
+  openFeature: OpenFeatureOption;
 };
 
 export type PluginFixture = {

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/feature-toggles/queryEditor.tlsEnabled.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/feature-toggles/queryEditor.tlsEnabled.spec.ts
@@ -13,9 +13,9 @@ test.use({
   },
 });
 
-test('should set feature toggles correctly', async ({ isFeatureToggleEnabled }) => {
-  expect(await isFeatureToggleEnabled(TRUTHY_CUSTOM_TOGGLE)).toBeTruthy();
-  expect(await isFeatureToggleEnabled(FALSY_CUSTOM_TOGGLE)).toBeFalsy();
+test('should set feature toggles correctly', async ({ isLegacyFeatureToggleEnabled }) => {
+  expect(await isLegacyFeatureToggleEnabled(TRUTHY_CUSTOM_TOGGLE)).toBeTruthy();
+  expect(await isLegacyFeatureToggleEnabled(FALSY_CUSTOM_TOGGLE)).toBeFalsy();
 });
 
 test('should display TLS enabled field when tlsEnabled feature toggle is set to true', async ({

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/getBooleanOpenFeatureFlag.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/getBooleanOpenFeatureFlag.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '../../../src';
+import { lt } from 'semver';
+
+test.use({
+  openFeature: {
+    flags: {
+      booleanFlagTrue: true,
+      booleanFlagFalse: false,
+      stringFlag: 'enabled',
+      numberFlag: 42,
+    },
+  },
+});
+
+test.describe('getBooleanOpenFeatureFlag fixture', () => {
+  test('should retrieve boolean flag values', async ({ getBooleanOpenFeatureFlag, grafanaVersion }) => {
+    test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+    const flagTrue = await getBooleanOpenFeatureFlag('booleanFlagTrue');
+    const flagFalse = await getBooleanOpenFeatureFlag('booleanFlagFalse');
+
+    expect(flagTrue).toBe(true);
+    expect(flagFalse).toBe(false);
+  });
+
+  test('should throw error for non-boolean flags', async ({ getBooleanOpenFeatureFlag, grafanaVersion }) => {
+    test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+    await expect(getBooleanOpenFeatureFlag('stringFlag')).rejects.toThrow(
+      /Expected boolean value for flag "stringFlag", but got string/
+    );
+    await expect(getBooleanOpenFeatureFlag('numberFlag')).rejects.toThrow(
+      /Expected boolean value for flag "numberFlag", but got number/
+    );
+  });
+
+  test('should throw error for non-existent flags', async ({ getBooleanOpenFeatureFlag, grafanaVersion }) => {
+    test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+    await expect(getBooleanOpenFeatureFlag('nonExistentFlag')).rejects.toThrow(/Failed to fetch OpenFeature flag/);
+  });
+});

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-compatibility.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-compatibility.spec.ts
@@ -1,7 +1,9 @@
 import { expect, test } from '../../../src';
+import { lt } from 'semver';
 
 // No featureToggles specified - should work unchanged
-test('should work without featureToggles option', async ({ page }) => {
+test('should work without featureToggles option', async ({ page, grafanaVersion }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   // Simply verify the page loads without errors
   await page.goto('/');
   await expect(page).toHaveURL(/.*\//);

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-compatibility.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-compatibility.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '../../../src';
 import { lt } from 'semver';
 
-// No featureToggles specified - should work unchanged
+// no featureToggles specified - should work unchanged
 test('should work without featureToggles option', async ({ page, grafanaVersion }) => {
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
-  // Simply verify the page loads without errors
+  // simply verify the page loads without errors
   await page.goto('/');
   await expect(page).toHaveURL(/.*\//);
 });

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-compatibility.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-compatibility.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '../../../src';
+
+// No featureToggles specified - should work unchanged
+test('should work without featureToggles option', async ({ page }) => {
+  // Simply verify the page loads without errors
+  await page.goto('/');
+  await expect(page).toHaveURL(/.*\//);
+});

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
@@ -10,16 +10,16 @@ test.use({
   openFeatureLatency: LATENCY_MS,
 });
 
-test('should apply artificial latency to OFREP responses', async ({ page, grafanaVersion }) => {
+test('should apply artificial latency to OFREP responses', async ({ page, grafanaVersion, selectors, namespace }) => {
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   const startTime = Date.now();
 
   // Make a request to the single flag endpoint which will be intercepted
-  const response = await page.evaluate(async () => {
+  const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/latencyTestFlag`;
+
+  const response = await page.evaluate(async (url) => {
     try {
-      const res = await fetch(
-        '/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/latencyTestFlag'
-      );
+      const res = await fetch(url);
       if (res.ok) {
         return res.json();
       }
@@ -27,7 +27,7 @@ test('should apply artificial latency to OFREP responses', async ({ page, grafan
     } catch {
       return null;
     }
-  });
+  }, flagUrl);
 
   const elapsed = Date.now() - startTime;
 

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../../src';
+import { lt } from 'semver';
 
 const LATENCY_MS = 200;
 
@@ -9,7 +10,8 @@ test.use({
   openFeatureLatency: LATENCY_MS,
 });
 
-test('should apply artificial latency to OFREP responses', async ({ page }) => {
+test('should apply artificial latency to OFREP responses', async ({ page, grafanaVersion }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   const startTime = Date.now();
 
   // Make a request to the single flag endpoint which will be intercepted

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
@@ -4,10 +4,12 @@ import { lt } from 'semver';
 const LATENCY_MS = 200;
 
 test.use({
-  featureToggles: {
-    latencyTestFlag: true,
+  openFeature: {
+    flags: {
+      latencyTestFlag: true,
+    },
+    latency: LATENCY_MS,
   },
-  openFeatureLatency: LATENCY_MS,
 });
 
 test('should apply artificial latency to OFREP responses', async ({ page, grafanaVersion, selectors, namespace }) => {

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '../../../src';
+
+const LATENCY_MS = 200;
+
+test.use({
+  featureToggles: {
+    latencyTestFlag: true,
+  },
+  openFeatureLatency: LATENCY_MS,
+});
+
+test('should apply artificial latency to OFREP responses', async ({ page }) => {
+  const startTime = Date.now();
+
+  // Make a request to the single flag endpoint which will be intercepted
+  const response = await page.evaluate(async () => {
+    try {
+      const res = await fetch(
+        '/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/latencyTestFlag'
+      );
+      if (res.ok) {
+        return res.json();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  });
+
+  const elapsed = Date.now() - startTime;
+
+  if (response) {
+    // Verify the response is correct
+    expect(response.key).toBe('latencyTestFlag');
+    expect(response.value).toBe(true);
+
+    // Verify the latency was applied (allow some margin for timing variance)
+    expect(elapsed).toBeGreaterThanOrEqual(LATENCY_MS - 50);
+  }
+});

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
@@ -16,7 +16,7 @@ test('should apply artificial latency to OFREP responses', async ({ page, grafan
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   const startTime = Date.now();
 
-  // Make a request to the single flag endpoint which will be intercepted
+  // make a request to the single flag endpoint which will be intercepted
   const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/latencyTestFlag`;
 
   const response = await page.evaluate(async (url) => {
@@ -34,11 +34,11 @@ test('should apply artificial latency to OFREP responses', async ({ page, grafan
   const elapsed = Date.now() - startTime;
 
   if (response) {
-    // Verify the response is correct
+    // verify the response is correct
     expect(response.key).toBe('latencyTestFlag');
     expect(response.value).toBe(true);
 
-    // Verify the latency was applied (allow some margin for timing variance)
+    // verify  the latency was applied (allow some margin for timing variance)
     expect(elapsed).toBeGreaterThanOrEqual(LATENCY_MS - 50);
   }
 });

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-latency.spec.ts
@@ -38,7 +38,7 @@ test('should apply artificial latency to OFREP responses', async ({ page, grafan
     expect(response.key).toBe('latencyTestFlag');
     expect(response.value).toBe(true);
 
-    // verify  the latency was applied (allow some margin for timing variance)
+    // verify the latency was applied (allow some margin for timing variance)
     expect(elapsed).toBeGreaterThanOrEqual(LATENCY_MS - 50);
   }
 });

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-multi-type.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-multi-type.spec.ts
@@ -16,7 +16,7 @@ test.use({
       numberFlagZero: 0,
       numberFlagNegative: -1,
       // object flags
-      objectFlag: { tier: 'premium', maxRetries: 3 },
+      objectFlag: { tier: 'free', maxRetries: 3 },
       objectFlagNested: { config: { api: { timeout: 5000, retries: 3 }, features: ['a', 'b'] } },
       objectFlagArray: [1, 2, 3],
     },
@@ -79,7 +79,7 @@ test('should support all OpenFeature value types in bulk evaluation', async ({
 
     // object flags
     const objectFlag = findFlag('objectFlag');
-    expect(objectFlag?.value).toEqual({ tier: 'premium', maxRetries: 3 });
+    expect(objectFlag?.value).toEqual({ tier: 'free', maxRetries: 3 });
 
     const objectNested = findFlag('objectFlagNested');
     expect(objectNested?.value).toEqual({
@@ -208,7 +208,7 @@ test('should support object flag in single evaluation', async ({ page, grafanaVe
 
   if (response) {
     expect(response.key).toBe('objectFlag');
-    expect(response.value).toEqual({ tier: 'premium', maxRetries: 3 });
+    expect(response.value).toEqual({ tier: 'free', maxRetries: 3 });
     expect(response.reason).toBe('STATIC');
   }
 });

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-multi-type.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-multi-type.spec.ts
@@ -1,0 +1,244 @@
+import { expect, test } from '../../../src';
+import { lt } from 'semver';
+
+test.use({
+  openFeature: {
+    flags: {
+      // boolean flags
+      booleanFlagTrue: true,
+      booleanFlagFalse: false,
+      // string flags
+      stringFlag: 'enabled',
+      stringFlagEmpty: '',
+      // number flags
+      numberFlag: 42,
+      numberFlagFloat: 3.14,
+      numberFlagZero: 0,
+      numberFlagNegative: -1,
+      // object flags
+      objectFlag: { tier: 'premium', maxRetries: 3 },
+      objectFlagNested: { config: { api: { timeout: 5000, retries: 3 }, features: ['a', 'b'] } },
+      objectFlagArray: [1, 2, 3],
+    },
+    latency: 0,
+  },
+});
+
+test('should support all OpenFeature value types in bulk evaluation', async ({
+  page,
+  grafanaVersion,
+  selectors,
+  namespace,
+}) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(selectors.apis.OpenFeature.ofrepBulkPath(namespace)) && !response.url().endsWith('/'),
+    { timeout: 5000 }
+  );
+
+  await page.goto('/');
+
+  try {
+    const response = await responsePromise;
+    const body = await response.json();
+
+    // helper to find flag by key
+    const findFlag = (key: string) => body.flags?.find((f: { key: string }) => f.key === key);
+
+    // boolean flags
+    const booleanTrue = findFlag('booleanFlagTrue');
+    expect(booleanTrue?.value).toBe(true);
+    expect(booleanTrue?.reason).toBe('STATIC');
+    expect(booleanTrue?.variant).toBe('playwright-override');
+
+    const booleanFalse = findFlag('booleanFlagFalse');
+    expect(booleanFalse?.value).toBe(false);
+
+    // string flags
+    const stringFlag = findFlag('stringFlag');
+    expect(stringFlag?.value).toBe('enabled');
+    expect(stringFlag?.reason).toBe('STATIC');
+
+    const stringEmpty = findFlag('stringFlagEmpty');
+    expect(stringEmpty?.value).toBe('');
+
+    // number flags
+    const numberFlag = findFlag('numberFlag');
+    expect(numberFlag?.value).toBe(42);
+
+    const numberFloat = findFlag('numberFlagFloat');
+    expect(numberFloat?.value).toBe(3.14);
+
+    const numberZero = findFlag('numberFlagZero');
+    expect(numberZero?.value).toBe(0);
+
+    const numberNegative = findFlag('numberFlagNegative');
+    expect(numberNegative?.value).toBe(-1);
+
+    // object flags
+    const objectFlag = findFlag('objectFlag');
+    expect(objectFlag?.value).toEqual({ tier: 'premium', maxRetries: 3 });
+
+    const objectNested = findFlag('objectFlagNested');
+    expect(objectNested?.value).toEqual({
+      config: { api: { timeout: 5000, retries: 3 }, features: ['a', 'b'] },
+    });
+
+    const objectArray = findFlag('objectFlagArray');
+    expect(objectArray?.value).toEqual([1, 2, 3]);
+  } catch (error) {
+    console.log('OFREP endpoint not called - OpenFeature may not be enabled', error);
+  }
+});
+
+test('should support boolean flag in single evaluation', async ({ page, grafanaVersion, selectors, namespace }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+  const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/booleanFlagTrue`;
+
+  const response = await page.evaluate(async (url) => {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return res.json();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, flagUrl);
+
+  if (response) {
+    expect(response.key).toBe('booleanFlagTrue');
+    expect(response.value).toBe(true);
+    expect(response.reason).toBe('STATIC');
+    expect(response.variant).toBe('playwright-override');
+  }
+});
+
+test('should support string flag in single evaluation', async ({ page, grafanaVersion, selectors, namespace }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+  const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/stringFlag`;
+
+  const response = await page.evaluate(async (url) => {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return res.json();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, flagUrl);
+
+  if (response) {
+    expect(response.key).toBe('stringFlag');
+    expect(response.value).toBe('enabled');
+    expect(response.reason).toBe('STATIC');
+  }
+});
+
+test('should support number flag in single evaluation', async ({ page, grafanaVersion, selectors, namespace }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+  const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/numberFlag`;
+
+  const response = await page.evaluate(async (url) => {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return res.json();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, flagUrl);
+
+  if (response) {
+    expect(response.key).toBe('numberFlag');
+    expect(response.value).toBe(42);
+    expect(response.reason).toBe('STATIC');
+  }
+});
+
+test('should support number zero in single evaluation', async ({ page, grafanaVersion, selectors, namespace }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+  const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/numberFlagZero`;
+
+  const response = await page.evaluate(async (url) => {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return res.json();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, flagUrl);
+
+  if (response) {
+    expect(response.key).toBe('numberFlagZero');
+    expect(response.value).toBe(0);
+  }
+});
+
+test('should support object flag in single evaluation', async ({ page, grafanaVersion, selectors, namespace }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+  const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/objectFlag`;
+
+  const response = await page.evaluate(async (url) => {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return res.json();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, flagUrl);
+
+  if (response) {
+    expect(response.key).toBe('objectFlag');
+    expect(response.value).toEqual({ tier: 'premium', maxRetries: 3 });
+    expect(response.reason).toBe('STATIC');
+  }
+});
+
+test('should support nested object flag in single evaluation', async ({
+  page,
+  grafanaVersion,
+  selectors,
+  namespace,
+}) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+  const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/objectFlagNested`;
+
+  const response = await page.evaluate(async (url) => {
+    try {
+      const res = await fetch(url);
+      if (res.ok) {
+        return res.json();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }, flagUrl);
+
+  if (response) {
+    expect(response.key).toBe('objectFlagNested');
+    expect(response.value).toEqual({
+      config: { api: { timeout: 5000, retries: 3 }, features: ['a', 'b'] },
+    });
+  }
+});

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
@@ -7,14 +7,14 @@ test.use({
   },
 });
 
-test('should intercept single flag evaluation endpoint', async ({ page, grafanaVersion }) => {
+test('should intercept single flag evaluation endpoint', async ({ page, grafanaVersion, selectors, namespace }) => {
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   // Make a request to the single flag endpoint which will be intercepted
-  const singleFlagResponse = await page.evaluate(async () => {
+  const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/singleTestFlag`;
+
+  const singleFlagResponse = await page.evaluate(async (url) => {
     try {
-      const response = await fetch(
-        '/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/singleTestFlag'
-      );
+      const response = await fetch(url);
       if (response.ok) {
         return response.json();
       }
@@ -22,7 +22,7 @@ test('should intercept single flag evaluation endpoint', async ({ page, grafanaV
     } catch {
       return null;
     }
-  });
+  }, flagUrl);
 
   if (singleFlagResponse) {
     expect(singleFlagResponse.key).toBe('singleTestFlag');

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '../../../src';
+
+test.use({
+  featureToggles: {
+    singleTestFlag: true,
+  },
+});
+
+test('should intercept single flag evaluation endpoint', async ({ page }) => {
+  // Make a request to the single flag endpoint which will be intercepted
+  const singleFlagResponse = await page.evaluate(async () => {
+    try {
+      const response = await fetch(
+        '/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/singleTestFlag'
+      );
+      if (response.ok) {
+        return response.json();
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  });
+
+  if (singleFlagResponse) {
+    expect(singleFlagResponse.key).toBe('singleTestFlag');
+    expect(singleFlagResponse.value).toBe(true);
+    expect(singleFlagResponse.reason).toBe('STATIC');
+    expect(singleFlagResponse.variant).toBe('playwright-override');
+  }
+});

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
@@ -2,8 +2,11 @@ import { expect, test } from '../../../src';
 import { lt } from 'semver';
 
 test.use({
-  featureToggles: {
-    singleTestFlag: true,
+  openFeature: {
+    flags: {
+      singleTestFlag: true,
+    },
+    latency: 0,
   },
 });
 

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../../src';
+import { lt } from 'semver';
 
 test.use({
   featureToggles: {
@@ -6,7 +7,8 @@ test.use({
   },
 });
 
-test('should intercept single flag evaluation endpoint', async ({ page }) => {
+test('should intercept single flag evaluation endpoint', async ({ page, grafanaVersion }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   // Make a request to the single flag endpoint which will be intercepted
   const singleFlagResponse = await page.evaluate(async () => {
     try {

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature-single.spec.ts
@@ -9,7 +9,7 @@ test.use({
 
 test('should intercept single flag evaluation endpoint', async ({ page, grafanaVersion, selectors, namespace }) => {
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
-  // Make a request to the single flag endpoint which will be intercepted
+  // make a request to the single flag endpoint which will be intercepted
   const flagUrl = `${selectors.apis.OpenFeature.ofrepSinglePath(namespace)}/singleTestFlag`;
 
   const singleFlagResponse = await page.evaluate(async (url) => {

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
@@ -15,22 +15,22 @@ test('should intercept OFREP bulk evaluation and override flags via featureToggl
   namespace,
 }) => {
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
-  // Set up a listener to capture the OFREP response
+  // set up a listener to capture the OFREP response
   const responsePromise = page.waitForResponse(
     (response) =>
       response.url().includes(selectors.apis.OpenFeature.ofrepBulkPath(namespace)) && !response.url().endsWith('/'),
     { timeout: 5000 }
   );
 
-  // Trigger a navigation that would cause OpenFeature to fetch flags
+  // trigger a navigation that would cause OpenFeature to fetch flags
   await page.goto('/');
 
-  // Wait for the OFREP response (may not happen if OpenFeature is not enabled in the Grafana instance)
+  // wait for the OFREP response (may not happen if OpenFeature is not enabled in the Grafana instance)
   try {
     const response = await responsePromise;
     const body = await response.json();
 
-    // Verify the response contains our overridden flags from featureToggles
+    // response should contains our overridden flags from featureToggles
     const testFlagTrue = body.flags?.find((f: { key: string }) => f.key === 'testFlagTrue');
     const testFlagFalse = body.flags?.find((f: { key: string }) => f.key === 'testFlagFalse');
 
@@ -46,8 +46,6 @@ test('should intercept OFREP bulk evaluation and override flags via featureToggl
       expect(testFlagFalse.variant).toBe('playwright-override');
     }
   } catch {
-    // OpenFeature may not be enabled in the test Grafana instance
-    // This is expected in some environments
     console.log('OFREP endpoint not called - OpenFeature may not be enabled');
   }
 });
@@ -59,36 +57,32 @@ test('should merge custom featureToggles with backend default flags', async ({
   namespace,
 }) => {
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
-  // Set up a listener to capture the OFREP response
   const responsePromise = page.waitForResponse(
     (response) =>
       response.url().includes(selectors.apis.OpenFeature.ofrepBulkPath(namespace)) && !response.url().endsWith('/'),
     { timeout: 5000 }
   );
 
-  // Trigger a navigation that would cause OpenFeature to fetch flags
-  await page.goto('/');
-
-  // Wait for the OFREP response
+  // wait for the OFREP response
   try {
     const response = await responsePromise;
     const body = await response.json();
 
-    // Define how many custom flags we set
+    // define how many custom flags we set
     const customFlagCount = 2; // testFlagTrue and testFlagFalse
 
-    // Verify we have more flags than just our custom ones (backend flags should be present)
+    // verify we have more flags than just our custom ones (backend flags should be present)
     expect(body.flags.length).toBeGreaterThan(customFlagCount);
 
-    // Verify our custom flags are present and overridden
+    // custom flags are present and overridden
     const customFlags = body.flags.filter((f: { variant: string }) => f.variant === 'playwright-override');
     expect(customFlags.length).toBeGreaterThanOrEqual(customFlagCount);
 
-    // Verify backend flags (without playwright-override variant) are still present
+    // backend flags (without playwright-override variant) are still present
     const backendFlags = body.flags.filter((f: { variant: string }) => f.variant !== 'playwright-override');
     expect(backendFlags.length).toBeGreaterThan(0);
 
-    // Verify our specific custom flags have the correct values
+    // our specific custom flags have the correct values
     const testFlagTrue = body.flags.find((f: { key: string }) => f.key === 'testFlagTrue');
     const testFlagFalse = body.flags.find((f: { key: string }) => f.key === 'testFlagFalse');
 
@@ -98,7 +92,6 @@ test('should merge custom featureToggles with backend default flags', async ({
     expect(testFlagFalse?.value).toBe(false);
     expect(testFlagFalse?.variant).toBe('playwright-override');
   } catch {
-    // OpenFeature may not be enabled in the test Grafana instance
     console.log('OFREP endpoint not called - OpenFeature may not be enabled');
   }
 });

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
@@ -97,3 +97,17 @@ test('should merge custom openFeature flags with backend default flags', async (
     console.log('OFREP endpoint not called - OpenFeature may not be enabled');
   }
 });
+
+test('should retrieve flag values using getBooleanOpenFeatureFlag fixture', async ({
+  getBooleanOpenFeatureFlag,
+  grafanaVersion,
+}) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
+
+  // should retrieve our overridden flags
+  const testFlagTrue = await getBooleanOpenFeatureFlag('testFlagTrue');
+  const testFlagFalse = await getBooleanOpenFeatureFlag('testFlagFalse');
+
+  expect(testFlagTrue).toBe(true);
+  expect(testFlagFalse).toBe(false);
+});

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
@@ -30,7 +30,7 @@ test('should intercept OFREP bulk evaluation and override flags via featureToggl
     const response = await responsePromise;
     const body = await response.json();
 
-    // response should contains our overridden flags from featureToggles
+    // response should contain our overridden flags from featureToggles
     const testFlagTrue = body.flags?.find((f: { key: string }) => f.key === 'testFlagTrue');
     const testFlagFalse = body.flags?.find((f: { key: string }) => f.key === 'testFlagFalse');
 

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
@@ -2,13 +2,15 @@ import { expect, test } from '../../../src';
 import { lt } from 'semver';
 
 test.use({
-  featureToggles: {
-    testFlagTrue: true,
-    testFlagFalse: false,
+  openFeature: {
+    flags: {
+      testFlagTrue: true,
+      testFlagFalse: false,
+    },
   },
 });
 
-test('should intercept OFREP bulk evaluation and override flags via featureToggles', async ({
+test('should intercept OFREP bulk evaluation and override flags via openFeature', async ({
   page,
   grafanaVersion,
   selectors,
@@ -30,7 +32,7 @@ test('should intercept OFREP bulk evaluation and override flags via featureToggl
     const response = await responsePromise;
     const body = await response.json();
 
-    // response should contain our overridden flags from featureToggles
+    // response should contain our overridden flags from openFeature
     const testFlagTrue = body.flags?.find((f: { key: string }) => f.key === 'testFlagTrue');
     const testFlagFalse = body.flags?.find((f: { key: string }) => f.key === 'testFlagFalse');
 
@@ -50,7 +52,7 @@ test('should intercept OFREP bulk evaluation and override flags via featureToggl
   }
 });
 
-test('should merge custom featureToggles with backend default flags', async ({
+test('should merge custom openFeature flags with backend default flags', async ({
   page,
   grafanaVersion,
   selectors,

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from '../../../src';
+
+test.describe('OpenFeature OFREP interception', () => {
+  test.use({
+    featureToggles: {
+      testFlagTrue: true,
+      testFlagFalse: false,
+    },
+  });
+
+  test('should intercept OFREP bulk evaluation and override flags via featureToggles', async ({ page }) => {
+    // Set up a listener to capture the OFREP response
+    const responsePromise = page.waitForResponse(
+      (response) => response.url().includes('/ofrep/v1/evaluate/flags') && !response.url().endsWith('/'),
+      { timeout: 5000 }
+    );
+
+    // Trigger a navigation that would cause OpenFeature to fetch flags
+    await page.goto('/');
+
+    // Wait for the OFREP response (may not happen if OpenFeature is not enabled in the Grafana instance)
+    try {
+      const response = await responsePromise;
+      const body = await response.json();
+
+      // Verify the response contains our overridden flags from featureToggles
+      const testFlagTrue = body.flags?.find((f: { key: string }) => f.key === 'testFlagTrue');
+      const testFlagFalse = body.flags?.find((f: { key: string }) => f.key === 'testFlagFalse');
+
+      if (testFlagTrue) {
+        expect(testFlagTrue.value).toBe(true);
+        expect(testFlagTrue.reason).toBe('STATIC');
+        expect(testFlagTrue.variant).toBe('playwright-override');
+      }
+
+      if (testFlagFalse) {
+        expect(testFlagFalse.value).toBe(false);
+        expect(testFlagFalse.reason).toBe('STATIC');
+        expect(testFlagFalse.variant).toBe('playwright-override');
+      }
+    } catch {
+      // OpenFeature may not be enabled in the test Grafana instance
+      // This is expected in some environments
+      console.log('OFREP endpoint not called - OpenFeature may not be enabled');
+    }
+  });
+});
+
+test.describe('OpenFeature single flag endpoint', () => {
+  test.use({
+    featureToggles: {
+      singleTestFlag: true,
+    },
+  });
+
+  test('should intercept single flag evaluation endpoint', async ({ page }) => {
+    // Make a request to the single flag endpoint which will be intercepted
+    const singleFlagResponse = await page.evaluate(async () => {
+      try {
+        const response = await fetch('/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/singleTestFlag');
+        if (response.ok) {
+          return response.json();
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    });
+
+    if (singleFlagResponse) {
+      expect(singleFlagResponse.key).toBe('singleTestFlag');
+      expect(singleFlagResponse.value).toBe(true);
+      expect(singleFlagResponse.reason).toBe('STATIC');
+      expect(singleFlagResponse.variant).toBe('playwright-override');
+    }
+  });
+});
+
+test.describe('OpenFeature with latency', () => {
+  const LATENCY_MS = 200;
+
+  test.use({
+    featureToggles: {
+      latencyTestFlag: true,
+    },
+    openFeatureLatency: LATENCY_MS,
+  });
+
+  test('should apply artificial latency to OFREP responses', async ({ page }) => {
+    const startTime = Date.now();
+
+    // Make a request to the single flag endpoint which will be intercepted
+    const response = await page.evaluate(async () => {
+      try {
+        const res = await fetch('/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/latencyTestFlag');
+        if (res.ok) {
+          return res.json();
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    });
+
+    const elapsed = Date.now() - startTime;
+
+    if (response) {
+      // Verify the response is correct
+      expect(response.key).toBe('latencyTestFlag');
+      expect(response.value).toBe(true);
+
+      // Verify the latency was applied (allow some margin for timing variance)
+      expect(elapsed).toBeGreaterThanOrEqual(LATENCY_MS - 50);
+    }
+  });
+});
+
+test.describe('OpenFeature - backward compatibility', () => {
+  // No featureToggles specified - should work unchanged
+  test('should work without featureToggles option', async ({ page }) => {
+    // Simply verify the page loads without errors
+    await page.goto('/');
+    await expect(page).toHaveURL(/.*\//);
+  });
+});

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '../../../src';
+import { lt } from 'semver';
 
 test.use({
   featureToggles: {
@@ -7,7 +8,11 @@ test.use({
   },
 });
 
-test('should intercept OFREP bulk evaluation and override flags via featureToggles', async ({ page }) => {
+test('should intercept OFREP bulk evaluation and override flags via featureToggles', async ({
+  page,
+  grafanaVersion,
+}) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   // Set up a listener to capture the OFREP response
   const responsePromise = page.waitForResponse(
     (response) => response.url().includes('/ofrep/v1/evaluate/flags') && !response.url().endsWith('/'),
@@ -44,7 +49,8 @@ test('should intercept OFREP bulk evaluation and override flags via featureToggl
   }
 });
 
-test('should merge custom featureToggles with backend default flags', async ({ page }) => {
+test('should merge custom featureToggles with backend default flags', async ({ page, grafanaVersion }) => {
+  test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   // Set up a listener to capture the OFREP response
   const responsePromise = page.waitForResponse(
     (response) => response.url().includes('/ofrep/v1/evaluate/flags') && !response.url().endsWith('/'),

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
@@ -1,125 +1,89 @@
 import { expect, test } from '../../../src';
 
-test.describe('OpenFeature OFREP interception', () => {
-  test.use({
-    featureToggles: {
-      testFlagTrue: true,
-      testFlagFalse: false,
-    },
-  });
-
-  test('should intercept OFREP bulk evaluation and override flags via featureToggles', async ({ page }) => {
-    // Set up a listener to capture the OFREP response
-    const responsePromise = page.waitForResponse(
-      (response) => response.url().includes('/ofrep/v1/evaluate/flags') && !response.url().endsWith('/'),
-      { timeout: 5000 }
-    );
-
-    // Trigger a navigation that would cause OpenFeature to fetch flags
-    await page.goto('/');
-
-    // Wait for the OFREP response (may not happen if OpenFeature is not enabled in the Grafana instance)
-    try {
-      const response = await responsePromise;
-      const body = await response.json();
-
-      // Verify the response contains our overridden flags from featureToggles
-      const testFlagTrue = body.flags?.find((f: { key: string }) => f.key === 'testFlagTrue');
-      const testFlagFalse = body.flags?.find((f: { key: string }) => f.key === 'testFlagFalse');
-
-      if (testFlagTrue) {
-        expect(testFlagTrue.value).toBe(true);
-        expect(testFlagTrue.reason).toBe('STATIC');
-        expect(testFlagTrue.variant).toBe('playwright-override');
-      }
-
-      if (testFlagFalse) {
-        expect(testFlagFalse.value).toBe(false);
-        expect(testFlagFalse.reason).toBe('STATIC');
-        expect(testFlagFalse.variant).toBe('playwright-override');
-      }
-    } catch {
-      // OpenFeature may not be enabled in the test Grafana instance
-      // This is expected in some environments
-      console.log('OFREP endpoint not called - OpenFeature may not be enabled');
-    }
-  });
+test.use({
+  featureToggles: {
+    testFlagTrue: true,
+    testFlagFalse: false,
+  },
 });
 
-test.describe('OpenFeature single flag endpoint', () => {
-  test.use({
-    featureToggles: {
-      singleTestFlag: true,
-    },
-  });
+test('should intercept OFREP bulk evaluation and override flags via featureToggles', async ({ page }) => {
+  // Set up a listener to capture the OFREP response
+  const responsePromise = page.waitForResponse(
+    (response) => response.url().includes('/ofrep/v1/evaluate/flags') && !response.url().endsWith('/'),
+    { timeout: 5000 }
+  );
 
-  test('should intercept single flag evaluation endpoint', async ({ page }) => {
-    // Make a request to the single flag endpoint which will be intercepted
-    const singleFlagResponse = await page.evaluate(async () => {
-      try {
-        const response = await fetch('/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/singleTestFlag');
-        if (response.ok) {
-          return response.json();
-        }
-        return null;
-      } catch {
-        return null;
-      }
-    });
+  // Trigger a navigation that would cause OpenFeature to fetch flags
+  await page.goto('/');
 
-    if (singleFlagResponse) {
-      expect(singleFlagResponse.key).toBe('singleTestFlag');
-      expect(singleFlagResponse.value).toBe(true);
-      expect(singleFlagResponse.reason).toBe('STATIC');
-      expect(singleFlagResponse.variant).toBe('playwright-override');
+  // Wait for the OFREP response (may not happen if OpenFeature is not enabled in the Grafana instance)
+  try {
+    const response = await responsePromise;
+    const body = await response.json();
+
+    // Verify the response contains our overridden flags from featureToggles
+    const testFlagTrue = body.flags?.find((f: { key: string }) => f.key === 'testFlagTrue');
+    const testFlagFalse = body.flags?.find((f: { key: string }) => f.key === 'testFlagFalse');
+
+    if (testFlagTrue) {
+      expect(testFlagTrue.value).toBe(true);
+      expect(testFlagTrue.reason).toBe('STATIC');
+      expect(testFlagTrue.variant).toBe('playwright-override');
     }
-  });
+
+    if (testFlagFalse) {
+      expect(testFlagFalse.value).toBe(false);
+      expect(testFlagFalse.reason).toBe('STATIC');
+      expect(testFlagFalse.variant).toBe('playwright-override');
+    }
+  } catch {
+    // OpenFeature may not be enabled in the test Grafana instance
+    // This is expected in some environments
+    console.log('OFREP endpoint not called - OpenFeature may not be enabled');
+  }
 });
 
-test.describe('OpenFeature with latency', () => {
-  const LATENCY_MS = 200;
+test('should merge custom featureToggles with backend default flags', async ({ page }) => {
+  // Set up a listener to capture the OFREP response
+  const responsePromise = page.waitForResponse(
+    (response) => response.url().includes('/ofrep/v1/evaluate/flags') && !response.url().endsWith('/'),
+    { timeout: 5000 }
+  );
 
-  test.use({
-    featureToggles: {
-      latencyTestFlag: true,
-    },
-    openFeatureLatency: LATENCY_MS,
-  });
+  // Trigger a navigation that would cause OpenFeature to fetch flags
+  await page.goto('/');
 
-  test('should apply artificial latency to OFREP responses', async ({ page }) => {
-    const startTime = Date.now();
+  // Wait for the OFREP response
+  try {
+    const response = await responsePromise;
+    const body = await response.json();
 
-    // Make a request to the single flag endpoint which will be intercepted
-    const response = await page.evaluate(async () => {
-      try {
-        const res = await fetch('/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/latencyTestFlag');
-        if (res.ok) {
-          return res.json();
-        }
-        return null;
-      } catch {
-        return null;
-      }
-    });
+    // Define how many custom flags we set
+    const customFlagCount = 2; // testFlagTrue and testFlagFalse
 
-    const elapsed = Date.now() - startTime;
+    // Verify we have more flags than just our custom ones (backend flags should be present)
+    expect(body.flags.length).toBeGreaterThan(customFlagCount);
 
-    if (response) {
-      // Verify the response is correct
-      expect(response.key).toBe('latencyTestFlag');
-      expect(response.value).toBe(true);
+    // Verify our custom flags are present and overridden
+    const customFlags = body.flags.filter((f: { variant: string }) => f.variant === 'playwright-override');
+    expect(customFlags.length).toBeGreaterThanOrEqual(customFlagCount);
 
-      // Verify the latency was applied (allow some margin for timing variance)
-      expect(elapsed).toBeGreaterThanOrEqual(LATENCY_MS - 50);
-    }
-  });
-});
+    // Verify backend flags (without playwright-override variant) are still present
+    const backendFlags = body.flags.filter((f: { variant: string }) => f.variant !== 'playwright-override');
+    expect(backendFlags.length).toBeGreaterThan(0);
 
-test.describe('OpenFeature - backward compatibility', () => {
-  // No featureToggles specified - should work unchanged
-  test('should work without featureToggles option', async ({ page }) => {
-    // Simply verify the page loads without errors
-    await page.goto('/');
-    await expect(page).toHaveURL(/.*\//);
-  });
+    // Verify our specific custom flags have the correct values
+    const testFlagTrue = body.flags.find((f: { key: string }) => f.key === 'testFlagTrue');
+    const testFlagFalse = body.flags.find((f: { key: string }) => f.key === 'testFlagFalse');
+
+    expect(testFlagTrue?.value).toBe(true);
+    expect(testFlagTrue?.variant).toBe('playwright-override');
+
+    expect(testFlagFalse?.value).toBe(false);
+    expect(testFlagFalse?.variant).toBe('playwright-override');
+  } catch {
+    // OpenFeature may not be enabled in the test Grafana instance
+    console.log('OFREP endpoint not called - OpenFeature may not be enabled');
+  }
 });

--- a/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/openfeature/openFeature.spec.ts
@@ -11,11 +11,14 @@ test.use({
 test('should intercept OFREP bulk evaluation and override flags via featureToggles', async ({
   page,
   grafanaVersion,
+  selectors,
+  namespace,
 }) => {
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   // Set up a listener to capture the OFREP response
   const responsePromise = page.waitForResponse(
-    (response) => response.url().includes('/ofrep/v1/evaluate/flags') && !response.url().endsWith('/'),
+    (response) =>
+      response.url().includes(selectors.apis.OpenFeature.ofrepBulkPath(namespace)) && !response.url().endsWith('/'),
     { timeout: 5000 }
   );
 
@@ -49,11 +52,17 @@ test('should intercept OFREP bulk evaluation and override flags via featureToggl
   }
 });
 
-test('should merge custom featureToggles with backend default flags', async ({ page, grafanaVersion }) => {
+test('should merge custom featureToggles with backend default flags', async ({
+  page,
+  grafanaVersion,
+  selectors,
+  namespace,
+}) => {
   test.skip(lt(grafanaVersion, '12.1.0'), 'OpenFeature OFREP was introduced in Grafana 12.1.0');
   // Set up a listener to capture the OFREP response
   const responsePromise = page.waitForResponse(
-    (response) => response.url().includes('/ofrep/v1/evaluate/flags') && !response.url().endsWith('/'),
+    (response) =>
+      response.url().includes(selectors.apis.OpenFeature.ofrepBulkPath(namespace)) && !response.url().endsWith('/'),
     { timeout: 5000 }
   );
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of its move toward multi-tenancy, Grafana’s existing feature toggle mechanism will be superseded by OpenFeature. This PR adds support for overriding OpenFeature (OFREP) flags in `@grafana/plugin-e2e`, enabling Grafana and plugin developers to reliably test plugins that depend on OpenFeature-based feature flags.

Each Playwright test runs in a separate browser context, allowing different OpenFeature flag states to be tested within a single end-to-end run without restarting the Grafana backend. 

Fore more details, please refer to the [design doc](https://docs.google.com/document/d/1rvWMSRGn5-B5lDfs8_HjQm2cZZTZystYkO6TpN9zd6A/edit?usp=sharing) _OpenFeature support in plugin-e2e Playwright tests_. 

OpenFeature flags can be defined globally and selectively overridden at the project level or even per test file.
                                                                                       
**Example usage**:                                                                       
  ```typescript                                                                        
  test.use({                                                                           
    openFeature: {                                                                     
      flags: {                                                                         
        enableNewUI: true,              // boolean                                     
        themeColor: "blue",             // string                                      
        maxRetries: 3,                  // number                                      
        apiConfig: { tier: "premium" }, // object                                      
      },                                                                               
      latency: 200, // optional: simulate network latency                              
    },                                                                                 
  });     

// if needed, one can retrieve flag values in tests
test('example', async ({ getBooleanOpenFeatureFlag }) => {
    const isEnabled = await getBooleanOpenFeatureFlag('enableNewUI');
    expect(isEnabled).toBe(true);
});

// legacy feature toggles (explicitly named)
test('legacy example', async ({ isLegacyFeatureToggleEnabled }) => {
    const isEnabled = await isLegacyFeatureToggleEnabled('oldToggle');
    expect(isEnabled).toBe(true);
});                 
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/plugin-tools/issues/2384

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.2.0-canary.2408.21361640222.0
  # or 
  yarn add @grafana/plugin-e2e@3.2.0-canary.2408.21361640222.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
