### PR TITLE
fix: silence warnings so json flag prints valid json

### DIFF
--- a/packages/react-detect/src/commands/detect19.ts
+++ b/packages/react-detect/src/commands/detect19.ts
@@ -15,6 +15,7 @@ export async function detect19(argv: minimist.ParsedArgs) {
     const pluginRoot = argv.pluginRoot || process.cwd();
     const skipDependencies = argv.skipDependencies || false;
     const skipBuildTooling = argv.skipBuildTooling || false;
+    const jsonOutput = argv.json || false;
 
     const allMatches = await getAllMatches(pluginRoot);
 
@@ -25,15 +26,17 @@ export async function detect19(argv: minimist.ParsedArgs) {
       try {
         await depContext.loadDependencies(pluginRoot);
       } catch (error) {
-        // Log warning but continue with null context
-        output.warning({
-          title: 'Failed to load dependencies',
-          body: [
-            (error as Error).message,
-            'Continuing without dependency analysis.',
-            'Use --skipDependencies to suppress this warning.',
-          ],
-        });
+        // Log warning only if not in JSON output mode and continue with null context
+        if (!jsonOutput) {
+          output.warning({
+            title: 'Failed to load dependencies',
+            body: [
+              (error as Error).message,
+              'Continuing without dependency analysis.',
+              'Use --skipDependencies to suppress this warning.',
+            ],
+          });
+        }
         depContext = null;
       }
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The json flag should only print valid json but I realised whilst scanning all plugins that the checks to skip  dependency analysis where logging to console which means stdout isn't valid json. E.g.

```
$ npx react-detect --json

@grafana/react-detect  Failed to load dependencies

Cannot convert undefined or null to object
Continuing without dependency analysis.
Use --skipDependencies to suppress this warning.

{
  "plugin": {
    "id": "verticle-flowhook-datasource",
    "name": "Flowhook Webhooks Datasource",
    "version": "0.1.3",
    "type": "datasource"
  },
  "summary": {
    "totalIssues": 0,
    "critical": 0,
    "warnings": 0,
    "sourceIssuesCount": 0,
    "dependencyIssuesCount": 0,
    "status": "no_action_required",
    "affectedDependencies": [],
    "analyzedBuildTooling": true,
    "analyzedDependencies": true
  },
  "sourceCodeIssues": {},
  "dependencyIssues": []
}
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.3.1-canary.2417.21287968542.0
  npm install @grafana/eslint-plugin-plugins@0.6.2-canary.2417.21287968542.0
  npm install @grafana/plugin-meta-extractor@0.12.1-canary.2417.21287968542.0
  npm install @grafana/react-detect@0.5.1-canary.2417.21287968542.0
  # or 
  yarn add website@5.3.1-canary.2417.21287968542.0
  yarn add @grafana/eslint-plugin-plugins@0.6.2-canary.2417.21287968542.0
  yarn add @grafana/plugin-meta-extractor@0.12.1-canary.2417.21287968542.0
  yarn add @grafana/react-detect@0.5.1-canary.2417.21287968542.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
