### PR TITLE
feat: support reading lock files for plugins in monorepos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31280,6 +31280,18 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/pm-detect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/pm-detect/-/pm-detect-0.4.0.tgz",
+      "integrity": "sha512-I5dXStb8nrOhJS7DQjxtEjIDMyRaqwBneXKuX07iEra8ibocWhCV6sXe0EdenvLCb7HurfC/3V6yymILPYs0HA==",
+      "license": "MIT",
+      "bin": {
+        "pm-detect": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "license": "MIT",
@@ -40493,6 +40505,7 @@
         "@typescript-eslint/typescript-estree": "^8.46.2",
         "fast-glob": "^3.3.2",
         "minimist": "^1.2.8",
+        "pm-detect": "0.4.0",
         "snyk-nodejs-lockfile-parser": "^2.4.4",
         "source-map": "^0.7.4"
       },

--- a/packages/react-detect/package.json
+++ b/packages/react-detect/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@typescript-eslint/parser": "^8.46.2",
     "@typescript-eslint/typescript-estree": "^8.46.2",
+    "pm-detect": "0.4.0",
     "fast-glob": "^3.3.2",
     "minimist": "^1.2.8",
     "snyk-nodejs-lockfile-parser": "^2.4.4",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

React detect currently cannot read lock files when scanning plugins in monorepos. This prevents deeper dependency analysis to help plugin devs understand why a dep lives in their project. This PR addresses this by using the pm-detect npm packages getLockFilePath to traverse up the filesystem to find the closest lock file.

PluginRoot should be used when scanning plugins in monorepos. e.g.

`npx @grafana/react-detect@canary --pluginRoot="path/to/plugin/workspace/"`


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/react-detect@0.6.1-canary.2454.22070146094.0
  # or 
  yarn add @grafana/react-detect@0.6.1-canary.2454.22070146094.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
