### PR TITLE
Plugin E2E: Fix tab selector

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
-          skip-grafana-dev-image: false
+          skip-grafana-dev-image: true
           # limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
 
   playwright-tests:
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -88,6 +88,7 @@ export class PanelEditPage extends GrafanaPage {
    * Sets the visualization for the panel. This method will open the visualization picker, select the given visualization
    */
   async setVisualization(visualization: Visualization | string) {
+    const { components, constants } = this.ctx.selectors;
     const showPanelEditElement = this.getByGrafanaSelector('Show options pane');
     const showPanelEditElementCount = await showPanelEditElement.count();
     if (showPanelEditElementCount > 0) {
@@ -98,20 +99,20 @@ export class PanelEditPage extends GrafanaPage {
     // and also we need to check whether we're already rendering the viz picker or not since creating a new panel shows
     // the viz picker by default when the panel editor is opened
     if (semver.gte(this.ctx.grafanaVersion, '12.4.0')) {
-      const allVisualizationsTab = this.ctx.selectors.components.Tab.title('All visualizations');
+      const allVisualizationsTab = components.Tab.title(constants.Tab.title);
       if (!(await this.getByGrafanaSelector(allVisualizationsTab).isVisible())) {
-        await this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker).click();
+        await this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker).click();
       }
       await this.getByGrafanaSelector(allVisualizationsTab).click();
     } else {
-      await this.getByGrafanaSelector(this.ctx.selectors.components.PanelEditor.toggleVizPicker).click();
+      await this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker).click();
     }
 
-    await this.getByGrafanaSelector(this.ctx.selectors.components.PluginVisualization.item(visualization)).click();
+    await this.getByGrafanaSelector(components.PluginVisualization.item(visualization)).click();
 
     const vizSelector = semver.lt(this.ctx.grafanaVersion, '12.4.0')
-      ? this.ctx.selectors.components.PanelEditor.toggleVizPicker
-      : this.ctx.selectors.components.PanelEditor.OptionsPane.header;
+      ? components.PanelEditor.toggleVizPicker
+      : components.PanelEditor.OptionsPane.header;
     await expect(
       this.getByGrafanaSelector(vizSelector),
       `Could not set visualization to ${visualization}. Ensure the panel is installed.`

--- a/packages/plugin-e2e/src/selectors/versionedConstants.ts
+++ b/packages/plugin-e2e/src/selectors/versionedConstants.ts
@@ -21,6 +21,12 @@ export const versionedConstants = {
       [MIN_GRAFANA_VERSION]: () => 'div[class="rc-cascader-menus"]',
     },
   },
+  Tab: {
+    title: {
+      '12.4.0': 'Visualizations',
+      [MIN_GRAFANA_VERSION]: 'All visualizations',
+    },
+  },
 } satisfies VersionedSelectorGroup;
 
 export type VersionedConstants = typeof versionedConstants;


### PR DESCRIPTION

**What this PR does / why we need it**:

Manage viz tab titles as versioned constants. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.4.2-canary.2451.21989475524.0
  npm install @grafana/create-plugin@6.8.5-canary.2451.21989475524.0
  npm install @grafana/plugin-e2e@3.2.3-canary.2451.21989475524.0
  # or 
  yarn add website@5.4.2-canary.2451.21989475524.0
  yarn add @grafana/create-plugin@6.8.5-canary.2451.21989475524.0
  yarn add @grafana/plugin-e2e@3.2.3-canary.2451.21989475524.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
