### PR TITLE
Plugin E2E: Fix OFREP single flag evaluation

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
-          skip-grafana-dev-image: true
+          skip-grafana-dev-image: false
           # limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
 
   playwright-tests:

--- a/packages/plugin-e2e/src/fixtures/getOpenFeatureFlag.ts
+++ b/packages/plugin-e2e/src/fixtures/getOpenFeatureFlag.ts
@@ -13,7 +13,11 @@ export const getBooleanOpenFeatureFlag: GetBooleanOpenFeatureFlagFixture = async
 
       // make the request from within the page context to use the same authentication
       const result = await page.evaluate(async (flagUrl) => {
-        const response = await fetch(flagUrl);
+        const response = await fetch(flagUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ context: {} }),
+        });
 
         if (!response.ok) {
           return {

--- a/packages/plugin-e2e/src/fixtures/openFeature.ts
+++ b/packages/plugin-e2e/src/fixtures/openFeature.ts
@@ -147,11 +147,6 @@ export async function setupOpenFeatureRoutes(
   latency: number,
   selectors: PlaywrightArgs['selectors']
 ): Promise<void> {
-  console.log('@grafana/plugin-e2e: setting up OpenFeature OFREP interception', {
-    openFeature,
-    latency,
-  });
-
   // intercept bulk evaluation endpoint
   await page.route(selectors.apis.OpenFeature.ofrepBulkPattern, async (route) => {
     await handleBulkEvaluationRoute(route, openFeature, latency);


### PR DESCRIPTION
**What this PR does / why we need it**:

The `getBooleanOpenFeatureFlag` fixture was using GET for the OFREP single flag evaluation endpoint, but the OFREP spec requires POST. This incorrect HTTP verb caused noisy errors in CI logs, making it harder to spot real failures. This PR also removes a verbose console.log in the OFREP setup that was adding noise to CI output.

**Which issue(s) this PR fixes**:

Closes #2455

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.3.1-canary.2456.22088470243.0
  # or 
  yarn add @grafana/plugin-e2e@3.3.1-canary.2456.22088470243.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
