### PR TITLE
fix: reduce false positives

### DIFF
--- a/packages/react-detect/src/patterns/matcher.test.ts
+++ b/packages/react-detect/src/patterns/matcher.test.ts
@@ -142,7 +142,7 @@ describe('matcher', () => {
       expect(matches[0].matched).toContain('ReactDOM.findDOMNode');
     });
 
-    it('should find direct findDOMNode calls', () => {
+    it('should match findDOMNode imported from react-dom', () => {
       const code = `
       import { findDOMNode } from 'react-dom';
       const node = findDOMNode(component);
@@ -152,6 +152,115 @@ describe('matcher', () => {
 
       expect(matches).toHaveLength(1);
       expect(matches[0].pattern).toBe('findDOMNode');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should handle renamed imports from react-dom', () => {
+      const code = `
+      import { findDOMNode as findNode } from 'react-dom';
+      const node = findNode(component);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findFindDOMNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('findDOMNode');
+      expect(matches[0].line).toBe(3);
+      expect(matches[0].matched).toContain('findNode');
+    });
+
+    it('should match ReactDOM default import with MemberExpression', () => {
+      const code = `
+      import ReactDOM from 'react-dom';
+      const node = ReactDOM.findDOMNode(component);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findFindDOMNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('findDOMNode');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should match renamed ReactDOM default import', () => {
+      const code = `
+      import RD from 'react-dom';
+      const node = RD.findDOMNode(component);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findFindDOMNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('findDOMNode');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should handle CommonJS require from react-dom', () => {
+      const code = `
+      const { findDOMNode } = require('react-dom');
+      const node = findDOMNode(component);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findFindDOMNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('findDOMNode');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should detect multiple call sites from single import', () => {
+      const code = `
+      import { findDOMNode } from 'react-dom';
+      const node1 = findDOMNode(component1);
+      const node2 = findDOMNode(component2);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findFindDOMNode(ast, code);
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0].line).toBe(3);
+      expect(matches[1].line).toBe(4);
+    });
+
+    it('should handle mixed patterns from react-dom', () => {
+      const code = `
+      import ReactDOM from 'react-dom';
+      import { findDOMNode } from 'react-dom';
+      const node1 = ReactDOM.findDOMNode(component1);
+      const node2 = findDOMNode(component2);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findFindDOMNode(ast, code);
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0].line).toBe(4);
+      expect(matches[1].line).toBe(5);
+    });
+
+    it('should NOT match local findDOMNode function', () => {
+      const code = `
+      function findDOMNode(component) {
+        return component.element;
+      }
+      const node = findDOMNode(component);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findFindDOMNode(ast, code);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should NOT match object method with same name', () => {
+      const code = `
+      const utils = {
+        findDOMNode: (component) => component
+      };
+      const node = utils.findDOMNode(component);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findFindDOMNode(ast, code);
+
+      expect(matches).toHaveLength(0);
     });
   });
 
@@ -298,6 +407,136 @@ describe('matcher', () => {
       expect(matches[0].pattern).toBe('ReactDOM.unmountComponentAtNode');
       expect(matches[0].matched).toContain('ReactDOM.unmountComponentAtNode');
     });
+
+    it('should match unmountComponentAtNode imported from react-dom', () => {
+      const code = `
+      import { unmountComponentAtNode } from 'react-dom';
+      unmountComponentAtNode(container);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('ReactDOM.unmountComponentAtNode');
+      expect(matches[0].line).toBe(3); // Call site, not import line
+    });
+
+    it('should handle renamed imports', () => {
+      const code = `
+      import { unmountComponentAtNode as unmount } from 'react-dom';
+      unmount(container);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('ReactDOM.unmountComponentAtNode');
+      expect(matches[0].line).toBe(3);
+      expect(matches[0].matched).toContain('unmount');
+    });
+
+    it('should match default import with MemberExpression', () => {
+      const code = `
+      import ReactDOM from 'react-dom';
+      ReactDOM.unmountComponentAtNode(container);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('ReactDOM.unmountComponentAtNode');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should match renamed default import', () => {
+      const code = `
+      import RD from 'react-dom';
+      RD.unmountComponentAtNode(container);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('ReactDOM.unmountComponentAtNode');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should handle CommonJS require', () => {
+      const code = `
+      const { unmountComponentAtNode } = require('react-dom');
+      unmountComponentAtNode(container);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('ReactDOM.unmountComponentAtNode');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should detect multiple call sites from single import', () => {
+      const code = `
+      import { unmountComponentAtNode } from 'react-dom';
+      unmountComponentAtNode(container1);
+      unmountComponentAtNode(container2);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0].line).toBe(3);
+      expect(matches[1].line).toBe(4);
+    });
+
+    it('should handle mixed patterns in same file', () => {
+      const code = `
+      import ReactDOM from 'react-dom';
+      import { unmountComponentAtNode } from 'react-dom';
+      ReactDOM.unmountComponentAtNode(container1);
+      unmountComponentAtNode(container2);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0].line).toBe(4);
+      expect(matches[1].line).toBe(5);
+    });
+
+    it('should NOT match local unmountComponentAtNode function', () => {
+      const code = `
+      function unmountComponentAtNode(container) {
+        return container;
+      }
+      unmountComponentAtNode(container);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(0); // No matches - not from react-dom
+    });
+
+    it('should NOT match with invalid argument count (0 args)', () => {
+      const code = `
+      import { unmountComponentAtNode } from 'react-dom';
+      unmountComponentAtNode();
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should NOT match with invalid argument count (2 args)', () => {
+      const code = `
+      import { unmountComponentAtNode } from 'react-dom';
+      unmountComponentAtNode(container, extra);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findReactDOMUnmountComponentAtNode(ast, code);
+
+      expect(matches).toHaveLength(0);
+    });
   });
 
   describe('findCreateFactory', () => {
@@ -311,6 +550,136 @@ describe('matcher', () => {
       expect(matches).toHaveLength(1);
       expect(matches[0].pattern).toBe('createFactory');
       expect(matches[0].matched).toContain('createFactory');
+    });
+
+    it('should match createFactory imported from react', () => {
+      const code = `
+      import { createFactory } from 'react';
+      const Button = createFactory('button');
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('createFactory');
+      expect(matches[0].line).toBe(3); // Call site, not import line
+    });
+
+    it('should handle renamed imports', () => {
+      const code = `
+      import { createFactory as factory } from 'react';
+      const Button = factory('button');
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('createFactory');
+      expect(matches[0].line).toBe(3);
+      expect(matches[0].matched).toContain('factory');
+    });
+
+    it('should match default import with MemberExpression', () => {
+      const code = `
+      import React from 'react';
+      const Button = React.createFactory('button');
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('createFactory');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should match renamed default import', () => {
+      const code = `
+      import R from 'react';
+      const Button = R.createFactory('button');
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('createFactory');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should handle CommonJS require', () => {
+      const code = `
+      const { createFactory } = require('react');
+      const Button = createFactory('button');
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].pattern).toBe('createFactory');
+      expect(matches[0].line).toBe(3);
+    });
+
+    it('should detect multiple call sites from single import', () => {
+      const code = `
+      import { createFactory } from 'react';
+      const Button = createFactory('button');
+      const Input = createFactory('input');
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0].line).toBe(3);
+      expect(matches[1].line).toBe(4);
+    });
+
+    it('should handle mixed patterns in same file', () => {
+      const code = `
+      import React from 'react';
+      import { createFactory } from 'react';
+      const Button = React.createFactory('button');
+      const Input = createFactory('input');
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(2);
+      expect(matches[0].line).toBe(4);
+      expect(matches[1].line).toBe(5);
+    });
+
+    it('should NOT match local createFactory function', () => {
+      const code = `
+      function createFactory(type) {
+        return { type };
+      }
+      const Button = createFactory('button');
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(0); // No matches - not from react
+    });
+
+    it('should NOT match with invalid argument count (0 args)', () => {
+      const code = `
+      import { createFactory } from 'react';
+      const Empty = createFactory();
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should NOT match with invalid argument count (2 args)', () => {
+      const code = `
+      import { createFactory } from 'react';
+      const Button = createFactory('button', extraArg);
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findCreateFactory(ast, code);
+
+      expect(matches).toHaveLength(0);
     });
   });
 });

--- a/packages/react-detect/src/patterns/matcher.ts
+++ b/packages/react-detect/src/patterns/matcher.ts
@@ -24,13 +24,7 @@ export function findDefaultProps(ast: TSESTree.Program, code: string): PatternMa
   const matches: PatternMatch[] = [];
 
   walk(ast, (node) => {
-    if (
-      node &&
-      node.type === 'AssignmentExpression' &&
-      node.left.type === 'MemberExpression' &&
-      node.left.property.type === 'Identifier' &&
-      node.left.property.name === 'defaultProps'
-    ) {
+    if (isAssignmentToProperty(node, 'defaultProps')) {
       matches.push(createPatternMatch(node, 'defaultProps', code));
     }
   });
@@ -42,13 +36,7 @@ export function findPropTypes(ast: TSESTree.Program, code: string): PatternMatch
   const matches: PatternMatch[] = [];
 
   walk(ast, (node) => {
-    if (
-      node &&
-      node.type === 'AssignmentExpression' &&
-      node.left.type === 'MemberExpression' &&
-      node.left.property.type === 'Identifier' &&
-      node.left.property.name === 'propTypes'
-    ) {
+    if (isAssignmentToProperty(node, 'propTypes')) {
       matches.push(createPatternMatch(node, 'propTypes', code));
     }
   });
@@ -60,13 +48,7 @@ export function findContextTypes(ast: TSESTree.Program, code: string): PatternMa
   const matches: PatternMatch[] = [];
 
   walk(ast, (node) => {
-    if (
-      node &&
-      node.type === 'AssignmentExpression' &&
-      node.left.type === 'MemberExpression' &&
-      node.left.property.type === 'Identifier' &&
-      node.left.property.name === 'contextTypes'
-    ) {
+    if (isAssignmentToProperty(node, 'contextTypes')) {
       matches.push(createPatternMatch(node, 'contextTypes', code));
     }
   });
@@ -78,13 +60,7 @@ export function findGetChildContext(ast: TSESTree.Program, code: string): Patter
   const matches: PatternMatch[] = [];
 
   walk(ast, (node) => {
-    if (
-      node &&
-      node.type === 'AssignmentExpression' &&
-      node.left.type === 'MemberExpression' &&
-      node.left.property.type === 'Identifier' &&
-      node.left.property.name === 'getChildContext'
-    ) {
+    if (isAssignmentToProperty(node, 'getChildContext')) {
       matches.push(createPatternMatch(node, 'getChildContext', code));
     }
   });
@@ -152,15 +128,7 @@ export function findFindDOMNode(ast: TSESTree.Program, code: string): PatternMat
       return;
     }
 
-    if (
-      node.callee &&
-      node.callee.type === 'MemberExpression' &&
-      node.callee.object &&
-      node.callee.object.type === 'Identifier' &&
-      node.callee.property &&
-      node.callee.property.type === 'Identifier' &&
-      node.callee.property.name === 'findDOMNode'
-    ) {
+    if (isMemberExpressionWithIdentifier(node.callee, 'findDOMNode')) {
       const objectName = node.callee.object.name;
       if (imports.defaultImports.has(objectName) || objectName === 'ReactDOM') {
         matches.push(createPatternMatch(node, 'findDOMNode', code));
@@ -168,7 +136,7 @@ export function findFindDOMNode(ast: TSESTree.Program, code: string): PatternMat
     }
 
     // Find findDOMNode(...) if imported from react-dom
-    if (node.callee && node.callee.type === 'Identifier' && findDOMNodeLocalNames.has(node.callee.name)) {
+    if (node.callee?.type === 'Identifier' && findDOMNodeLocalNames.has(node.callee.name)) {
       matches.push(createPatternMatch(node, 'findDOMNode', code));
     }
   });
@@ -188,16 +156,7 @@ export function findReactDOMRender(ast: TSESTree.Program, code: string): Pattern
 
     const hasValidArgs = node.arguments.length === 2 || node.arguments.length === 3;
 
-    if (
-      node.callee &&
-      node.callee.type === 'MemberExpression' &&
-      node.callee.object &&
-      node.callee.object.type === 'Identifier' &&
-      node.callee.property &&
-      node.callee.property.type === 'Identifier' &&
-      node.callee.property.name === 'render' &&
-      hasValidArgs
-    ) {
+    if (isMemberExpressionWithIdentifier(node.callee, 'render') && hasValidArgs) {
       const objectName = node.callee.object.name;
       if (imports.defaultImports.has(objectName) || objectName === 'ReactDOM') {
         matches.push(createPatternMatch(node, 'ReactDOM.render', code));
@@ -205,7 +164,7 @@ export function findReactDOMRender(ast: TSESTree.Program, code: string): Pattern
     }
 
     // Find render(...) if imported from react-dom
-    if (node.callee && node.callee.type === 'Identifier' && renderLocalNames.has(node.callee.name) && hasValidArgs) {
+    if (node.callee?.type === 'Identifier' && renderLocalNames.has(node.callee.name) && hasValidArgs) {
       matches.push(createPatternMatch(node, 'ReactDOM.render', code));
     }
   });
@@ -225,16 +184,7 @@ export function findReactDOMUnmountComponentAtNode(ast: TSESTree.Program, code: 
 
     const hasValidArgs = node.arguments.length === 1;
 
-    if (
-      node.callee &&
-      node.callee.type === 'MemberExpression' &&
-      node.callee.object &&
-      node.callee.object.type === 'Identifier' &&
-      node.callee.property &&
-      node.callee.property.type === 'Identifier' &&
-      node.callee.property.name === 'unmountComponentAtNode' &&
-      hasValidArgs
-    ) {
+    if (isMemberExpressionWithIdentifier(node.callee, 'unmountComponentAtNode') && hasValidArgs) {
       const objectName = node.callee.object.name;
       if (imports.defaultImports.has(objectName) || objectName === 'ReactDOM') {
         matches.push(createPatternMatch(node, 'ReactDOM.unmountComponentAtNode', code));
@@ -242,7 +192,7 @@ export function findReactDOMUnmountComponentAtNode(ast: TSESTree.Program, code: 
     }
 
     // Find unmountComponentAtNode(...) if imported from react-dom
-    if (node.callee && node.callee.type === 'Identifier' && unmountLocalNames.has(node.callee.name) && hasValidArgs) {
+    if (node.callee?.type === 'Identifier' && unmountLocalNames.has(node.callee.name) && hasValidArgs) {
       matches.push(createPatternMatch(node, 'ReactDOM.unmountComponentAtNode', code));
     }
   });
@@ -262,33 +212,47 @@ export function findCreateFactory(ast: TSESTree.Program, code: string): PatternM
 
     const hasValidArgs = node.arguments.length === 1;
 
-    if (
-      node.callee &&
-      node.callee.type === 'MemberExpression' &&
-      node.callee.object &&
-      node.callee.object.type === 'Identifier' &&
-      node.callee.property &&
-      node.callee.property.type === 'Identifier' &&
-      node.callee.property.name === 'createFactory' &&
-      hasValidArgs
-    ) {
+    if (isMemberExpressionWithIdentifier(node.callee, 'createFactory') && hasValidArgs) {
       if (imports.defaultImports.has(node.callee.object.name) || node.callee.object.name === 'React') {
         matches.push(createPatternMatch(node, 'createFactory', code));
       }
     }
 
     // Find createFactory(...) if imported from react
-    if (
-      node.callee &&
-      node.callee.type === 'Identifier' &&
-      createFactoryLocalNames.has(node.callee.name) &&
-      hasValidArgs
-    ) {
+    if (node.callee?.type === 'Identifier' && createFactoryLocalNames.has(node.callee.name) && hasValidArgs) {
       matches.push(createPatternMatch(node, 'createFactory', code));
     }
   });
 
   return matches;
+}
+
+function isMemberExpressionWithIdentifier(
+  node: TSESTree.Node | null | undefined,
+  propertyName: string
+): node is TSESTree.MemberExpression & { property: TSESTree.Identifier; object: TSESTree.Identifier } {
+  return (
+    node?.type === 'MemberExpression' &&
+    node.object?.type === 'Identifier' &&
+    node.property?.type === 'Identifier' &&
+    node.property.name === propertyName
+  );
+}
+
+function isAssignmentToProperty(
+  node: TSESTree.Node | null | undefined,
+  propertyName: string
+): node is TSESTree.AssignmentExpression & {
+  left: TSESTree.MemberExpression & {
+    property: TSESTree.Identifier;
+  };
+} {
+  return (
+    node?.type === 'AssignmentExpression' &&
+    node.left?.type === 'MemberExpression' &&
+    node.left.property?.type === 'Identifier' &&
+    node.left.property.name === propertyName
+  );
 }
 
 export function createPatternMatch(node: any, pattern: string, code: string): PatternMatch {

--- a/packages/react-detect/src/reporters/console.ts
+++ b/packages/react-detect/src/reporters/console.ts
@@ -4,15 +4,16 @@ import { output } from '../utils/output.js';
 import { groupByPattern, groupByPackage } from './utils.js';
 
 const summaryMsg = [
-  `We strongly recommend testing your plugin using the React 19 Grafana docker image: ${output.formatCode('grafana/grafana:dev-preview-react19')}`,
+  `We strongly recommend testing your plugin using the React 19 Grafana docker image: ${output.formatCode('grafana/grafana-enterprise:dev-preview-react19')}`,
   ...output.bulletList([
-    `Start the server with ${output.formatCode('GRAFANA_VERSION=dev-preview-react19 GRAFANA_IMAGE=grafana docker compose up --build')} flag and manually test your plugin.`,
+    `Start the server with ${output.formatCode('GRAFANA_VERSION=dev-preview-react19 docker compose up --build')} flag and manually test your plugin.`,
     'Run any e2e tests to try and catch any potential issues.',
     'Manually test your plugin in the browser. Look for any console warnings or errors related to React.',
   ]),
   '',
   'For more information, please refer to:',
   `React 19 blog post: ${output.formatUrl('https://react.dev/blog/2024/04/25/react-19-upgrade-guide')}.`,
+  `Grafana React 19 announcement: ${output.formatUrl('https://grafana.com/blog/react-19-is-coming-to-grafana-what-plugin-developers-need-to-know/')}`,
   `Grafana developer documentation: ${output.formatUrl('https://grafana.com/developers/plugin-tools/set-up/set-up-docker')}`,
 ];
 

--- a/packages/react-detect/src/results.test.ts
+++ b/packages/react-detect/src/results.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateAnalysisResults, AnalysisOptions } from './results.js';
+import { AnalyzedMatch } from './types/processors.js';
+import { DependencyContext } from './utils/dependencies.js';
+
+// Mock the plugin utils to avoid needing a real plugin.json file
+vi.mock('./utils/plugin.js', () => ({
+  getPluginJson: vi.fn(() => ({
+    id: 'test-plugin',
+    name: 'Test Plugin',
+    type: 'app',
+    info: {
+      version: '1.0.0',
+    },
+  })),
+  hasExternalisedJsxRuntime: vi.fn(() => false),
+}));
+
+describe('generateAnalysisResults', () => {
+  const createDependencyMatch = (
+    packageName: string,
+    rootDependency: string,
+    pattern = '__SECRET_INTERNALS'
+  ): AnalyzedMatch => ({
+    pattern,
+    type: 'dependency',
+    confidence: 'high',
+    packageName,
+    rootDependency,
+    sourceFile: `node_modules/${packageName}/index.js`,
+    sourceLine: 1,
+    sourceColumn: 0,
+    componentType: 'unknown',
+    matched: '',
+    context: '',
+    bundledFilePath: `node_modules/${packageName}/index.js`,
+  });
+
+  const pluginRoot = process.cwd();
+  const depContext = new DependencyContext();
+  const options: AnalysisOptions = {
+    skipBuildTooling: true,
+    skipDependencies: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('externalized dependency filtering', () => {
+    it('should never filter source code matches, only dependencies', () => {
+      const sourceMatch: AnalyzedMatch = {
+        pattern: 'defaultProps',
+        type: 'source',
+        confidence: 'high',
+        packageName: undefined,
+        rootDependency: undefined,
+        sourceFile: 'src/components/MyComponent.tsx',
+        sourceLine: 10,
+        sourceColumn: 5,
+        componentType: 'function',
+        matched: 'defaultProps',
+        context: 'MyComponent.defaultProps = {}',
+        bundledFilePath: 'src/components/MyComponent.tsx',
+      };
+      const matches: AnalyzedMatch[] = [sourceMatch, createDependencyMatch('react', 'react')];
+      const results = generateAnalysisResults(matches, pluginRoot, depContext, options);
+
+      expect(results.summary.sourceIssuesCount).toBe(1);
+      expect(results.summary.dependencyIssuesCount).toBe(0);
+    });
+
+    it('should filter externalized dependencies but not user packages', () => {
+      const matches: AnalyzedMatch[] = [
+        createDependencyMatch('lodash', 'lodash'), // lodash is externalized by Grafana
+        createDependencyMatch('axios', 'axios'),
+      ];
+      const results = generateAnalysisResults(matches, pluginRoot, depContext, options);
+
+      expect(results.issues.dependencies).toHaveLength(1);
+      expect(results.issues.dependencies[0].packageName).toBe('axios');
+    });
+
+    it('should filter scoped externalized packages (@grafana/*)', () => {
+      const matches: AnalyzedMatch[] = [
+        createDependencyMatch('@grafana/data', '@grafana/data'),
+        createDependencyMatch('@grafana/ui', '@grafana/ui'),
+        createDependencyMatch('@custom/package', '@custom/package'),
+      ];
+      const results = generateAnalysisResults(matches, pluginRoot, depContext, options);
+
+      expect(results.issues.dependencies).toHaveLength(1);
+      expect(results.issues.dependencies[0].packageName).toBe('@custom/package');
+    });
+
+    it('should filter subpath imports of externalized packages', () => {
+      const matches: AnalyzedMatch[] = [
+        createDependencyMatch('@grafana/data/utils', '@grafana/data'),
+        createDependencyMatch('@custom/package/utils', '@custom/package'),
+      ];
+      const results = generateAnalysisResults(matches, pluginRoot, depContext, options);
+
+      expect(results.issues.dependencies).toHaveLength(1);
+      expect(results.issues.dependencies[0].packageName).toBe('@custom/package/utils');
+    });
+
+    it('should filter transitive dependencies with externalized root', () => {
+      // Real-world scenario: prop-types is bundled by react, scheduler by react
+      const matches: AnalyzedMatch[] = [
+        createDependencyMatch('prop-types', 'react'),
+        createDependencyMatch('scheduler', 'react'),
+        createDependencyMatch('debug', 'axios'), // Non-externalized root dependency
+      ];
+      const results = generateAnalysisResults(matches, pluginRoot, depContext, options);
+
+      expect(results.issues.dependencies).toHaveLength(1);
+      expect(results.issues.dependencies[0].packageName).toBe('debug');
+      expect(results.issues.dependencies[0].rootDependency).toBe('axios');
+    });
+
+    it('should filter externalized deps from critical and warnings arrays used by reporters', () => {
+      // This tests the actual consumption path - console reporter reads from critical/warnings
+      const matches: AnalyzedMatch[] = [
+        createDependencyMatch('react', 'react'),
+        createDependencyMatch('@grafana/data', '@grafana/data'),
+        createDependencyMatch('axios', 'axios'),
+      ];
+      const results = generateAnalysisResults(matches, pluginRoot, depContext, options);
+      // Filter to only critical dep issues
+      const reportedDeps = results.issues.critical.filter((i) => i.location.type === 'dependency');
+      expect(reportedDeps).toHaveLength(1);
+      expect(reportedDeps[0].packageName).toBe('axios');
+    });
+  });
+});

--- a/packages/react-detect/src/results.ts
+++ b/packages/react-detect/src/results.ts
@@ -2,7 +2,7 @@ import { AnalyzedMatch } from './types/processors.js';
 import { PluginAnalysisResults, AnalysisResult, DependencyIssue } from './types/reporters.js';
 import { getPattern } from './patterns/definitions.js';
 import { getPluginJson, hasExternalisedJsxRuntime } from './utils/plugin.js';
-import { DependencyContext } from './utils/dependencies.js';
+import { DependencyContext, isExternal } from './utils/dependencies.js';
 import path from 'node:path';
 
 export interface AnalysisOptions {
@@ -18,15 +18,19 @@ export function generateAnalysisResults(
 ): PluginAnalysisResults {
   const filtered = filterMatches(matches, options.skipBuildTooling);
   const pluginJson = getPluginJson(pluginRoot);
-  const sourceMatches = filtered.filter((m) => m.type === 'source');
-  const dependencyMatches = filtered.filter((m) => m.type === 'dependency');
 
-  const criticalMatches = filtered.filter((m) => {
+  // Filter out externalized dependencies and known compatible versions
+  const filteredWithoutExternals = filtered.filter((match) => shouldIncludeDependencyMatch(match, depContext));
+
+  const sourceMatches = filteredWithoutExternals.filter((m) => m.type === 'source');
+  const dependencyMatches = filteredWithoutExternals.filter((m) => m.type === 'dependency');
+
+  const criticalMatches = filteredWithoutExternals.filter((m) => {
     const pattern = getPattern(m.pattern);
     return pattern?.impactLevel === 'critical';
   });
 
-  const warningMatches = filtered.filter((m) => {
+  const warningMatches = filteredWithoutExternals.filter((m) => {
     const pattern = getPattern(m.pattern);
     return pattern?.impactLevel === 'warning';
   });
@@ -35,9 +39,9 @@ export function generateAnalysisResults(
   const warnings = warningMatches.map((m) => generateResult(m));
   const dependencies = buildDependencyIssues(dependencyMatches, depContext);
 
-  const totalIssues = filtered.length;
+  const totalIssues = filteredWithoutExternals.length;
   const affectedDeps = new Set(
-    dependencyMatches.map((m) => m.packageName).filter((name): name is string => name !== undefined)
+    dependencies.map((m) => m.packageName).filter((name): name is string => name !== undefined)
   );
 
   return {
@@ -52,7 +56,7 @@ export function generateAnalysisResults(
       critical: critical.length,
       warnings: warnings.length,
       sourceIssuesCount: sourceMatches.length,
-      dependencyIssuesCount: dependencyMatches.length,
+      dependencyIssuesCount: dependencies.length,
       status: totalIssues > 0 ? 'action_required' : 'no_action_required',
       affectedDependencies: Array.from(affectedDeps),
       analyzedBuildTooling: !options.skipBuildTooling,
@@ -64,6 +68,39 @@ export function generateAnalysisResults(
       dependencies,
     },
   };
+}
+
+/**
+ * Determines whether a match should be included in the analysis results.
+ *
+ * This function filters out:
+ * - Externalized dependencies provided by Grafana at runtime (react, @grafana/*, etc.)
+ * - Dependencies with versions known to be compatible with React 18 and 19 (to be implemented)
+ *
+ * @param match - The analyzed match to check
+ * @param _depContext - Dependency context for version lookups (reserved for future use)
+ * @returns true if the match should be included in results, false if it should be filtered out
+ */
+function shouldIncludeDependencyMatch(match: AnalyzedMatch, _depContext: DependencyContext | null): boolean {
+  // Always include source code matches
+  if (match.type === 'source') {
+    return true;
+  }
+
+  // Filter out externalized dependencies provided by Grafana
+  if (match.type === 'dependency' && match.rootDependency) {
+    if (isExternal(match.rootDependency)) {
+      return false;
+    }
+
+    // TODO: Add version-specific compatibility checks here
+    // Example: Check if dependency version is known to be compatible with React 18/19
+    // if (_depContext && isKnownCompatibleVersion(match.packageName, _depContext.getVersion(match.packageName))) {
+    //   return false;
+    // }
+  }
+
+  return true;
 }
 
 function filterMatches(matches: AnalyzedMatch[], skipBuildTooling: boolean): AnalyzedMatch[] {

--- a/packages/react-detect/src/results.ts
+++ b/packages/react-detect/src/results.ts
@@ -19,7 +19,7 @@ export function generateAnalysisResults(
   const filtered = filterMatches(matches, options.skipBuildTooling);
   const pluginJson = getPluginJson(pluginRoot);
 
-  // Filter out externalized dependencies and known compatible versions
+  // Filter out externalized dependencies
   const filteredWithoutExternals = filtered.filter((match) => shouldIncludeDependencyMatch(match, depContext));
 
   const sourceMatches = filteredWithoutExternals.filter((m) => m.type === 'source');
@@ -70,34 +70,9 @@ export function generateAnalysisResults(
   };
 }
 
-/**
- * Determines whether a match should be included in the analysis results.
- *
- * This function filters out:
- * - Externalized dependencies provided by Grafana at runtime (react, @grafana/*, etc.)
- * - Dependencies with versions known to be compatible with React 18 and 19 (to be implemented)
- *
- * @param match - The analyzed match to check
- * @param _depContext - Dependency context for version lookups (reserved for future use)
- * @returns true if the match should be included in results, false if it should be filtered out
- */
 function shouldIncludeDependencyMatch(match: AnalyzedMatch, _depContext: DependencyContext | null): boolean {
-  // Always include source code matches
-  if (match.type === 'source') {
-    return true;
-  }
-
-  // Filter out externalized dependencies provided by Grafana
-  if (match.type === 'dependency' && match.rootDependency) {
-    if (isExternal(match.rootDependency)) {
-      return false;
-    }
-
-    // TODO: Add version-specific compatibility checks here
-    // Example: Check if dependency version is known to be compatible with React 18/19
-    // if (_depContext && isKnownCompatibleVersion(match.packageName, _depContext.getVersion(match.packageName))) {
-    //   return false;
-    // }
+  if (match.type === 'dependency' && match.rootDependency && isExternal(match.rootDependency)) {
+    return false;
   }
 
   return true;

--- a/packages/react-detect/src/utils/ast.ts
+++ b/packages/react-detect/src/utils/ast.ts
@@ -59,6 +59,9 @@ export function trackImportsFromPackage(ast: TSESTree.Program, packageName: stri
         if (spec.type === 'ImportDefaultSpecifier') {
           // e.g import symbol from packageName
           tracking.defaultImports.add(spec.local.name);
+        } else if (spec.type === 'ImportNamespaceSpecifier') {
+          // e.g import * as symbol from packageName
+          tracking.defaultImports.add(spec.local.name);
         } else if (spec.type === 'ImportSpecifier' && spec.imported && spec.imported.type === 'Identifier') {
           // import { symbol } from packageName OR import { symbol as localName } from packageName
           const importedName = spec.imported.name;

--- a/packages/react-detect/src/utils/ast.ts
+++ b/packages/react-detect/src/utils/ast.ts
@@ -1,3 +1,5 @@
+import type { TSESTree } from '@typescript-eslint/typescript-estree';
+
 export function walk(node: any, callback: (node: any) => void): void {
   callback(node);
   for (const key in node) {
@@ -16,4 +18,98 @@ export function getSurroundingCode(code: string, node: any): string {
   const startLine = Math.max(0, node.loc.start.line - 3);
   const endLine = Math.min(lines.length, node.loc.end.line + 2);
   return lines.slice(startLine, endLine).join('\n');
+}
+
+interface ImportTracking {
+  defaultImports: Set<string>; // Local names for default imports
+  namedImports: Map<string, Set<string>>; // Imported name -> Set of local names
+}
+
+/**
+ *
+ * @param ast - The AST to analyze
+ * @param packageName - The package name to track (e.g., 'react-dom')
+ *
+ * @example
+ * // For code: import ReactDOM from 'react-dom'
+ * // Returns: { defaultImports: Set(['ReactDOM']), namedImports: Map() }
+ *
+ * @example
+ * // For code: import { render } from 'react-dom'
+ * // Returns: { defaultImports: Set(), namedImports: Map([['render', Set(['render'])]]) }
+ *
+ * @example
+ * // For code: import { render as r } from 'react-dom'
+ * // Returns: { defaultImports: Set(), namedImports: Map([['render', Set(['r'])]]) }
+ */
+export function trackImportsFromPackage(ast: TSESTree.Program, packageName: string): ImportTracking {
+  const tracking: ImportTracking = {
+    defaultImports: new Set(),
+    namedImports: new Map(),
+  };
+
+  walk(ast, (node: TSESTree.Node) => {
+    if (!node) {
+      return;
+    }
+
+    // ES6 Import declarations
+    if (node.type === 'ImportDeclaration' && node.source && node.source.value === packageName) {
+      node.specifiers.forEach((spec) => {
+        if (spec.type === 'ImportDefaultSpecifier') {
+          // e.g import symbol from packageName
+          tracking.defaultImports.add(spec.local.name);
+        } else if (spec.type === 'ImportSpecifier' && spec.imported && spec.imported.type === 'Identifier') {
+          // import { symbol } from packageName OR import { symbol as localName } from packageName
+          const importedName = spec.imported.name;
+          const localName = spec.local.name;
+
+          if (!tracking.namedImports.has(importedName)) {
+            tracking.namedImports.set(importedName, new Set());
+          }
+          tracking.namedImports.get(importedName)?.add(localName);
+        }
+      });
+    }
+
+    // CommonJS require()
+    if (node.type === 'VariableDeclaration') {
+      node.declarations.forEach((decl) => {
+        if (
+          decl.init?.type === 'CallExpression' &&
+          decl.init.callee &&
+          decl.init.callee.type === 'Identifier' &&
+          decl.init.callee.name === 'require' &&
+          decl.init.arguments[0]?.type === 'Literal' &&
+          decl.init.arguments[0].value === packageName
+        ) {
+          if (decl.id.type === 'Identifier') {
+            // e.g const symbol = require('packageName')
+            tracking.defaultImports.add(decl.id.name);
+          } else if (decl.id.type === 'ObjectPattern') {
+            // e.g const { symbol } = require('packageName') OR const { symbol: localName } = require('packageName')
+            decl.id.properties.forEach((prop) => {
+              if (
+                prop.type === 'Property' &&
+                prop.key &&
+                prop.key.type === 'Identifier' &&
+                prop.value &&
+                prop.value.type === 'Identifier'
+              ) {
+                const importedName = prop.key.name;
+                const localName = prop.value.name;
+
+                if (!tracking.namedImports.has(importedName)) {
+                  tracking.namedImports.set(importedName, new Set());
+                }
+                tracking.namedImports.get(importedName)?.add(localName);
+              }
+            });
+          }
+        }
+      });
+    }
+  });
+
+  return tracking;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Whilst going through the list of [troublesome dependencies](https://ops.grafana-ops.net/d/ja2mrnc/react-19-breaking-changes-plugin-analysis?orgId=1&from=now-6h&to=now&timezone=utc&viewPanel=panel-9) and checking their source code to confirm if they're react 18 & 19 compatible I discovered a lot of false positives mostly due to matching function names like `render` or `findDOMNode`.

We've also had [a report of issues](https://github.com/grafana/grafana/issues/112798#issuecomment-3838938826) being raised by the react-detect cli for externalised dependencies which feels wrong as most plugins will use these externalised dependencies but none of the code is bundled.


Originally I'd planned to make this lib as naive as possible but having thought some more on it I think the solution I've got here to track imports from packages (e.g. `react` / `react-dom`) in the source files and then walk the AST checking if the Identifier name is listed in the imports should work. You can't import `findDOMNode` and then have a function with the same name in a js module, right?

For any deps that are externalised (either directly or indirectly due to their parent deps) I'm now filtering them out.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.8.4-canary.2434.21718739764.0
  npm install @grafana/plugin-docs-renderer@0.0.2-canary.2434.21718739764.0
  npm install @grafana/react-detect@0.5.2-canary.2434.21718739764.0
  # or 
  yarn add @grafana/create-plugin@6.8.4-canary.2434.21718739764.0
  yarn add @grafana/plugin-docs-renderer@0.0.2-canary.2434.21718739764.0
  yarn add @grafana/react-detect@0.5.2-canary.2434.21718739764.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
