### PR TITLE
Fix: Pin golint-ci in scaffolded plugins 

### DIFF
--- a/packages/create-plugin/templates/github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Lint backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           version: latest
           args: ./...

--- a/packages/create-plugin/templates/github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Lint backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa
         with:
           version: latest
           args: ./...


### PR DESCRIPTION

**What this PR does / why we need it**:

My changes in [this PR](https://github.com/grafana/plugin-tools/pull/2409) broke the CI for scaffolded plugins, see [this error](https://github.com/grafana/grafana-plugin-examples/actions/runs/21238207003) in plugin-examples. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.7.8-canary.2414.21243790948.0
  # or 
  yarn add @grafana/create-plugin@6.7.8-canary.2414.21243790948.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
