### PR TITLE
Docs CLI: Add validation engine and `validate` command

### DIFF
--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
+import { access } from 'node:fs/promises';
 import minimist from 'minimist';
 import createDebug from 'debug';
+import { resolveDocsPath } from '../utils/utils.plugin.js';
 import { serve } from '../commands/serve.command.js';
-import { build } from '../commands/build.command.js';
+import { buildDocs } from '../commands/build.command.js';
+import { validateCommand } from '../commands/validate.command.js';
 
 const debug = createDebug('plugin-docs-cli:main');
 
@@ -17,8 +20,26 @@ async function main() {
     console.error('Usage: plugin-docs-cli <command> [options]');
     console.error('');
     console.error('Commands:');
-    console.error('  serve   Start the local docs preview server');
-    console.error('  build   Build docs for publishing (generates manifest, copies to dist/)');
+    console.error('  serve      Start the local docs preview server');
+    console.error('  build      Build docs for publishing (generates manifest, copies to dist/)');
+    console.error('  validate   Validate documentation (--json, --strict)');
+    process.exit(1);
+  }
+
+  // resolve docs path once for all commands.
+  let docsPath: string;
+  try {
+    docsPath = await resolveDocsPath();
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
+  }
+
+  try {
+    await access(docsPath);
+  } catch {
+    console.error(`Error: Path not found: ${docsPath}`);
+    console.error('Check that the "docsPath" in src/plugin.json points to an existing directory.');
     process.exit(1);
   }
 
@@ -36,11 +57,22 @@ async function main() {
           reload: false,
         },
       });
-      await serve(serveArgv);
+      await serve(serveArgv, docsPath);
       break;
     }
     case 'build': {
-      await build();
+      await buildDocs(process.cwd(), docsPath);
+      break;
+    }
+    case 'validate': {
+      const validateArgv = minimist(process.argv.slice(3), {
+        boolean: ['json', 'strict'],
+        default: {
+          json: false,
+          strict: false,
+        },
+      });
+      await validateCommand(validateArgv, docsPath);
       break;
     }
     default:
@@ -50,6 +82,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(err);
+  console.error(`Error: ${err instanceof Error ? err.message : err}`);
   process.exit(1);
 });

--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -22,7 +22,7 @@ async function main() {
     console.error('Commands:');
     console.error('  serve      Start the local docs preview server');
     console.error('  build      Build docs for publishing (generates manifest, copies to dist/)');
-    console.error('  validate   Validate documentation (--json, --strict)');
+    console.error('  validate   Validate documentation');
     process.exit(1);
   }
 
@@ -65,14 +65,7 @@ async function main() {
       break;
     }
     case 'validate': {
-      const validateArgv = minimist(process.argv.slice(3), {
-        boolean: ['json', 'strict'],
-        default: {
-          json: false,
-          strict: false,
-        },
-      });
-      await validateCommand(validateArgv, docsPath);
+      await validateCommand(docsPath);
       break;
     }
     default:

--- a/packages/plugin-docs-cli/src/commands/build.command.ts
+++ b/packages/plugin-docs-cli/src/commands/build.command.ts
@@ -1,30 +1,18 @@
-import { access, cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import createDebug from 'debug';
-import { resolveDocsPath } from '../utils/utils.plugin.js';
 import { scanDocsFolder } from '../scanner.js';
 
 const debug = createDebug('plugin-docs-cli:build');
 
 /**
- * Core build logic. Exported for testing.
+ * Core build logic.
  *
  * @param projectRoot - The root directory of the plugin project
+ * @param docsPath - Resolved absolute path to the docs directory
  */
-export async function buildDocs(projectRoot: string): Promise<void> {
-  debug('Build invoked with projectRoot: %s', projectRoot);
-
-  // resolve docs path from plugin.json
-  const docsPath = await resolveDocsPath(projectRoot);
-
-  // validate docs path exists
-  try {
-    await access(docsPath);
-  } catch {
-    throw new Error(
-      `Docs path not found: ${docsPath}\nCheck that the "docsPath" in src/plugin.json points to an existing directory.`
-    );
-  }
+export async function buildDocs(projectRoot: string, docsPath: string): Promise<void> {
+  debug('Build invoked with projectRoot: %s, docsPath: %s', projectRoot, docsPath);
 
   // scan docs folder and generate manifest
   const { manifest } = await scanDocsFolder(docsPath);
@@ -54,17 +42,4 @@ export async function buildDocs(projectRoot: string): Promise<void> {
   console.log(`\n📦 Documentation built successfully`);
   console.log(`✓ Pages: ${countPages(manifest.pages)}`);
   console.log(`✓ Output: ${outputDir}\n`);
-}
-
-/**
- * CLI entry point for the build command.
- * Handles errors and exits with appropriate codes.
- */
-export async function build(): Promise<void> {
-  try {
-    await buildDocs(process.cwd());
-  } catch (error) {
-    console.error(`Error: ${error instanceof Error ? error.message : error}`);
-    process.exit(1);
-  }
 }

--- a/packages/plugin-docs-cli/src/commands/serve.command.ts
+++ b/packages/plugin-docs-cli/src/commands/serve.command.ts
@@ -1,30 +1,11 @@
-import { access } from 'node:fs/promises';
 import type minimist from 'minimist';
 import createDebug from 'debug';
 import { startServer } from '../server/server.js';
-import { resolveDocsPath } from '../utils/utils.plugin.js';
 
 const debug = createDebug('plugin-docs-cli:serve');
 
-export const serve = async (argv: minimist.ParsedArgs) => {
+export const serve = async (argv: minimist.ParsedArgs, docsPath: string) => {
   debug('Serve command invoked with args: %O', argv);
-
-  let docsPath: string;
-  try {
-    docsPath = await resolveDocsPath();
-  } catch (error) {
-    console.error(`Error: ${error instanceof Error ? error.message : error}`);
-    process.exit(1);
-  }
-
-  // check if the path exists
-  try {
-    await access(docsPath);
-  } catch {
-    console.error(`Error: Path not found: ${docsPath}`);
-    console.error('Check that the "docsPath" in src/plugin.json points to an existing directory.');
-    process.exit(1);
-  }
 
   // parse port
   const port = parseInt(argv.port, 10);

--- a/packages/plugin-docs-cli/src/commands/validate.command.ts
+++ b/packages/plugin-docs-cli/src/commands/validate.command.ts
@@ -1,0 +1,26 @@
+import type minimist from 'minimist';
+import createDebug from 'debug';
+import { validate } from '../validation/engine.js';
+import { allRules } from '../validation/rules/index.js';
+import { formatHuman, formatJson } from '../validation/format.js';
+
+const debug = createDebug('plugin-docs-cli:validate');
+
+export async function validateCommand(argv: minimist.ParsedArgs, docsPath: string): Promise<void> {
+  debug('Validate command invoked with args: %O', argv);
+
+  const json = argv.json || false;
+  const strict = argv.strict || false;
+
+  debug('Validating docs at: %s (strict: %s)', docsPath, strict);
+
+  const result = await validate({ docsPath }, 'release', allRules, { strict });
+
+  if (json) {
+    console.log(formatJson(result));
+  } else {
+    console.log(formatHuman(result));
+  }
+
+  process.exit(result.valid ? 0 : 1);
+}

--- a/packages/plugin-docs-cli/src/commands/validate.command.ts
+++ b/packages/plugin-docs-cli/src/commands/validate.command.ts
@@ -11,5 +11,5 @@ export async function validateCommand(docsPath: string): Promise<void> {
 
   console.log(JSON.stringify(result, null, 2));
 
-  process.exit(result.valid ? 0 : 1);
+  process.exitCode = result.valid ? 0 : 1;
 }

--- a/packages/plugin-docs-cli/src/commands/validate.command.ts
+++ b/packages/plugin-docs-cli/src/commands/validate.command.ts
@@ -1,26 +1,15 @@
-import type minimist from 'minimist';
 import createDebug from 'debug';
 import { validate } from '../validation/engine.js';
 import { allRules } from '../validation/rules/index.js';
-import { formatHuman, formatJson } from '../validation/format.js';
 
 const debug = createDebug('plugin-docs-cli:validate');
 
-export async function validateCommand(argv: minimist.ParsedArgs, docsPath: string): Promise<void> {
-  debug('Validate command invoked with args: %O', argv);
+export async function validateCommand(docsPath: string): Promise<void> {
+  debug('Validating docs at: %s', docsPath);
 
-  const json = argv.json || false;
-  const strict = argv.strict || false;
+  const result = await validate({ docsPath }, allRules);
 
-  debug('Validating docs at: %s (strict: %s)', docsPath, strict);
-
-  const result = await validate({ docsPath }, 'release', allRules, { strict });
-
-  if (json) {
-    console.log(formatJson(result));
-  } else {
-    console.log(formatHuman(result));
-  }
+  console.log(JSON.stringify(result, null, 2));
 
   process.exit(result.valid ? 0 : 1);
 }

--- a/packages/plugin-docs-cli/src/validation/engine.test.ts
+++ b/packages/plugin-docs-cli/src/validation/engine.test.ts
@@ -66,7 +66,7 @@ describe('validate', () => {
     expect(result.diagnostics).toHaveLength(1);
   });
 
-  it('should ignore findings with unknown rule ids', async () => {
+  it('should throw when a finding references an unknown rule id', async () => {
     const rules: RuleCategory[] = [
       {
         definitions: [{ id: 'known', severity: 'error' }],
@@ -77,8 +77,6 @@ describe('validate', () => {
       },
     ];
 
-    const result = await validate(input, rules);
-    expect(result.diagnostics).toHaveLength(1);
-    expect(result.diagnostics[0].rule).toBe('known');
+    await expect(validate(input, rules)).rejects.toThrow('Unknown rule id encountered during validation: unknown');
   });
 });

--- a/packages/plugin-docs-cli/src/validation/engine.test.ts
+++ b/packages/plugin-docs-cli/src/validation/engine.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { validate, type RuleCategory } from './engine.js';
+import type { ValidationInput } from './types.js';
+
+describe('validate', () => {
+  const input: ValidationInput = { docsPath: '/fake' };
+
+  it('should return valid when no rules are provided', async () => {
+    const result = await validate(input, []);
+    expect(result.valid).toBe(true);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('should stamp severity from rule definition', async () => {
+    const rules: RuleCategory[] = [
+      {
+        definitions: [{ id: 'test-rule', severity: 'error' }],
+        run: () => [{ rule: 'test-rule', title: 'Test', detail: 'Detail' }],
+      },
+    ];
+
+    const result = await validate(input, rules);
+    expect(result.diagnostics[0].severity).toBe('error');
+  });
+
+  it('should set valid to false when any diagnostic is an error', async () => {
+    const rules: RuleCategory[] = [
+      {
+        definitions: [{ id: 'err', severity: 'error' }],
+        run: () => [{ rule: 'err', title: 'Bad', detail: '' }],
+      },
+    ];
+
+    const result = await validate(input, rules);
+    expect(result.valid).toBe(false);
+  });
+
+  it('should set valid to true when all diagnostics are warnings or info', async () => {
+    const rules: RuleCategory[] = [
+      {
+        definitions: [
+          { id: 'w', severity: 'warning' },
+          { id: 'i', severity: 'info' },
+        ],
+        run: () => [
+          { rule: 'w', title: 'Warn', detail: '' },
+          { rule: 'i', title: 'Info', detail: '' },
+        ],
+      },
+    ];
+
+    const result = await validate(input, rules);
+    expect(result.valid).toBe(true);
+    expect(result.diagnostics).toHaveLength(2);
+  });
+
+  it('should handle async rule runners', async () => {
+    const rules: RuleCategory[] = [
+      {
+        definitions: [{ id: 'async-rule', severity: 'error' }],
+        run: async () => [{ rule: 'async-rule', title: 'Async', detail: '' }],
+      },
+    ];
+
+    const result = await validate(input, rules);
+    expect(result.diagnostics).toHaveLength(1);
+  });
+
+  it('should ignore findings with unknown rule ids', async () => {
+    const rules: RuleCategory[] = [
+      {
+        definitions: [{ id: 'known', severity: 'error' }],
+        run: () => [
+          { rule: 'unknown', title: 'Ghost', detail: '' },
+          { rule: 'known', title: 'Real', detail: '' },
+        ],
+      },
+    ];
+
+    const result = await validate(input, rules);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0].rule).toBe('known');
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/engine.ts
+++ b/packages/plugin-docs-cli/src/validation/engine.ts
@@ -1,38 +1,14 @@
-import type { Diagnostic, Finding, RuleDefinition, RuleRunner, ValidationInput, ValidationResult } from './types.js';
-
-export interface RuleCategory {
-  definitions: RuleDefinition[];
-  run: RuleRunner;
-}
+import type { Diagnostic, RuleRunner, ValidationInput, ValidationResult } from './types.js';
 
 /**
- * Run all provided rules against the input and return stamped diagnostics.
+ * Run all provided rule runners against the input and return diagnostics.
  */
-export async function validate(input: ValidationInput, rules: RuleCategory[]): Promise<ValidationResult> {
-  // build a lookup from rule id to definition across all categories.
-  const definitionMap = new Map<string, RuleDefinition>();
-  for (const category of rules) {
-    for (const def of category.definitions) {
-      definitionMap.set(def.id, def);
-    }
-  }
-
-  // run all rule runners and collect findings.
-  const allFindings: Finding[] = [];
-  for (const category of rules) {
-    const findings = await category.run(input);
-    allFindings.push(...findings);
-  }
-
-  // stamp severity and filter.
+export async function validate(input: ValidationInput, rules: RuleRunner[]): Promise<ValidationResult> {
   const diagnostics: Diagnostic[] = [];
-  for (const finding of allFindings) {
-    const def = definitionMap.get(finding.rule);
-    if (!def) {
-      throw new Error(`Unknown rule id encountered during validation: ${finding.rule}`);
-    }
 
-    diagnostics.push({ ...finding, severity: def.severity });
+  for (const run of rules) {
+    const results = await run(input);
+    diagnostics.push(...results);
   }
 
   const valid = diagnostics.every((d) => d.severity !== 'error');

--- a/packages/plugin-docs-cli/src/validation/engine.ts
+++ b/packages/plugin-docs-cli/src/validation/engine.ts
@@ -1,0 +1,41 @@
+import type { Diagnostic, Finding, RuleDefinition, RuleRunner, ValidationInput, ValidationResult } from './types.js';
+
+export interface RuleCategory {
+  definitions: RuleDefinition[];
+  run: RuleRunner;
+}
+
+/**
+ * Run all provided rules against the input and return stamped diagnostics.
+ */
+export async function validate(input: ValidationInput, rules: RuleCategory[]): Promise<ValidationResult> {
+  // build a lookup from rule id to definition across all categories.
+  const definitionMap = new Map<string, RuleDefinition>();
+  for (const category of rules) {
+    for (const def of category.definitions) {
+      definitionMap.set(def.id, def);
+    }
+  }
+
+  // run all rule runners and collect findings.
+  const allFindings: Finding[] = [];
+  for (const category of rules) {
+    const findings = await category.run(input);
+    allFindings.push(...findings);
+  }
+
+  // stamp severity and filter.
+  const diagnostics: Diagnostic[] = [];
+  for (const finding of allFindings) {
+    const def = definitionMap.get(finding.rule);
+    if (!def) {
+      continue;
+    }
+
+    diagnostics.push({ ...finding, severity: def.severity });
+  }
+
+  const valid = diagnostics.every((d) => d.severity !== 'error');
+
+  return { valid, diagnostics };
+}

--- a/packages/plugin-docs-cli/src/validation/engine.ts
+++ b/packages/plugin-docs-cli/src/validation/engine.ts
@@ -29,7 +29,7 @@ export async function validate(input: ValidationInput, rules: RuleCategory[]): P
   for (const finding of allFindings) {
     const def = definitionMap.get(finding.rule);
     if (!def) {
-      continue;
+      throw new Error(`Unknown rule id encountered during validation: ${finding.rule}`);
     }
 
     diagnostics.push({ ...finding, severity: def.severity });

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { checkFilesystem } from './filesystem.js';
+
+describe('checkFilesystem', () => {
+  const testDocsPath = join(__dirname, '..', '..', '__fixtures__', 'test-docs');
+
+  it('should report missing root index.md', async () => {
+    const findings = await checkFilesystem({ docsPath: testDocsPath });
+
+    const finding = findings.find((f) => f.rule === 'root-index-exists');
+    expect(finding).toBeDefined();
+    expect(finding!.title).toContain('index.md');
+  });
+
+  it('should not report has-markdown-files when docs folder has .md files', async () => {
+    const findings = await checkFilesystem({ docsPath: testDocsPath });
+
+    const finding = findings.find((f) => f.rule === 'has-markdown-files');
+    expect(finding).toBeUndefined();
+  });
+
+  it('should not report when root index.md exists', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(
+      join(tmp, 'index.md'),
+      '---\ntitle: Home\ndescription: Home page\nsidebar_position: 1\n---\n# Home\n'
+    );
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    expect(findings.find((f) => f.rule === 'root-index-exists')).toBeUndefined();
+    expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeUndefined();
+  });
+
+  it('should report has-markdown-files when docs path does not exist', async () => {
+    const findings = await checkFilesystem({ docsPath: '/nonexistent/path' });
+
+    expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeDefined();
+  });
+
+  it('should report has-markdown-files for empty directory', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-empty-'));
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeDefined();
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -1,20 +1,9 @@
 import { access, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { Finding, RuleDefinition, ValidationInput } from '../types.js';
+import type { Diagnostic, ValidationInput } from '../types.js';
 
-export const filesystemDefinitions: RuleDefinition[] = [
-  {
-    id: 'root-index-exists',
-    severity: 'error',
-  },
-  {
-    id: 'has-markdown-files',
-    severity: 'error',
-  },
-];
-
-export async function checkFilesystem(input: ValidationInput): Promise<Finding[]> {
-  const findings: Finding[] = [];
+export async function checkFilesystem(input: ValidationInput): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = [];
 
   // check for at least one .md file
   let hasMarkdown = false;
@@ -26,8 +15,9 @@ export async function checkFilesystem(input: ValidationInput): Promise<Finding[]
   }
 
   if (!hasMarkdown) {
-    findings.push({
+    diagnostics.push({
       rule: 'has-markdown-files',
+      severity: 'error',
       title: 'Docs folder must contain at least one .md file',
       detail:
         'The docs folder must contain at least one markdown file. Add markdown files with valid frontmatter to get started.',
@@ -38,13 +28,14 @@ export async function checkFilesystem(input: ValidationInput): Promise<Finding[]
   try {
     await access(join(input.docsPath, 'index.md'));
   } catch {
-    findings.push({
+    diagnostics.push({
       rule: 'root-index-exists',
+      severity: 'error',
       title: 'Root index.md must exist',
       detail:
         'The docs folder must contain an index.md file at its root. This serves as the landing page for your plugin documentation.',
     });
   }
 
-  return findings;
+  return diagnostics;
 }

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -2,6 +2,9 @@ import { access, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Diagnostic, ValidationInput } from '../types.js';
 
+const RULE_HAS_MARKDOWN = 'has-markdown-files';
+const RULE_ROOT_INDEX = 'root-index-exists';
+
 export async function checkFilesystem(input: ValidationInput): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];
 
@@ -16,7 +19,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
 
   if (!hasMarkdown) {
     diagnostics.push({
-      rule: 'has-markdown-files',
+      rule: RULE_HAS_MARKDOWN,
       severity: 'error',
       title: 'Docs folder must contain at least one .md file',
       detail:
@@ -29,7 +32,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     await access(join(input.docsPath, 'index.md'));
   } catch {
     diagnostics.push({
-      rule: 'root-index-exists',
+      rule: RULE_ROOT_INDEX,
       severity: 'error',
       title: 'Root index.md must exist',
       detail:

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -1,0 +1,50 @@
+import { access, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Finding, RuleDefinition, ValidationInput } from '../types.js';
+
+export const filesystemDefinitions: RuleDefinition[] = [
+  {
+    id: 'root-index-exists',
+    severity: 'error',
+  },
+  {
+    id: 'has-markdown-files',
+    severity: 'error',
+  },
+];
+
+export async function checkFilesystem(input: ValidationInput): Promise<Finding[]> {
+  const findings: Finding[] = [];
+
+  // check for at least one .md file
+  let hasMarkdown = false;
+  try {
+    const entries = await readdir(input.docsPath, { recursive: true });
+    hasMarkdown = entries.some((entry) => entry.endsWith('.md'));
+  } catch {
+    // docsPath doesn't exist or isn't readable - will be caught by has-markdown-files
+  }
+
+  if (!hasMarkdown) {
+    findings.push({
+      rule: 'has-markdown-files',
+      title: 'Docs folder must contain at least one .md file',
+      detail:
+        'The docs folder must contain at least one markdown file. Add markdown files with valid frontmatter to get started.',
+    });
+  }
+
+  // check for root index.md
+  try {
+    await access(join(input.docsPath, 'index.md'));
+  } catch {
+    findings.push({
+      rule: 'root-index-exists',
+      title: 'Root index.md must exist',
+      detail:
+        'The docs folder must contain an index.md file at its root. This serves as the landing page for your plugin documentation.',
+    });
+  }
+
+  return findings;
+}

--- a/packages/plugin-docs-cli/src/validation/rules/index.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/index.ts
@@ -1,0 +1,7 @@
+import type { RuleCategory } from '../engine.js';
+import { filesystemDefinitions, checkFilesystem } from './filesystem.js';
+
+/**
+ * All registered rule categories.
+ */
+export const allRules: RuleCategory[] = [{ definitions: filesystemDefinitions, run: checkFilesystem }];

--- a/packages/plugin-docs-cli/src/validation/rules/index.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/index.ts
@@ -1,7 +1,4 @@
-import type { RuleCategory } from '../engine.js';
-import { filesystemDefinitions, checkFilesystem } from './filesystem.js';
+import type { RuleRunner } from '../types.js';
+import { checkFilesystem } from './filesystem.js';
 
-/**
- * All registered rule categories.
- */
-export const allRules: RuleCategory[] = [{ definitions: filesystemDefinitions, run: checkFilesystem }];
+export const allRules: RuleRunner[] = [checkFilesystem];

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -1,30 +1,15 @@
 export type Severity = 'error' | 'warning' | 'info';
 
 /**
- * A finding from a rule check - no severity attached.
- * The engine stamps severity based on the rule definition.
+ * A diagnostic reported by a rule runner.
  */
-export interface Finding {
+export interface Diagnostic {
   rule: string;
+  severity: Severity;
   file?: string;
   line?: number;
   title: string;
   detail: string;
-}
-
-/**
- * A diagnostic is a finding with severity stamped by the engine.
- */
-export interface Diagnostic extends Finding {
-  severity: Severity;
-}
-
-/**
- * Metadata for a single validation rule.
- */
-export interface RuleDefinition {
-  id: string;
-  severity: Severity;
 }
 
 /**
@@ -43,6 +28,6 @@ export interface ValidationResult {
 }
 
 /**
- * A function that checks rules and returns findings.
+ * A function that checks rules and returns diagnostics.
  */
-export type RuleRunner = (input: ValidationInput) => Finding[] | Promise<Finding[]>;
+export type RuleRunner = (input: ValidationInput) => Diagnostic[] | Promise<Diagnostic[]>;

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -1,0 +1,48 @@
+export type Severity = 'error' | 'warning' | 'info';
+
+/**
+ * A finding from a rule check - no severity attached.
+ * The engine stamps severity based on the rule definition.
+ */
+export interface Finding {
+  rule: string;
+  file?: string;
+  line?: number;
+  title: string;
+  detail: string;
+}
+
+/**
+ * A diagnostic is a finding with severity stamped by the engine.
+ */
+export interface Diagnostic extends Finding {
+  severity: Severity;
+}
+
+/**
+ * Metadata for a single validation rule.
+ */
+export interface RuleDefinition {
+  id: string;
+  severity: Severity;
+}
+
+/**
+ * Data available to rule runners. Grows as slices add more rule categories.
+ */
+export interface ValidationInput {
+  docsPath: string;
+}
+
+/**
+ * The result of running validation.
+ */
+export interface ValidationResult {
+  valid: boolean;
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * A function that checks rules and returns findings.
+ */
+export type RuleRunner = (input: ValidationInput) => Finding[] | Promise<Finding[]>;


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a validation foundation to `@grafana/plugin-docs-cli` with a new `validate` CLI command and two basic filesystem rules (`root-index-exists` and `has-markdown-files`).

The validation architecture separates rules from the engine. Rule runners return `Finding[]` (rule ID, title, detail) without severity. The engine stamps severity from `RuleDefinition` metadata and returns a `ValidationResult` with `valid: boolean` and `diagnostics: Diagnostic[]`. The JSON output schema is designed to map directly to plugin-validator's `analysis.Diagnostic`.

More filesystem rules and other rule categories (frontmatter, markdown, security, assets, cross-file) will follow in subsequent PRs. Output is JSON only for now - human-readable formatting comes later. For the full plan see the epic.

```bash
npx @grafana/plugin-docs-cli validate
```

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana-catalog-team/issues/769

**Special notes for your reviewer**:
wdocsPath resolution (reading src/plugin.json + checking the path exists) was centralized in run.ts instead of being duplicated across serve, build and validate. Each command now receives docsPath as a parameter.

