### PR TITLE
Enhanced plugin docs: Add new package skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39851,10 +39851,10 @@
     },
     "packages/plugin-docs-renderer": {
       "name": "@grafana/plugin-docs-renderer",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "packages/plugin-e2e": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "packages/eslint-plugin-plugins",
         "packages/tsconfig",
         "packages/react-detect",
+        "packages/plugin-docs-renderer",
         "libs/*"
       ],
       "devDependencies": {
@@ -6158,6 +6159,10 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
+    },
+    "node_modules/@grafana/plugin-docs-renderer": {
+      "resolved": "packages/plugin-docs-renderer",
+      "link": true
     },
     "node_modules/@grafana/plugin-e2e": {
       "resolved": "packages/plugin-e2e",
@@ -39842,6 +39847,14 @@
       "peerDependencies": {
         "@types/eslint": "^8.56.10 || ^9.0.0",
         "eslint": "^8.56.0 || ^9.0.0"
+      }
+    },
+    "packages/plugin-docs-renderer": {
+      "name": "@grafana/plugin-docs-renderer",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/plugin-e2e": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-tools",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "repository": "https://github.com/grafana/plugin-tools",
   "author": "Grafana",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-tools",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "repository": "https://github.com/grafana/plugin-tools",
   "author": "Grafana",
   "private": true,
@@ -77,6 +77,7 @@
     "packages/eslint-plugin-plugins",
     "packages/tsconfig",
     "packages/react-detect",
+    "packages/plugin-docs-renderer",
     "libs/*"
   ],
   "lint-staged": {

--- a/packages/plugin-docs-renderer/CHANGELOG.md
+++ b/packages/plugin-docs-renderer/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/packages/plugin-docs-renderer/LICENSE
+++ b/packages/plugin-docs-renderer/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Grafana Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/plugin-docs-renderer/README.md
+++ b/packages/plugin-docs-renderer/README.md
@@ -1,0 +1,5 @@
+# @grafana/plugin-docs-renderer
+
+A library for rendering Grafana plugin documentation from markdown files.
+
+**In Development** - This package is currently under active development as part of the enhanced plugin documentation project.

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@grafana/plugin-docs-renderer",
+  "version": "0.1.0",
+  "description": "A library for rendering Grafana plugin documentation from markdown files.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "repository": {
+    "directory": "packages/plugin-docs-renderer",
+    "url": "https://github.com/grafana/plugin-tools"
+  },
+  "author": "Grafana",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "rollup -c ../../rollup.config.ts --configPlugin esbuild",
+    "lint": "eslint --cache ./src",
+    "lint:fix": "npm run lint -- --fix",
+    "lint:package": "publint",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "grafana",
+    "plugin",
+    "documentation",
+    "markdown",
+    "renderer"
+  ],
+  "bugs": {
+    "url": "https://github.com/grafana/plugin-tools/issues"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -41,6 +41,6 @@
     "url": "https://github.com/grafana/plugin-tools/issues"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   }
 }

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@grafana/plugin-docs-renderer",
   "version": "0.0.1",
+  "private": "true",
   "description": "A library for rendering Grafana plugin documentation from markdown files.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -5,6 +5,12 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md"
+  ],
   "repository": {
     "directory": "packages/plugin-docs-renderer",
     "url": "https://github.com/grafana/plugin-tools"

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-docs-renderer",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "A library for rendering Grafana plugin documentation from markdown files.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/plugin-docs-renderer/src/index.test.ts
+++ b/packages/plugin-docs-renderer/src/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import type { Manifest, Page, MarkdownFiles } from './index.js';
+
+describe('@grafana/plugin-docs-renderer', () => {
+  it('should export core types', () => {
+    const manifest: Manifest = {
+      version: '1.0',
+      title: 'Test Documentation',
+      pages: [],
+    };
+
+    const page: Page = {
+      title: 'Overview',
+      slug: 'overview',
+      file: 'index.md',
+    };
+
+    const files: MarkdownFiles = {
+      'index.md': '# Overview',
+    };
+
+    expect(manifest.version).toBe('1.0');
+    expect(page.title).toBe('Overview');
+    expect(files['index.md']).toBe('# Overview');
+  });
+});

--- a/packages/plugin-docs-renderer/src/index.ts
+++ b/packages/plugin-docs-renderer/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @grafana/plugin-docs-renderer
+ *
+ * A library for rendering Grafana plugin documentation from markdown files.
+ */
+
+// Export types
+export type { Manifest, Page, MarkdownFiles } from './types.js';

--- a/packages/plugin-docs-renderer/src/types.ts
+++ b/packages/plugin-docs-renderer/src/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Core types for the plugin documentation renderer.
+ *
+ * These types define the structure of documentation manifests and pages.
+ */
+
+/**
+ * Represents a documentation page in the manifest.
+ */
+export interface Page {
+  /**
+   * The display title of the page.
+   */
+  title: string;
+
+  /**
+   * The URL slug for the page.
+   */
+  slug: string;
+
+  /**
+   * The relative path to the markdown file (e.g., "installation.md").
+   */
+  file: string;
+
+  /**
+   * Optional nested child pages.
+   */
+  children?: Page[];
+}
+
+/**
+ * The documentation manifest that defines the structure and navigation.
+ */
+export interface Manifest {
+  /**
+   * The manifest format version.
+   */
+  version: string;
+
+  /**
+   * The title of the documentation.
+   */
+  title: string;
+
+  /**
+   * The list of documentation pages.
+   */
+  pages: Page[];
+}
+
+/**
+ * A collection of markdown files indexed by their file path.
+ */
+export interface MarkdownFiles {
+  [filePath: string]: string;
+}

--- a/packages/plugin-docs-renderer/tsconfig.json
+++ b/packages/plugin-docs-renderer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "exclude": ["node_modules"],
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/plugin-docs-renderer/vitest.config.ts
+++ b/packages/plugin-docs-renderer/vitest.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path';
+import { defineProject, mergeConfig } from 'vitest/config';
+import configShared from '../../vitest.config.base.js';
+
+export default mergeConfig(
+  configShared,
+  defineProject({
+    test: {
+      root: resolve(__dirname),
+    },
+  })
+);


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds basic package structure for `@grafana/plugin-docs-renderer`, a new library for rendering plugin documentation from markdown. This is part of the enhanced plugin documentation project. See [design doc](https://docs.google.com/document/d/1dskdr3kaeK7RAg8h6v4rQYFzlj_-QVAytGOM11-ySkc/edit?tab=t.0#heading=h.5sybau7waq2q) for details and the full picture and this [epic](https://github.com/grafana/grafana-community-team/issues/734) for steps required for the POC. Next PR will add markdown parsing using `marked` and basic HTML generation.

In this PR, the core TypeScript types and build tooling (rollup + esbuild, vitest, eslint) is set up, following the same patterns as `sign-plugin`. The package has no runtime dependencies yet as it only exports types at this stage. It's registered in the monorepo workspaces and ready for the next phase.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-community-team/issues/735

**Special notes for your reviewer**:
