### PR TITLE
Plugin E2E: Allow e2e OFREP logging to be disabled

### DIFF
--- a/packages/plugin-e2e/src/fixtures/page.ts
+++ b/packages/plugin-e2e/src/fixtures/page.ts
@@ -43,7 +43,7 @@ export const page: PageFixture = async (
   // set up OpenFeature OFREP route interception BEFORE navigation
   // only runs if openFeature flags are provided and Grafana version >= 12.1.0
   if (hasOpenFeature && gte(grafanaVersion, '12.1.0')) {
-    await setupOpenFeatureRoutes(page, openFeature.flags, openFeature.latency ?? 0, selectors);
+    await setupOpenFeatureRoutes(page, openFeature.flags, openFeature.latency ?? 0, openFeature.log ?? true, selectors);
   }
 
   await page.goto('/');

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -102,6 +102,7 @@ export type PluginOptions = {
    *       apiConfig: { tier: "premium" }, // object
    *     },
    *     latency: 200, // optional: artificial latency in ms for OFREP responses
+   *     log: false, // optional: disable logging for OFREP interception (defaults to true)
    *   },
    * });
    * ```
@@ -109,6 +110,7 @@ export type PluginOptions = {
   openFeature: {
     flags: Record<string, FeatureFlagValue>;
     latency?: number;
+    log?: boolean;
   };
 
   /**


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows the logging to be disabled for the OpenFeature OFREP interception, as it gets very noisy in test logs.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.4.0-canary.2455.22072272353.0
  # or 
  yarn add @grafana/plugin-e2e@3.4.0-canary.2455.22072272353.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
