### PR TITLE
Enhanced plugin docs: Implement markdown parsing and CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39851,8 +39851,6 @@
     },
     "packages/plugin-docs-renderer": {
       "name": "@grafana/plugin-docs-renderer",
-<<<<<<< HEAD
-<<<<<<< HEAD
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -39861,18 +39859,6 @@
       },
       "engines": {
         "node": ">=24"
-=======
-      "version": "0.1.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20"
->>>>>>> 63d7ddbf (add basic skeleton for new package)
-=======
-      "version": "0.0.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=24"
->>>>>>> 0def04cd (update lock file after version change)
       }
     },
     "packages/plugin-docs-renderer/node_modules/marked": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39855,6 +39855,10 @@
 <<<<<<< HEAD
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "marked": "^13.0.0"
+      },
       "engines": {
         "node": ">=24"
 =======
@@ -39869,6 +39873,18 @@
       "engines": {
         "node": ">=24"
 >>>>>>> 0def04cd (update lock file after version change)
+      }
+    },
+    "packages/plugin-docs-renderer/node_modules/marked": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
+      "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "packages/plugin-e2e": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39855,7 +39855,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "gray-matter": "^4.0.3",
-        "marked": "^13.0.0"
+        "marked": "^13.0.0",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "plugin-docs-renderer": "dist/bin/run.js"
+      },
+      "devDependencies": {
+        "@types/minimist": "^1.2.5"
       },
       "engines": {
         "node": ">=24"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40350,6 +40350,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "debug": "^4.3.7",
         "gray-matter": "^4.0.3",
         "isomorphic-dompurify": "^2.16.0",
         "marked": "^13.0.0",
@@ -40359,6 +40360,7 @@
         "plugin-docs-renderer": "dist/bin/run.js"
       },
       "devDependencies": {
+        "@types/debug": "^4.1.12",
         "@types/dompurify": "^3.0.5",
         "@types/minimist": "^1.2.5"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -39851,10 +39851,17 @@
     },
     "packages/plugin-docs-renderer": {
       "name": "@grafana/plugin-docs-renderer",
+<<<<<<< HEAD
       "version": "0.0.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24"
+=======
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+>>>>>>> 63d7ddbf (add basic skeleton for new package)
       }
     },
     "packages/plugin-e2e": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -337,6 +337,12 @@
         "find-up": "^7.0.0"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "license": "MIT"
+    },
     "node_modules/@algolia/abtesting": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.7.0.tgz",
@@ -605,6 +611,75 @@
       "dependencies": {
         "grapheme-splitter": "^1.0.4"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.7.tgz",
+      "integrity": "sha512-8CO/UQ4tzDd7ula+/CVimJIVWez99UJlbMyIgk8xOnhAVPKLnBZmUFYVgugS441v2ZqUq5EnSh6B0Ua0liSFAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@atomist/slack-messages": {
       "version": "1.2.2",
@@ -2616,9 +2691,9 @@
       }
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "funding": [
         {
           "type": "github",
@@ -2658,9 +2733,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
-      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "funding": [
         {
           "type": "github",
@@ -2673,7 +2748,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/color-helpers": "^5.1.0",
         "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
@@ -2706,6 +2781,22 @@
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
       }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -5499,6 +5590,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.11.0.tgz",
+      "integrity": "sha512-wO3vd8nsEHdumsXrjGO/v4p6irbg7hy9kvIeR6i2AwylZSk4HJdWgL0FNaVquW1+AweJcdvU1IEpuIWk/WaPnA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@grafana/create-plugin": {
@@ -11754,6 +11862,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/emscripten": {
       "version": "1.41.5",
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
@@ -12161,9 +12279,8 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -14073,6 +14190,15 @@
       "version": "2.2.3",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -16636,6 +16762,49 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cssstyle/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "license": "MIT"
@@ -16699,6 +16868,62 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/data-view-buffer": {
@@ -16827,6 +17052,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -21979,6 +22210,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -23214,6 +23457,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "dev": true,
@@ -23433,6 +23682,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-dompurify": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.35.0.tgz",
+      "integrity": "sha512-a9+LQqylQCU8f1zmsYmg2tfrbdY2YS/Hc+xntcq/mDI2MY3Q108nq8K23BWDIg6YGC5JsUMC15fj2ZMqCzt/+A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.3.1",
+        "jsdom": "^27.4.0"
+      },
+      "engines": {
+        "node": ">=20.19.5"
+      }
+    },
+    "node_modules/isomorphic-dompurify/node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/iterator.prototype": {
@@ -23701,6 +23972,147 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -34503,6 +34915,18 @@
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "license": "MIT",
@@ -36073,6 +36497,12 @@
         "webpack": ">=2"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -36540,6 +36970,24 @@
       "version": "4.3.2",
       "license": "MIT"
     },
+    "node_modules/tldts": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.22.tgz",
+      "integrity": "sha512-nqpKFC53CgopKPjT6Wfb6tpIcZXHcI6G37hesvikhx0EmUGPkZrujRyAjgnmp1SHNgpQfKVanZ+KfpANFt2Hxw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.22"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.22",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.22.tgz",
+      "integrity": "sha512-KgbTDC5wzlL6j/x6np6wCnDSMUq4kucHNm00KXPbfNzmllCmtmvtykJHfmgdHntwIeupW04y8s1N/43S1PkQDw==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -36661,6 +37109,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -38391,6 +38851,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
@@ -38856,6 +39328,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
@@ -39382,10 +39863,25 @@
         "xml-js": "bin/cli.js"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xml-utils": {
       "version": "1.10.1",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/xss": {
       "version": "1.0.15",
@@ -39855,6 +40351,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "gray-matter": "^4.0.3",
+        "isomorphic-dompurify": "^2.16.0",
         "marked": "^13.0.0",
         "minimist": "^1.2.8"
       },
@@ -39862,6 +40359,7 @@
         "plugin-docs-renderer": "dist/bin/run.js"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/minimist": "^1.2.5"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39852,6 +39852,7 @@
     "packages/plugin-docs-renderer": {
       "name": "@grafana/plugin-docs-renderer",
 <<<<<<< HEAD
+<<<<<<< HEAD
       "version": "0.0.1",
       "license": "Apache-2.0",
       "engines": {
@@ -39862,6 +39863,12 @@
       "engines": {
         "node": ">=20"
 >>>>>>> 63d7ddbf (add basic skeleton for new package)
+=======
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=24"
+>>>>>>> 0def04cd (update lock file after version change)
       }
     },
     "packages/plugin-e2e": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-tools",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "repository": "https://github.com/grafana/plugin-tools",
   "author": "Grafana",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-tools",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "repository": "https://github.com/grafana/plugin-tools",
   "author": "Grafana",
   "private": true,

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -48,9 +48,11 @@
   "dependencies": {
     "marked": "^13.0.0",
     "gray-matter": "^4.0.3",
-    "minimist": "^1.2.8"
+    "minimist": "^1.2.8",
+    "isomorphic-dompurify": "^2.16.0"
   },
   "devDependencies": {
-    "@types/minimist": "^1.2.5"
+    "@types/minimist": "^1.2.5",
+    "@types/dompurify": "^3.0.5"
   }
 }

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -43,5 +43,9 @@
   },
   "engines": {
     "node": ">=24"
+  },
+  "dependencies": {
+    "marked": "^13.0.0",
+    "gray-matter": "^4.0.3"
   }
 }

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -49,10 +49,12 @@
     "marked": "^13.0.0",
     "gray-matter": "^4.0.3",
     "minimist": "^1.2.8",
-    "isomorphic-dompurify": "^2.16.0"
+    "isomorphic-dompurify": "^2.16.0",
+    "debug": "^4.3.7"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.5",
-    "@types/dompurify": "^3.0.5"
+    "@types/dompurify": "^3.0.5",
+    "@types/debug": "^4.1.12"
   }
 }

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": "./dist/bin/run.js",
   "files": [
     "dist",
     "LICENSE",

--- a/packages/plugin-docs-renderer/package.json
+++ b/packages/plugin-docs-renderer/package.json
@@ -47,6 +47,10 @@
   },
   "dependencies": {
     "marked": "^13.0.0",
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "minimist": "^1.2.8"
+  },
+  "devDependencies": {
+    "@types/minimist": "^1.2.5"
   }
 }

--- a/packages/plugin-docs-renderer/src/bin/run.ts
+++ b/packages/plugin-docs-renderer/src/bin/run.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { access, writeFile } from 'node:fs/promises';
+import { loadDocsFolder } from '../loader.js';
+import { parseMarkdown } from '../parser.js';
+
+async function main() {
+  const docsPath = process.argv[2];
+
+  // find --output flag
+  const outputIndex = process.argv.indexOf('--output');
+  const outputPath = outputIndex !== -1 ? process.argv[outputIndex + 1] : undefined;
+
+  // check if the first argument is present
+  if (docsPath === undefined) {
+    console.error('Please provide the path to the docs folder as an argument.');
+    process.exit(1);
+  }
+
+  // check if --output flag is provided
+  if (outputPath === undefined) {
+    console.error('Please provide an output file using the --output flag.');
+    process.exit(1);
+  }
+
+  // check if the path exists
+  try {
+    await access(docsPath);
+  } catch {
+    console.error(`Path not found: ${docsPath}`);
+    process.exit(1);
+  }
+
+  // load and parse documentation
+  try {
+    const { manifest, files } = await loadDocsFolder(docsPath);
+
+    // parse each markdown file
+    const pages: Record<string, { frontmatter: Record<string, unknown>; html: string }> = {};
+    for (const [filePath, content] of Object.entries(files)) {
+      const parsed = parseMarkdown(content);
+      pages[filePath] = {
+        frontmatter: parsed.frontmatter,
+        html: parsed.html,
+      };
+    }
+
+    // write output to file
+    const result = {
+      manifest,
+      pages,
+    };
+
+    await writeFile(outputPath, JSON.stringify(result, null, 2), 'utf-8');
+    console.log(`Documentation rendered successfully to ${outputPath}`);
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('Error processing documentation:', error.message);
+    } else {
+      console.error('Error processing documentation:', error);
+    }
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/plugin-docs-renderer/src/bin/run.ts
+++ b/packages/plugin-docs-renderer/src/bin/run.ts
@@ -1,32 +1,21 @@
 #!/usr/bin/env node
-import { access, writeFile } from 'node:fs/promises';
+import { access } from 'node:fs/promises';
+import minimist from 'minimist';
 import { loadDocsFolder } from '../loader.js';
 import { parseMarkdown } from '../parser.js';
 
 async function main() {
-  const docsPath = process.argv[2];
-
-  // find --output flag
-  const outputIndex = process.argv.indexOf('--output');
-  const outputPath = outputIndex !== -1 ? process.argv[outputIndex + 1] : undefined;
-
-  // check if the first argument is present
-  if (docsPath === undefined) {
-    console.error('Please provide the path to the docs folder as an argument.');
-    process.exit(1);
-  }
-
-  // check if --output flag is provided
-  if (outputPath === undefined) {
-    console.error('Please provide an output file using the --output flag.');
-    process.exit(1);
-  }
+  const argv = minimist(process.argv.slice(2));
+  // get docs path from command line arguments or use default (./docs)
+  const docsPath = argv._[0] || './docs';
 
   // check if the path exists
   try {
     await access(docsPath);
   } catch {
     console.error(`Path not found: ${docsPath}`);
+    console.error('Usage: npx @grafana/plugin-docs-renderer [docs-folder]');
+    console.error('Example: npx @grafana/plugin-docs-renderer ./docs');
     process.exit(1);
   }
 
@@ -44,14 +33,13 @@ async function main() {
       };
     }
 
-    // write output to file
+    // output to console
     const result = {
       manifest,
       pages,
     };
 
-    await writeFile(outputPath, JSON.stringify(result, null, 2), 'utf-8');
-    console.log(`Documentation rendered successfully to ${outputPath}`);
+    console.log(JSON.stringify(result, null, 2));
   } catch (error) {
     if (error instanceof Error) {
       console.error('Error processing documentation:', error.message);

--- a/packages/plugin-docs-renderer/src/index.ts
+++ b/packages/plugin-docs-renderer/src/index.ts
@@ -1,8 +1,10 @@
-/**
- * @grafana/plugin-docs-renderer
- *
- * A library for rendering Grafana plugin documentation from markdown files.
- */
-
-// Export types
+// export types
 export type { Manifest, Page, MarkdownFiles } from './types.js';
+
+// export parser functions
+export { parseMarkdown } from './parser.js';
+export type { ParsedMarkdown } from './parser.js';
+
+// export loader functions
+export { loadDocsFolder } from './loader.js';
+export type { LoadedDocs } from './loader.js';

--- a/packages/plugin-docs-renderer/src/loader.ts
+++ b/packages/plugin-docs-renderer/src/loader.ts
@@ -1,6 +1,9 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { join, relative } from 'node:path';
+import createDebug from 'debug';
 import type { Manifest, MarkdownFiles } from './types.js';
+
+const debug = createDebug('plugin-docs-renderer:loader');
 
 /**
  * Result of loading a docs folder.
@@ -26,6 +29,7 @@ export interface LoadedDocs {
  */
 async function findMarkdownFiles(dir: string, baseDir: string): Promise<string[]> {
   const files: string[] = [];
+  debug('Searching for markdown files in %s', dir);
 
   let entries;
   try {
@@ -40,13 +44,16 @@ async function findMarkdownFiles(dir: string, baseDir: string): Promise<string[]
 
     if (entry.isDirectory()) {
       // recursively search subdirectories
+      debug('Found subdirectory: %s', entry.name);
       const subFiles = await findMarkdownFiles(fullPath, baseDir);
       files.push(...subFiles);
     } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      debug('Found markdown file: %s', entry.name);
       files.push(fullPath);
     }
   }
 
+  debug('Found %d markdown file(s) in %s', files.length, dir);
   return files;
 }
 
@@ -58,8 +65,11 @@ async function findMarkdownFiles(dir: string, baseDir: string): Promise<string[]
  * @throws {Error} If manifest.json is not found or invalid
  */
 export async function loadDocsFolder(rootPath: string): Promise<LoadedDocs> {
+  debug('Loading docs folder: %s', rootPath);
+
   // read and parse manifest.json
   const manifestPath = join(rootPath, 'manifest.json');
+  debug('Reading manifest from: %s', manifestPath);
 
   let manifestContent;
   try {
@@ -72,6 +82,7 @@ export async function loadDocsFolder(rootPath: string): Promise<LoadedDocs> {
   let manifest;
   try {
     manifest = JSON.parse(manifestContent) as Manifest;
+    debug('Parsed manifest: title=%s, version=%s, pages=%d', manifest.title, manifest.version, manifest.pages.length);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to parse manifest.json: ${message}`);
@@ -81,6 +92,7 @@ export async function loadDocsFolder(rootPath: string): Promise<LoadedDocs> {
   let markdownPaths;
   try {
     markdownPaths = await findMarkdownFiles(rootPath, rootPath);
+    debug('Found %d total markdown file(s)', markdownPaths.length);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to find markdown files in ${rootPath}: ${message}`);
@@ -90,6 +102,7 @@ export async function loadDocsFolder(rootPath: string): Promise<LoadedDocs> {
   const files: MarkdownFiles = {};
   for (const filePath of markdownPaths) {
     const relativePath = relative(rootPath, filePath);
+    debug('Reading markdown file: %s', relativePath);
 
     try {
       const content = await readFile(filePath, 'utf-8');
@@ -100,6 +113,7 @@ export async function loadDocsFolder(rootPath: string): Promise<LoadedDocs> {
     }
   }
 
+  debug('Successfully loaded docs folder with %d file(s)', Object.keys(files).length);
   return {
     manifest,
     files,

--- a/packages/plugin-docs-renderer/src/loader.ts
+++ b/packages/plugin-docs-renderer/src/loader.ts
@@ -26,7 +26,14 @@ export interface LoadedDocs {
  */
 async function findMarkdownFiles(dir: string, baseDir: string): Promise<string[]> {
   const files: string[] = [];
-  const entries = await readdir(dir, { withFileTypes: true });
+
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read directory ${dir}: ${message}`);
+  }
 
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
@@ -53,18 +60,44 @@ async function findMarkdownFiles(dir: string, baseDir: string): Promise<string[]
 export async function loadDocsFolder(rootPath: string): Promise<LoadedDocs> {
   // read and parse manifest.json
   const manifestPath = join(rootPath, 'manifest.json');
-  const manifestContent = await readFile(manifestPath, 'utf-8');
-  const manifest = JSON.parse(manifestContent) as Manifest;
+
+  let manifestContent;
+  try {
+    manifestContent = await readFile(manifestPath, 'utf-8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read manifest.json at ${manifestPath}: ${message}`);
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestContent) as Manifest;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to parse manifest.json: ${message}`);
+  }
 
   // find all markdown files
-  const markdownPaths = await findMarkdownFiles(rootPath, rootPath);
+  let markdownPaths;
+  try {
+    markdownPaths = await findMarkdownFiles(rootPath, rootPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to find markdown files in ${rootPath}: ${message}`);
+  }
 
   // read all markdown files
   const files: MarkdownFiles = {};
   for (const filePath of markdownPaths) {
     const relativePath = relative(rootPath, filePath);
-    const content = await readFile(filePath, 'utf-8');
-    files[relativePath] = content;
+
+    try {
+      const content = await readFile(filePath, 'utf-8');
+      files[relativePath] = content;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to read markdown file ${relativePath}: ${message}`);
+    }
   }
 
   return {

--- a/packages/plugin-docs-renderer/src/loader.ts
+++ b/packages/plugin-docs-renderer/src/loader.ts
@@ -1,0 +1,74 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import type { Manifest, MarkdownFiles } from './types.js';
+
+/**
+ * Result of loading a docs folder.
+ */
+export interface LoadedDocs {
+  /**
+   * The parsed manifest.json.
+   */
+  manifest: Manifest;
+
+  /**
+   * All markdown files indexed by their relative path.
+   */
+  files: MarkdownFiles;
+}
+
+/**
+ * Recursively finds all markdown files in a directory.
+ *
+ * @param dir - The directory to search
+ * @param baseDir - The base directory for calculating relative paths
+ * @returns Array of absolute file paths
+ */
+async function findMarkdownFiles(dir: string, baseDir: string): Promise<string[]> {
+  const files: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      // recursively search subdirectories
+      const subFiles = await findMarkdownFiles(fullPath, baseDir);
+      files.push(...subFiles);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Loads a documentation folder containing manifest.json and markdown files.
+ *
+ * @param rootPath - The absolute path to the docs folder
+ * @returns The loaded manifest and markdown files
+ * @throws {Error} If manifest.json is not found or invalid
+ */
+export async function loadDocsFolder(rootPath: string): Promise<LoadedDocs> {
+  // read and parse manifest.json
+  const manifestPath = join(rootPath, 'manifest.json');
+  const manifestContent = await readFile(manifestPath, 'utf-8');
+  const manifest = JSON.parse(manifestContent) as Manifest;
+
+  // find all markdown files
+  const markdownPaths = await findMarkdownFiles(rootPath, rootPath);
+
+  // read all markdown files
+  const files: MarkdownFiles = {};
+  for (const filePath of markdownPaths) {
+    const relativePath = relative(rootPath, filePath);
+    const content = await readFile(filePath, 'utf-8');
+    files[relativePath] = content;
+  }
+
+  return {
+    manifest,
+    files,
+  };
+}

--- a/packages/plugin-docs-renderer/src/parser.test.ts
+++ b/packages/plugin-docs-renderer/src/parser.test.ts
@@ -60,4 +60,29 @@ Body text here.`;
     expect(result.frontmatter).toEqual({});
     expect(result.html).toContain('<h1>Title</h1>');
   });
+
+  it('should sanitize potentially dangerous HTML', () => {
+    const markdown = `
+# Test
+
+<script>alert('xss')</script>
+
+<img src="x" onerror="alert('xss')">
+
+Regular content.
+`;
+
+    const result = parseMarkdown(markdown);
+
+    // script tags should be removed
+    expect(result.html).not.toContain('<script>');
+    expect(result.html).not.toContain('alert(');
+
+    // event handlers should be removed
+    expect(result.html).not.toContain('onerror');
+
+    // safe content should remain
+    expect(result.html).toContain('<h1>Test</h1>');
+    expect(result.html).toContain('<p>Regular content.</p>');
+  });
 });

--- a/packages/plugin-docs-renderer/src/parser.test.ts
+++ b/packages/plugin-docs-renderer/src/parser.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { parseMarkdown } from './parser.js';
+
+describe('parseMarkdown', () => {
+  it('should parse simple markdown to HTML', () => {
+    const markdown = '# Hello World\n\nThis is a paragraph.';
+    const result = parseMarkdown(markdown);
+
+    expect(result.html).toContain('<h1>Hello World</h1>');
+    expect(result.html).toContain('<p>This is a paragraph.</p>');
+    expect(result.frontmatter).toEqual({});
+  });
+
+  it('should extract frontmatter', () => {
+    const markdown = `---
+title: Test Page
+description: A test page
+---
+# Content
+
+Body text here.`;
+
+    const result = parseMarkdown(markdown);
+
+    expect(result.frontmatter).toEqual({
+      title: 'Test Page',
+      description: 'A test page',
+    });
+    expect(result.html).toContain('<h1>Content</h1>');
+    expect(result.html).toContain('<p>Body text here.</p>');
+  });
+
+  it('should handle GitHub Flavored Markdown tables', () => {
+    const markdown = `| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |`;
+
+    const result = parseMarkdown(markdown);
+
+    expect(result.html).toContain('<table>');
+    expect(result.html).toContain('<th>Header 1</th>');
+    expect(result.html).toContain('<td>Cell 1</td>');
+  });
+
+  it('should handle code blocks', () => {
+    const markdown = '```typescript\nconst x = 42;\n```';
+    const result = parseMarkdown(markdown);
+
+    expect(result.html).toContain('<code');
+    expect(result.html).toContain('const x = 42;');
+  });
+
+  it('should handle empty frontmatter', () => {
+    const markdown = `---
+---
+# Title`;
+
+    const result = parseMarkdown(markdown);
+
+    expect(result.frontmatter).toEqual({});
+    expect(result.html).toContain('<h1>Title</h1>');
+  });
+});

--- a/packages/plugin-docs-renderer/src/parser.ts
+++ b/packages/plugin-docs-renderer/src/parser.ts
@@ -1,5 +1,6 @@
 import { marked } from 'marked';
 import matter from 'gray-matter';
+import DOMPurify from 'isomorphic-dompurify';
 
 /**
  * Result of parsing a markdown file.
@@ -33,7 +34,10 @@ export function parseMarkdown(content: string): ParsedMarkdown {
     breaks: false, // don't convert \n to <br>
   });
 
-  const html = marked.parse(markdownContent) as string;
+  const rawHtml = marked.parse(markdownContent) as string;
+
+  // sanitize HTML to prevent XSS attacks
+  const html = DOMPurify.sanitize(rawHtml);
 
   return {
     frontmatter,

--- a/packages/plugin-docs-renderer/src/parser.ts
+++ b/packages/plugin-docs-renderer/src/parser.ts
@@ -1,0 +1,42 @@
+import { marked } from 'marked';
+import matter from 'gray-matter';
+
+/**
+ * Result of parsing a markdown file.
+ */
+export interface ParsedMarkdown {
+  /**
+   * Frontmatter metadata extracted from the markdown file.
+   */
+  frontmatter: Record<string, unknown>;
+
+  /**
+   * The rendered HTML content.
+   */
+  html: string;
+}
+
+/**
+ * Parses markdown content and extracts frontmatter.
+ *
+ * @param content - The raw markdown content to parse
+ * @returns The parsed result with frontmatter and HTML
+ */
+export function parseMarkdown(content: string): ParsedMarkdown {
+  // extract frontmatter using gray-matter
+  const { data: frontmatter, content: markdownContent } = matter(content);
+
+  // parse markdown to HTML using marked
+  // configure marked to use GitHub Flavored Markdown
+  marked.setOptions({
+    gfm: true, // enable GitHub Flavored Markdown
+    breaks: false, // don't convert \n to <br>
+  });
+
+  const html = marked.parse(markdownContent) as string;
+
+  return {
+    frontmatter,
+    html,
+  };
+}

--- a/packages/plugin-docs-renderer/src/parser.ts
+++ b/packages/plugin-docs-renderer/src/parser.ts
@@ -1,6 +1,9 @@
 import { marked } from 'marked';
 import matter from 'gray-matter';
 import DOMPurify from 'isomorphic-dompurify';
+import createDebug from 'debug';
+
+const debug = createDebug('plugin-docs-renderer:parser');
 
 /**
  * Result of parsing a markdown file.
@@ -25,6 +28,8 @@ export interface ParsedMarkdown {
  * @throws {Error} If markdown parsing fails
  */
 export function parseMarkdown(content: string): ParsedMarkdown {
+  debug('Parsing markdown content (%d bytes)', content.length);
+
   // extract frontmatter using gray-matter
   let frontmatter: Record<string, unknown>;
   let markdownContent: string;
@@ -33,6 +38,7 @@ export function parseMarkdown(content: string): ParsedMarkdown {
     const result = matter(content);
     frontmatter = result.data;
     markdownContent = result.content;
+    debug('Extracted frontmatter with %d key(s)', Object.keys(frontmatter).length);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to extract frontmatter: ${message}`);
@@ -48,6 +54,7 @@ export function parseMarkdown(content: string): ParsedMarkdown {
   let rawHtml: string;
   try {
     rawHtml = marked.parse(markdownContent) as string;
+    debug('Parsed markdown to HTML (%d bytes)', rawHtml.length);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to parse markdown: ${message}`);
@@ -57,6 +64,7 @@ export function parseMarkdown(content: string): ParsedMarkdown {
   let html: string;
   try {
     html = DOMPurify.sanitize(rawHtml);
+    debug('Sanitized HTML (%d bytes)', html.length);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to sanitize HTML: ${message}`);


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements the core markdown parsing functionality for the `plugin-docs-renderer` package. It adds the ability to load documentation folders inc. manifest.json files, parse markdown content with YAML frontmatter and convert to HTML using GH flavored markdown. The package includes a CLI tool that processes a docs folder and dumps parsed JSON to stdout.

To test this: 
This [PR](https://github.com/grafana/grafana-polystat-panel/pull/517) in the polystat panel has markdown docs + a manifest file with nested docs tree that can be used for testing. 
```bash
npx @grafana/plugin-docs-renderer ./docs
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-community-team/issues/737

**Special notes for your reviewer**:

The next couple of PRs will add template rendering, validation and a local dev server. Will add more unit tests then. 
