### PR TITLE
Plugin Docs CLI: Add build command

### DIFF
--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -2,6 +2,7 @@
 import minimist from 'minimist';
 import createDebug from 'debug';
 import { serve } from '../commands/serve.command.js';
+import { build } from '../commands/build.command.js';
 
 const debug = createDebug('plugin-docs-cli:main');
 
@@ -17,6 +18,7 @@ async function main() {
     console.error('');
     console.error('Commands:');
     console.error('  serve   Start the local docs preview server');
+    console.error('  build   Build docs for publishing (generates manifest, copies to dist/)');
     process.exit(1);
   }
 
@@ -35,6 +37,10 @@ async function main() {
         },
       });
       await serve(serveArgv);
+      break;
+    }
+    case 'build': {
+      await build();
       break;
     }
     default:

--- a/packages/plugin-docs-cli/src/commands/build.command.test.ts
+++ b/packages/plugin-docs-cli/src/commands/build.command.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, mkdir, writeFile, cp, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildDocs } from './build.command.js';
+
+describe('build', () => {
+  let tmpDir: string;
+  const fixturesPath = join(__dirname, '..', '__fixtures__');
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'plugin-docs-build-'));
+
+    // set up src/plugin.json
+    await mkdir(join(tmpDir, 'src'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'src', 'plugin.json'),
+      JSON.stringify({ type: 'datasource', name: 'Test Plugin', id: 'test-plugin', docsPath: 'docs' })
+    );
+
+    // copy test-docs fixture as the docs folder
+    await cp(join(fixturesPath, 'test-docs'), join(tmpDir, 'docs'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should generate manifest.json in the output directory', async () => {
+    await buildDocs(tmpDir);
+
+    const manifestPath = join(tmpDir, 'dist', 'docs', 'manifest.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+
+    expect(manifest.version).toBe('1');
+    expect(manifest.pages).toHaveLength(4);
+    expect(manifest.pages[0].title).toBe('Home Page');
+    expect(manifest.pages[0].slug).toBe('home');
+  });
+
+  it('should copy markdown files preserving directory structure', async () => {
+    await buildDocs(tmpDir);
+
+    const outputDir = join(tmpDir, 'dist', 'docs');
+
+    // top-level files
+    const homeContent = await readFile(join(outputDir, 'home.md'), 'utf-8');
+    expect(homeContent).toContain('# Welcome');
+
+    // nested files
+    const settingsContent = await readFile(join(outputDir, 'config', 'settings.md'), 'utf-8');
+    expect(settingsContent).toContain('# Settings');
+  });
+
+  it('should copy non-markdown assets', async () => {
+    await buildDocs(tmpDir);
+
+    const imgPath = join(tmpDir, 'dist', 'docs', 'img', 'test.png');
+    await expect(access(imgPath)).resolves.toBeUndefined();
+  });
+
+  it('should clean the output directory before building', async () => {
+    const outputDir = join(tmpDir, 'dist', 'docs');
+
+    // create a stale file in the output directory
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(join(outputDir, 'stale.txt'), 'should be removed');
+
+    await buildDocs(tmpDir);
+
+    await expect(access(join(outputDir, 'stale.txt'))).rejects.toThrow();
+  });
+
+  it('should include nested pages with children in manifest', async () => {
+    await buildDocs(tmpDir);
+
+    const manifestPath = join(tmpDir, 'dist', 'docs', 'manifest.json');
+    const manifest = JSON.parse(await readFile(manifestPath, 'utf-8'));
+
+    const configPage = manifest.pages.find((p: { slug: string }) => p.slug === 'config');
+    expect(configPage).toBeDefined();
+    expect(configPage.children).toHaveLength(2);
+    expect(configPage.children[0].slug).toBe('config/settings');
+  });
+
+  it('should throw when docs path does not exist', async () => {
+    // point to a non-existent docs folder
+    await writeFile(join(tmpDir, 'src', 'plugin.json'), JSON.stringify({ docsPath: 'nonexistent' }));
+
+    await expect(buildDocs(tmpDir)).rejects.toThrow('Docs path not found');
+  });
+
+  it('should throw when plugin.json is missing', async () => {
+    await rm(join(tmpDir, 'src', 'plugin.json'));
+
+    await expect(buildDocs(tmpDir)).rejects.toThrow('Could not find src/plugin.json');
+  });
+});

--- a/packages/plugin-docs-cli/src/commands/build.command.ts
+++ b/packages/plugin-docs-cli/src/commands/build.command.ts
@@ -1,0 +1,61 @@
+import { access, cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import createDebug from 'debug';
+import { resolveDocsPath } from '../utils/utils.plugin.js';
+import { scanDocsFolder } from '../scanner.js';
+
+const debug = createDebug('plugin-docs-cli:build');
+
+/**
+ * Builds plugin documentation for publishing.
+ *
+ * Scans the docs folder, generates a manifest from the filesystem structure
+ * and copies everything to dist/ for inclusion in the plugin archive.
+ *
+ * @param projectRoot - The root directory of the plugin project (defaults to cwd)
+ */
+export async function build(projectRoot?: string): Promise<void> {
+  const root = projectRoot || process.cwd();
+  debug('Build command invoked with projectRoot: %s', root);
+
+  // resolve docs path from plugin.json
+  const docsPath = await resolveDocsPath(root);
+
+  // validate docs path exists
+  try {
+    await access(docsPath);
+  } catch {
+    throw new Error(
+      `Docs path not found: ${docsPath}\nCheck that the "docsPath" in src/plugin.json points to an existing directory.`
+    );
+  }
+
+  // scan docs folder and generate manifest
+  const { manifest } = await scanDocsFolder(docsPath);
+
+  // determine output directory: dist/{relative docsPath}/
+  const relativeDocsPath = relative(root, docsPath);
+  const outputDir = join(root, 'dist', relativeDocsPath);
+  debug('Output directory: %s', outputDir);
+
+  // clean and recreate output directory
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  // copy entire docs folder to output (preserves .md files, images and other assets)
+  await cp(docsPath, outputDir, { recursive: true });
+  debug('Copied docs folder to %s', outputDir);
+
+  // write generated manifest
+  const manifestPath = join(outputDir, 'manifest.json');
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  debug('Wrote manifest to %s', manifestPath);
+
+  // count pages recursively
+  const countPages = (pages: typeof manifest.pages): number =>
+    pages.reduce((sum, page) => sum + 1 + (page.children ? countPages(page.children) : 0), 0);
+
+  console.log(`\n📦 Documentation built successfully`);
+  console.log(`✓ Pages: ${countPages(manifest.pages)}`);
+  console.log(`✓ Output: ${outputDir}\n`);
+}

--- a/packages/plugin-docs-cli/src/commands/serve.command.ts
+++ b/packages/plugin-docs-cli/src/commands/serve.command.ts
@@ -1,40 +1,10 @@
-import { access, readFile } from 'node:fs/promises';
-import { resolve, join } from 'node:path';
+import { access } from 'node:fs/promises';
 import type minimist from 'minimist';
 import createDebug from 'debug';
 import { startServer } from '../server/server.js';
+import { resolveDocsPath } from '../utils/utils.plugin.js';
 
 const debug = createDebug('plugin-docs-cli:serve');
-
-/**
- * Resolves the docs path by reading docsPath from src/plugin.json.
- *
- * @param projectRoot - The root directory of the plugin project (defaults to cwd)
- * @returns The resolved absolute path to the docs directory
- * @throws {Error} If plugin.json is missing or lacks docsPath
- */
-export async function resolveDocsPath(projectRoot?: string): Promise<string> {
-  const root = projectRoot || process.cwd();
-  const pluginJsonPath = join(root, 'src', 'plugin.json');
-  debug('Looking for plugin.json at: %s', pluginJsonPath);
-
-  let raw: string;
-  try {
-    raw = await readFile(pluginJsonPath, 'utf-8');
-  } catch {
-    throw new Error(`Could not find src/plugin.json in ${root}`);
-  }
-
-  const pluginJson: { docsPath?: string } = JSON.parse(raw);
-
-  if (!pluginJson.docsPath) {
-    throw new Error('"docsPath" is not set in src/plugin.json');
-  }
-
-  const docsPath = resolve(root, pluginJson.docsPath);
-  debug('Resolved docsPath from plugin.json: %s -> %s', pluginJson.docsPath, docsPath);
-  return docsPath;
-}
 
 export const serve = async (argv: minimist.ParsedArgs) => {
   debug('Serve command invoked with args: %O', argv);

--- a/packages/plugin-docs-cli/src/utils/utils.plugin.test.ts
+++ b/packages/plugin-docs-cli/src/utils/utils.plugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
-import { resolveDocsPath } from './serve.command.js';
+import { resolveDocsPath } from './utils.plugin.js';
 
 describe('resolveDocsPath', () => {
   const fixturesPath = join(__dirname, '..', '__fixtures__');

--- a/packages/plugin-docs-cli/src/utils/utils.plugin.ts
+++ b/packages/plugin-docs-cli/src/utils/utils.plugin.ts
@@ -1,0 +1,35 @@
+import { readFile } from 'node:fs/promises';
+import { resolve, join } from 'node:path';
+import createDebug from 'debug';
+
+const debug = createDebug('plugin-docs-cli:utils:plugin');
+
+/**
+ * Resolves the docs path by reading docsPath from src/plugin.json.
+ *
+ * @param projectRoot - The root directory of the plugin project (defaults to cwd)
+ * @returns The resolved absolute path to the docs directory
+ * @throws {Error} If plugin.json is missing or lacks docsPath
+ */
+export async function resolveDocsPath(projectRoot?: string): Promise<string> {
+  const root = projectRoot || process.cwd();
+  const pluginJsonPath = join(root, 'src', 'plugin.json');
+  debug('Looking for plugin.json at: %s', pluginJsonPath);
+
+  let raw: string;
+  try {
+    raw = await readFile(pluginJsonPath, 'utf-8');
+  } catch {
+    throw new Error(`Could not find src/plugin.json in ${root}`);
+  }
+
+  const pluginJson: { docsPath?: string } = JSON.parse(raw);
+
+  if (!pluginJson.docsPath) {
+    throw new Error('"docsPath" is not set in src/plugin.json');
+  }
+
+  const docsPath = resolve(root, pluginJson.docsPath);
+  debug('Resolved docsPath from plugin.json: %s -> %s', pluginJson.docsPath, docsPath);
+  return docsPath;
+}

--- a/packages/plugin-docs-cli/src/utils/utils.plugin.ts
+++ b/packages/plugin-docs-cli/src/utils/utils.plugin.ts
@@ -23,7 +23,12 @@ export async function resolveDocsPath(projectRoot?: string): Promise<string> {
     throw new Error(`Could not find src/plugin.json in ${root}`);
   }
 
-  const pluginJson: { docsPath?: string } = JSON.parse(raw);
+  let pluginJson: { docsPath?: string };
+  try {
+    pluginJson = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse ${pluginJsonPath}: ${error instanceof Error ? error.message : error}`);
+  }
 
   if (!pluginJson.docsPath) {
     throw new Error('"docsPath" is not set in src/plugin.json');


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a build command to `@grafana/plugin-docs-cli` that scans the docs folder, generates a manifest.json from the filesystem structure and frontmatter metadata and copies everything (markdown files, images, assets) to `dist/` for inclusion in the plugin archive. This is the CI/publishing counterpart to the existing serve comman. Both share the same scanner and manifest generation logic, but serve works in-memory for local development while build transfers the output to disk.

Local development (unchanged)
```ts
npx @grafana/plugin-docs-cli serve --reload
```

 CI / publishing (new)
```ts
npx @grafana/plugin-docs-cli build
```

**Which issue(s) this PR fixes**:

Part of the rich [plugin documentation initiative](https://github.com/grafana/grafana-catalog-team/issues/734).
Fixes https://github.com/grafana/grafana-catalog-team/issues/768
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
