### PR TITLE
ts-grapher: small utility package for graphing typescript dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ packed-artifacts/
 # Don't commit local claude settings
 .claude/settings.local.json
 .claude/hooks
+
+# @grafana/ts-grapher
+out

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "packages/eslint-plugin-plugins",
         "packages/tsconfig",
         "packages/react-detect",
+        "packages/ts-grapher",
         "libs/*"
       ],
       "devDependencies": {
@@ -6194,6 +6195,10 @@
       "resolved": "packages/sign-plugin",
       "link": true
     },
+    "node_modules/@grafana/ts-grapher": {
+      "resolved": "packages/ts-grapher",
+      "link": true
+    },
     "node_modules/@grafana/tsconfig": {
       "resolved": "packages/tsconfig",
       "link": true
@@ -11559,6 +11564,32 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.28.1.tgz",
+      "integrity": "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^10.0.1",
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "dev": true,
@@ -15210,6 +15241,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
     },
     "node_modules/collapse-white-space": {
       "version": "2.1.0",
@@ -20196,7 +20233,6 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
       "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.1.1",
@@ -20228,7 +20264,6 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
       "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
@@ -30570,6 +30605,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "5.0.0",
       "license": "MIT",
@@ -36762,6 +36803,16 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/ts-morph": {
+      "version": "27.0.2",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-27.0.2.tgz",
+      "integrity": "sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.28.1",
+        "code-block-writer": "^13.0.3"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "dev": true,
@@ -40012,6 +40063,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/ts-grapher": {
+      "name": "@grafana/ts-grapher",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "glob": "^13.0.0",
+        "minimist": "^1.2.8",
+        "ts-morph": "^27.0.2"
+      },
+      "bin": {
+        "ts-grapher": "dist/bin/run.js"
+      },
+      "devDependencies": {
+        "@types/minimist": "^1.2.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/tsconfig": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "packages/eslint-plugin-plugins",
     "packages/tsconfig",
     "packages/react-detect",
+    "packages/ts-grapher",
     "libs/*"
   ],
   "lint-staged": {

--- a/packages/ts-grapher/LICENSE
+++ b/packages/ts-grapher/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Grafana Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/ts-grapher/README.md
+++ b/packages/ts-grapher/README.md
@@ -1,0 +1,74 @@
+# @grafana/ts-grapher
+
+A small utility for analyzing TypeScript dependency relationships. It searches for a given symbol and outputs its dependencies in [DOT](https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29) format.
+
+This can be useful when exploring complex dependency trees or when planning refactors.
+
+> [!WARNING]
+> Currently only tested on macOS
+
+## Installation
+
+```bash
+npm i
+```
+
+## Usage
+
+The tool expects three arguments:
+
+1. The name of the function, variable, or class to search for
+2. The path to the file where the symbol is declared
+3. The path to the root TypeScript `tsconfig.json` file
+
+```bash
+npx @grafana/ts-grapher getExtensionPointPluginDependencies /Users/hugoh/git/grafana/public/app/features/plugins/extensions/utils.tsx /Users/hugoh/git/grafana/tsconfig.json
+```
+
+### Options
+
+#### --level
+
+Controls how many levels of dependencies are traversed.
+
+- Default: 1
+- Higher values will increase processing time
+
+```bash
+npx @grafana/ts-grapher getExtensionPointPluginDependencies /Users/hugoh/git/grafana/public/app/features/plugins/extensions/utils.tsx /Users/hugoh/git/grafana/tsconfig.json --level=3
+```
+
+#### --svg
+
+Generates an SVG visualization in addition to the .gv file.
+Requires [Graphviz](https://graphviz.org/download/) to be installed and available in your PATH.
+
+```bash
+npx @grafana/ts-grapher getExtensionPointPluginDependencies /Users/hugoh/git/grafana/public/app/features/plugins/extensions/utils.tsx /Users/hugoh/git/grafana/tsconfig.json --svg
+```
+
+#### --debug
+
+Generates more log output
+
+```bash
+npx @grafana/ts-grapher getExtensionPointPluginDependencies /Users/hugoh/git/grafana/public/app/features/plugins/extensions/utils.tsx /Users/hugoh/git/grafana/tsconfig.json --debug
+```
+
+## Output
+
+`.gv` files are written to the out directory
+
+When `--svg` is enabled, a corresponding `.svg` file is generated.
+
+You can also output to many other [formats](https://graphviz.org/docs/outputs/) by calling `dot` manually like
+
+```bash
+dot -Tpng getExtensionPointPluginDependencies.gv > getExtensionPointPluginDependencies.png
+```
+
+Read more about output formats [here](https://graphviz.org/docs/outputs/).
+
+## License
+
+Apache License v2

--- a/packages/ts-grapher/package.json
+++ b/packages/ts-grapher/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@grafana/ts-grapher",
+  "description": "A utility for analyzing TypeScript dependency relationships.",
+  "version": "0.0.1",
+  "repository": {
+    "directory": "packages/ts-grapher",
+    "url": "git+https://github.com/grafana/plugin-tools.git"
+  },
+  "author": "Grafana",
+  "license": "Apache-2.0",
+  "bin": "./dist/bin/run.js",
+  "type": "module",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "clean": "rm -rf ./dist",
+    "build": "rollup -c ../../rollup.config.ts --configPlugin esbuild",
+    "dev": "npm run build -- -w",
+    "lint": "eslint --cache ./src",
+    "lint:fix": "npm run lint -- --fix",
+    "lint:package": "publint",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "chalk": "^5.6.2",
+    "glob": "^13.0.0",
+    "minimist": "^1.2.8",
+    "ts-morph": "^27.0.2"
+  },
+  "devDependencies": {
+    "@types/minimist": "^1.2.5"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/ts-grapher/src/bin/run.ts
+++ b/packages/ts-grapher/src/bin/run.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import chalk from 'chalk';
+import minimist from 'minimist';
+import { Project } from 'ts-morph';
+
+import { generateDotContent } from '../dot.js';
+import { getClass, getFile, getFunction, getName, getType, getVariable, traverse } from '../helpers.js';
+import { getTsConfigFiles, outputToSvg, writeToFile } from '../io.js';
+import type { DotNode } from '../types.js';
+
+const argv: minimist.ParsedArgs = minimist(process.argv.slice(2));
+const searchingFor = argv._[0];
+const searchingIn = argv._[1];
+const rootTsConfig = argv._[2];
+const maxLevel = argv.level ? Number(argv.level) : 0;
+const svg = Boolean(argv.svg) || false;
+const debug = Boolean(argv.debug) || false;
+
+if (!searchingFor) {
+  throw new Error(chalk.red(`Did you forget to supply an argument for what we should search for?`));
+}
+
+if (!searchingIn) {
+  throw new Error(chalk.red(`Did you forget to supply an argument for the file we should start from?`));
+}
+
+if (!rootTsConfig) {
+  throw new Error(chalk.red(`Did you forget to supply an argument for the root tsconfig file?`));
+}
+
+console.log(`ts-grapher started with:
+\t- Name to look for: ${chalk.green(searchingFor)}
+\t- Start in file: ${chalk.green(searchingIn)}
+\t- Root tsconfig.json: ${chalk.green(rootTsConfig)}
+\t- Maximum levels to traverse: ${chalk.green(maxLevel)}
+\t- Save to svg (requires Graphwiz https://graphviz.org/download/): ${chalk.green(svg)}
+\t- Debug: ${chalk.green(debug)}
+`);
+
+const tsconfigs = getTsConfigFiles(rootTsConfig);
+if (tsconfigs.length < 1) {
+  throw new Error(chalk.red(`couldn't find any tsconfig files`));
+}
+
+console.log(`creating ts project from ${chalk.green(tsconfigs[0])}`);
+const project = new Project({ tsConfigFilePath: tsconfigs[0] });
+
+for (let index = 1; index < tsconfigs.length; index++) {
+  const tsconfig = tsconfigs[index];
+  if (debug) {
+    console.log(`Adding source files from ${chalk.green(tsconfig)}`);
+  }
+  project.addSourceFilesFromTsConfig(tsconfig);
+}
+
+const source = project.getSourceFileOrThrow(searchingIn);
+
+const start = getFunction(source, searchingFor) || getVariable(source, searchingFor) || getClass(source, searchingFor);
+
+if (!start) {
+  throw new Error(`couldn't find ${chalk.red(searchingFor)} in ${chalk.red(searchingIn)}`);
+}
+
+const file = getFile(start);
+const name = getName(start);
+const type = getType(start, name);
+const kind = start.getKindName();
+const dotNode: DotNode = { dependants: [], file, kind, name, type };
+
+traverse({ dotNode, tsObj: start, level: 0, maxLevel, debug });
+const output = generateDotContent({
+  parent: dotNode,
+  output: '',
+  seen: new Set(),
+});
+
+writeToFile(searchingFor, output);
+if (svg) {
+  outputToSvg(searchingFor);
+}

--- a/packages/ts-grapher/src/dot.ts
+++ b/packages/ts-grapher/src/dot.ts
@@ -1,0 +1,114 @@
+import { getFileName } from './io.js';
+import type { DotNode } from './types.js';
+
+export function generateHTMLStringLabel(node: DotNode) {
+  return `<<table border="0">
+			<tr><td><b>${encodeURIComponent(node.name)}</b></td></tr>
+      <tr><td>(${node.type})</td></tr>
+		</table>>`;
+}
+
+export function generateNodeColor(node: DotNode) {
+  if (node.type === 'hook') {
+    return 'aliceblue';
+  }
+
+  if (node.type === 'component') {
+    return 'cornsilk';
+  }
+
+  if (node.type === 'variable') {
+    return 'bisque';
+  }
+
+  if (node.type === 'class') {
+    return 'pink';
+  }
+
+  return '';
+}
+
+export function generateDotStart({
+  outputDPI = 96,
+  outputHeight = 1080,
+  outputWidth = 1920,
+}: {
+  outputDPI?: number;
+  outputHeight?: number;
+  outputWidth?: number;
+}) {
+  let output = '';
+  const width = outputWidth / outputDPI;
+  const height = outputHeight / outputDPI;
+  output += `digraph graphname {\n`;
+  output += `\trankdir="LR"\n`;
+  output += `\tgraph [size="${width},${height}!" dpi=${outputDPI}];\n`;
+
+  return output;
+}
+
+export function generateDotEnd() {
+  return `}\n`;
+}
+
+function getDotNodeId(node: DotNode): string {
+  return encodeURIComponent(`${getFileName(node.file)}_${node.name}_${node.kind}`.replaceAll('.', ''));
+}
+
+export function generateDotNode(node: DotNode) {
+  const label = generateHTMLStringLabel(node);
+  const color = generateNodeColor(node);
+  return `\t${getDotNodeId(node)} [style="filled" fillcolor="${color}" shape=rect label=${label} URL="file://${node.file}" tooltip="${node.file}"]\n`;
+}
+
+export function generateDotEdge(parent: DotNode, dependant: DotNode) {
+  return `${getDotNodeId(parent)} -> ${getDotNodeId(dependant)}`;
+}
+
+export function generateDotContent({
+  level = 0,
+  output,
+  outputDPI,
+  outputHeight,
+  outputWidth,
+  parent,
+  seen,
+}: {
+  level?: number;
+  output: string;
+  outputDPI?: number;
+  outputHeight?: number;
+  outputWidth?: number;
+  parent: DotNode;
+  seen: Set<string>;
+}) {
+  if (level === 0) {
+    output += generateDotStart({ outputDPI, outputHeight, outputWidth });
+  }
+
+  output += generateDotNode(parent);
+  for (const dependant of parent.dependants) {
+    const edge = generateDotEdge(parent, dependant);
+    if (seen.has(edge)) {
+      continue;
+    }
+    seen.add(edge);
+    const depOutput = generateDotContent({
+      output,
+      outputDPI,
+      outputHeight,
+      outputWidth,
+      parent: dependant,
+      seen,
+      level: level + 1,
+    });
+    output = depOutput;
+    output += `${edge} [dir=back]\n`;
+  }
+
+  if (level === 0) {
+    output += generateDotEnd();
+  }
+
+  return output;
+}

--- a/packages/ts-grapher/src/helpers.ts
+++ b/packages/ts-grapher/src/helpers.ts
@@ -1,0 +1,273 @@
+import chalk from 'chalk';
+import {
+  type ClassDeclaration,
+  type FunctionDeclaration,
+  Node,
+  type SourceFile,
+  SyntaxKind,
+  type VariableDeclaration,
+} from 'ts-morph';
+
+import type { DotNode, NodeType } from './types.js';
+
+const hookNameRegex = /^use[A-Z]/;
+const classNameRegex = /^[A-Z]/;
+
+export function getFunction(source: SourceFile, name: string): FunctionDeclaration | undefined {
+  const fn = source.getFunction(name);
+
+  return fn;
+}
+
+export function getVariable(source: SourceFile, name: string): VariableDeclaration | undefined {
+  const v = source.getVariableDeclaration(name);
+
+  return v;
+}
+
+export function getClass(source: SourceFile, name: string): ClassDeclaration | undefined {
+  const v = source.getClass(name);
+
+  return v;
+}
+
+export function getFile(node: Node): string {
+  return node.getSourceFile().getFilePath();
+}
+
+export function getName(node: Node): string {
+  if (Node.isVariableDeclaration(node)) {
+    return node.getName();
+  }
+
+  if (Node.isVariableStatement(node)) {
+    return node.getDeclarations()[0].getName();
+  }
+
+  if (Node.isFunctionDeclaration(node)) {
+    return node.getNameOrThrow();
+  }
+
+  if (Node.isMethodDeclaration(node)) {
+    return node.getName();
+  }
+
+  if (Node.isArrowFunction(node)) {
+    const parent = node.getParent();
+
+    if (Node.isVariableDeclaration(parent)) {
+      return parent.getName();
+    }
+
+    if (Node.isPropertyAssignment(parent)) {
+      return parent.getName();
+    }
+
+    if (Node.isPropertyDeclaration(parent)) {
+      return parent.getName();
+    }
+
+    if (Node.isCallExpression(parent)) {
+      const expression = parent.getExpression();
+
+      if (Node.isIdentifier(expression)) {
+        return expression.getText();
+      }
+
+      if (Node.isPropertyAccessExpression(expression)) {
+        return expression.getName();
+      }
+    }
+
+    return 'unknown';
+  }
+
+  if (Node.isClassDeclaration(node)) {
+    return node.getNameOrThrow();
+  }
+
+  return 'unknown';
+}
+
+function hasJsxTypeReturns(node: Node): boolean {
+  if (!Node.isFunctionDeclaration(node) && !Node.isMethodDeclaration(node) && !Node.isArrowFunction(node)) {
+    return false;
+  }
+
+  const returnType = node.getReturnType();
+  const returnTypeText = returnType.getText();
+
+  // Check for common React return types
+  const reactReturnTypes = [
+    'JSX.Element',
+    'ReactElement',
+    'ReactNode',
+    'React.ReactElement',
+    'React.ReactNode',
+    'Element',
+  ];
+
+  return reactReturnTypes.some((r) => returnTypeText.includes(r));
+}
+
+function hasJsxReturn(node: Node): boolean {
+  const jsxElements = node.getDescendantsOfKind(SyntaxKind.JsxElement);
+  const jsxSelfClosing = node.getDescendantsOfKind(SyntaxKind.JsxSelfClosingElement);
+  const jsxFragment = node.getDescendantsOfKind(SyntaxKind.JsxFragment);
+
+  if (jsxElements.length > 0 || jsxSelfClosing.length > 0 || jsxFragment.length > 0) {
+    return true;
+  }
+
+  return hasJsxTypeReturns(node);
+}
+
+function getClassType(node: Node, name: string): NodeType | undefined {
+  if (classNameRegex.test(name) && hasJsxReturn(node)) {
+    return 'component';
+  }
+
+  return 'class';
+}
+
+function getFunctionType(node: Node, name: string, defaultType: NodeType = 'function'): NodeType | undefined {
+  if (hookNameRegex.test(name)) {
+    return 'hook';
+  }
+
+  if (classNameRegex.test(name) && hasJsxReturn(node)) {
+    return 'component';
+  }
+
+  return defaultType;
+}
+
+export function getType(node: Node, name: string): NodeType | undefined {
+  if (Node.isClassDeclaration(node)) {
+    return getClassType(node, name);
+  }
+
+  if (Node.isFunctionDeclaration(node) || Node.isMethodDeclaration(node) || Node.isArrowFunction(node)) {
+    return getFunctionType(node, name);
+  }
+
+  if (Node.isVariableDeclaration(node)) {
+    const arrowFunction = node.getInitializerIfKind(SyntaxKind.ArrowFunction);
+    if (arrowFunction) {
+      return getFunctionType(arrowFunction, name);
+    }
+
+    const functionDeclaration = node.getInitializerIfKind(SyntaxKind.FunctionDeclaration);
+    if (functionDeclaration) {
+      return getFunctionType(functionDeclaration, name);
+    }
+
+    const callExpression = node.getInitializerIfKind(SyntaxKind.CallExpression);
+    if (callExpression) {
+      return getFunctionType(callExpression, name, 'variable');
+    }
+
+    const classDeclaration = node.getInitializerIfKind(SyntaxKind.ClassDeclaration);
+    if (classDeclaration) {
+      return getClassType(classDeclaration, name);
+    }
+
+    return 'variable';
+  }
+
+  return;
+}
+
+function equals(first: DotNode, second: DotNode) {
+  return first.name === second.name && first.file === second.file && first.kind === second.kind;
+}
+
+function getTopMostAncestor(ref: Node) {
+  const ancestor = ref.getFirstAncestor(
+    (node) =>
+      node.getKind() === SyntaxKind.FunctionDeclaration ||
+      node.getKind() === SyntaxKind.MethodDeclaration ||
+      node.getKind() === SyntaxKind.VariableDeclaration ||
+      node.getKind() === SyntaxKind.ClassDeclaration
+  );
+
+  if (!ancestor) {
+    return ref;
+  }
+
+  return getTopMostAncestor(ancestor);
+}
+
+function shouldFilterFile(file: string) {
+  return (
+    file.includes('.test.') ||
+    file.includes('.spec.') ||
+    file.includes('/mocks/') ||
+    file.includes('/node_modules/') ||
+    file.includes('/dist/') ||
+    file.includes('/build/') ||
+    file.includes('/out/')
+  );
+}
+
+export function traverse({
+  dotNode,
+  tsObj,
+  level = 0,
+  maxLevel = 0,
+  debug = false,
+}: {
+  tsObj: any;
+  dotNode: DotNode;
+  level?: number;
+  maxLevel?: number;
+  debug?: boolean;
+}) {
+  if (!tsObj?.findReferencesAsNodes) {
+    return;
+  }
+
+  const refs = tsObj?.findReferencesAsNodes() || [];
+  if (debug) {
+    console.log(`searching for ${chalk.green(dotNode.name)}`);
+  }
+
+  for (const ref of refs) {
+    const ancestor = getTopMostAncestor(ref);
+    if (!ancestor) {
+      continue;
+    }
+
+    const file = getFile(ancestor);
+    if (shouldFilterFile(file)) {
+      continue;
+    }
+
+    const name = getName(ancestor);
+    if (name === 'unknown') {
+      continue;
+    }
+
+    const type = getType(ancestor, name);
+    const kind = ancestor.getKindName();
+    const dependant: DotNode = { dependants: [], file, name, type, kind };
+
+    if (equals(dependant, dotNode)) {
+      continue;
+    }
+
+    if (dotNode.dependants.find((d) => equals(d, dependant))) {
+      continue;
+    }
+
+    dotNode.dependants.push(dependant);
+    if (debug) {
+      console.log(
+        `${chalk.yellow(dependant.name)} references ${chalk.yellow(dotNode.name)} at level ${chalk.green(level)} of ${chalk.green(maxLevel)} (${chalk.green(dependant.file)})`
+      );
+    }
+    if (level < maxLevel) {
+      traverse({ dotNode: dependant, tsObj: ancestor, level: level + 1, maxLevel, debug });
+    }
+  }
+}

--- a/packages/ts-grapher/src/io.ts
+++ b/packages/ts-grapher/src/io.ts
@@ -1,0 +1,64 @@
+import chalk from 'chalk';
+import { globSync } from 'glob';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+function getOutputPath() {
+  return path.join(process.cwd(), 'out');
+}
+
+function getFilePath(name: string) {
+  return path.join(getOutputPath(), name);
+}
+
+export function writeToFile(name: string, output: string) {
+  const outputPath = getOutputPath();
+  if (!existsSync(outputPath)) {
+    mkdirSync(outputPath);
+  }
+
+  const filePath = getFilePath(`${name}.gv`);
+  writeFileSync(filePath, output, { encoding: 'utf8' });
+  console.log(`dot file ${chalk.green(filePath)} successfully created`);
+}
+
+export function outputToSvg(name: string) {
+  try {
+    const input = getFilePath(`${name}.gv`);
+    const output = getFilePath(`${name}.svg`);
+    const svgoutput = execFileSync('dot', ['-Tsvg', input], { encoding: 'utf8' });
+    writeFileSync(output, svgoutput, { encoding: 'utf-8' });
+    console.log(`svg file ${chalk.green(output)} successfully created`);
+  } catch (error) {
+    if (error instanceof Error && 'status' in error && error.status === 1) {
+      return;
+    }
+    throw error;
+  }
+}
+
+export function getTsConfigFiles(rootTsConfig: string): string[] {
+  if (!rootTsConfig) {
+    return [];
+  }
+
+  if (!rootTsConfig.includes('tsconfig.json')) {
+    return [];
+  }
+
+  if (!existsSync(rootTsConfig)) {
+    return [];
+  }
+
+  const dirPath = path.dirname(rootTsConfig);
+  const tsconfigs = globSync(`${dirPath}/**/tsconfig.json`, {
+    ignore: [`${dirPath}/node_modules/**`, `${dirPath}/data/**`],
+  });
+
+  return tsconfigs;
+}
+
+export function getFileName(filePath: string) {
+  return path.basename(filePath);
+}

--- a/packages/ts-grapher/src/types.ts
+++ b/packages/ts-grapher/src/types.ts
@@ -1,0 +1,9 @@
+export type NodeType = 'variable' | 'function' | 'class' | 'hook' | 'component';
+
+export interface DotNode {
+  file: string;
+  name: string;
+  type?: NodeType;
+  kind: string;
+  dependants: DotNode[];
+}

--- a/packages/ts-grapher/tsconfig.json
+++ b/packages/ts-grapher/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "exclude": ["node_modules"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/ts-grapher/vitest.config.ts
+++ b/packages/ts-grapher/vitest.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path';
+import { defineProject, mergeConfig } from 'vitest/config';
+import configShared from '../../vitest.config.base.js';
+
+export default mergeConfig(
+  configShared,
+  defineProject({
+    test: {
+      root: resolve(__dirname),
+    },
+  })
+);


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request introduces a new utility package, `@grafana/ts-dependency-grapher`, for analyzing TypeScript dependency relationships. The package includes command-line functionality for generating DOT-format dependency graphs, documentation, licensing, and helper utilities for TypeScript AST traversal.

Created first in core Grafana repo but @mckn [suggested](https://github.com/grafana/grafana/pull/116108#pullrequestreview-3680823730) that I moved it here instead so I did.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

You can try it out yourself:
1. cd to the folder that contains the `grafana` folder
```bash
cd /Users/hugoh/git
```
2.  run command
```bash
npx @grafana/ts-grapher@0.1.0-canary.2411.21208495859.0 getAppPluginDependenciesSync grafana/public/app/features/plugins/extensions/appUtils.tsx grafana/tsconfig.json --level=4 
```
3. if you want to output to `svg` install Graphviz
```bash
brew install graphviz
```
4.  run command with `--svg`
```bash
npx @grafana/ts-grapher@0.1.0-canary.2411.21208495859.0 getAppPluginDependenciesSync grafana/public/app/features/plugins/extensions/appUtils.tsx grafana/tsconfig.json --level=4 --svg
```
![getAppPluginDependenciesSync](https://github.com/user-attachments/assets/2670bc84-8db0-447b-8714-d5c951cc2aa6)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/ts-grapher@0.1.0-canary.2411.21238771434.0
  # or 
  yarn add @grafana/ts-grapher@0.1.0-canary.2411.21238771434.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
