### PR TITLE
Plugin Docs: Add filesystem validation rules

### DIFF
--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -22,7 +22,7 @@ async function main() {
     console.error('Commands:');
     console.error('  serve      Start the local docs preview server');
     console.error('  build      Build docs for publishing (generates manifest, copies to dist/)');
-    console.error('  validate   Validate documentation');
+    console.error('  validate   Validate documentation (--json for machine-readable output)');
     process.exit(1);
   }
 
@@ -66,12 +66,13 @@ async function main() {
     }
     case 'validate': {
       const validateArgv = minimist(process.argv.slice(3), {
-        boolean: ['strict'],
+        boolean: ['strict', 'json'],
         default: {
           strict: true,
+          json: false,
         },
       });
-      await validateCommand(docsPath, { strict: validateArgv.strict });
+      await validateCommand(docsPath, { strict: validateArgv.strict, json: validateArgv.json });
       break;
     }
     default:

--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -65,7 +65,13 @@ async function main() {
       break;
     }
     case 'validate': {
-      await validateCommand(docsPath);
+      const validateArgv = minimist(process.argv.slice(3), {
+        boolean: ['strict'],
+        default: {
+          strict: true,
+        },
+      });
+      await validateCommand(docsPath, { strict: validateArgv.strict });
       break;
     }
     default:

--- a/packages/plugin-docs-cli/src/commands/build.command.ts
+++ b/packages/plugin-docs-cli/src/commands/build.command.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { cp, lstat, mkdir, rm, writeFile } from 'node:fs/promises';
 import { extname, join, relative } from 'node:path';
 import createDebug from 'debug';
 import { scanDocsFolder } from '../scanner.js';
@@ -30,9 +30,12 @@ export async function buildDocs(projectRoot: string, docsPath: string): Promise<
   // copy only allowed file types to output (mirrors the allowed-file-types validation rule)
   await cp(docsPath, outputDir, {
     recursive: true,
-    filter: (src) => {
-      const ext = extname(src).toLowerCase();
-      return ext === '' || ALLOWED_EXTENSIONS.has(ext);
+    filter: async (src) => {
+      const stat = await lstat(src);
+      if (stat.isDirectory()) {
+        return true;
+      }
+      return ALLOWED_EXTENSIONS.has(extname(src).toLowerCase());
     },
   });
   debug('Copied docs folder to %s', outputDir);

--- a/packages/plugin-docs-cli/src/commands/build.command.ts
+++ b/packages/plugin-docs-cli/src/commands/build.command.ts
@@ -1,7 +1,8 @@
 import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { extname, join, relative } from 'node:path';
 import createDebug from 'debug';
 import { scanDocsFolder } from '../scanner.js';
+import { ALLOWED_EXTENSIONS } from '../validation/rules/filesystem.js';
 
 const debug = createDebug('plugin-docs-cli:build');
 
@@ -26,8 +27,14 @@ export async function buildDocs(projectRoot: string, docsPath: string): Promise<
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
 
-  // copy entire docs folder to output (preserves .md files, images and other assets)
-  await cp(docsPath, outputDir, { recursive: true });
+  // copy only allowed file types to output (mirrors the allowed-file-types validation rule)
+  await cp(docsPath, outputDir, {
+    recursive: true,
+    filter: (src) => {
+      const ext = extname(src).toLowerCase();
+      return ext === '' || ALLOWED_EXTENSIONS.has(ext);
+    },
+  });
   debug('Copied docs folder to %s', outputDir);
 
   // write generated manifest

--- a/packages/plugin-docs-cli/src/commands/validate.command.ts
+++ b/packages/plugin-docs-cli/src/commands/validate.command.ts
@@ -4,10 +4,13 @@ import { allRules } from '../validation/rules/index.js';
 
 const debug = createDebug('plugin-docs-cli:validate');
 
-export async function validateCommand(docsPath: string): Promise<void> {
-  debug('Validating docs at: %s', docsPath);
+export async function validateCommand(
+  docsPath: string,
+  options: { strict: boolean } = { strict: true }
+): Promise<void> {
+  debug('Validating docs at: %s (strict: %s)', docsPath, options.strict);
 
-  const result = await validate({ docsPath }, allRules);
+  const result = await validate({ docsPath, strict: options.strict }, allRules);
 
   console.log(JSON.stringify(result, null, 2));
 

--- a/packages/plugin-docs-cli/src/commands/validate.command.ts
+++ b/packages/plugin-docs-cli/src/commands/validate.command.ts
@@ -1,18 +1,23 @@
 import createDebug from 'debug';
 import { validate } from '../validation/engine.js';
+import { formatResult } from '../validation/format.js';
 import { allRules } from '../validation/rules/index.js';
 
 const debug = createDebug('plugin-docs-cli:validate');
 
 export async function validateCommand(
   docsPath: string,
-  options: { strict: boolean } = { strict: true }
+  options: { strict: boolean; json: boolean } = { strict: true, json: false }
 ): Promise<void> {
-  debug('Validating docs at: %s (strict: %s)', docsPath, options.strict);
+  debug('Validating docs at: %s (strict: %s, json: %s)', docsPath, options.strict, options.json);
 
   const result = await validate({ docsPath, strict: options.strict }, allRules);
 
-  console.log(JSON.stringify(result, null, 2));
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatResult(result));
+  }
 
   process.exitCode = result.valid ? 0 : 1;
 }

--- a/packages/plugin-docs-cli/src/validation/engine.test.ts
+++ b/packages/plugin-docs-cli/src/validation/engine.test.ts
@@ -3,7 +3,7 @@ import { validate } from './engine.js';
 import type { RuleRunner, ValidationInput } from './types.js';
 
 describe('validate', () => {
-  const input: ValidationInput = { docsPath: '/fake' };
+  const input: ValidationInput = { docsPath: '/fake', strict: true };
 
   it('should return valid when no rules are provided', async () => {
     const result = await validate(input, []);

--- a/packages/plugin-docs-cli/src/validation/format.test.ts
+++ b/packages/plugin-docs-cli/src/validation/format.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { formatResult } from './format.js';
+import type { ValidationResult } from './types.js';
+
+describe('formatResult', () => {
+  it('should show success for valid result with no diagnostics', () => {
+    const result: ValidationResult = { valid: true, diagnostics: [] };
+    const output = formatResult(result);
+    expect(output).toContain('✓');
+    expect(output).toContain('valid');
+  });
+
+  it('should show error count and ✗ icon when errors exist', () => {
+    const result: ValidationResult = {
+      valid: false,
+      diagnostics: [{ rule: 'test', severity: 'error', title: 'Bad thing', detail: 'Fix it' }],
+    };
+    const output = formatResult(result);
+    expect(output).toContain('✗');
+    expect(output).toContain('1 error');
+    expect(output).toContain('Bad thing');
+    expect(output).toContain('Fix it');
+  });
+
+  it('should show ⚠ icon when only warnings exist', () => {
+    const result: ValidationResult = {
+      valid: true,
+      diagnostics: [{ rule: 'test', severity: 'warning', title: 'Heads up', detail: '' }],
+    };
+    const output = formatResult(result);
+    expect(output).toContain('⚠');
+    expect(output).toContain('1 warning');
+  });
+
+  it('should pluralize counts correctly', () => {
+    const result: ValidationResult = {
+      valid: false,
+      diagnostics: [
+        { rule: 'a', severity: 'error', title: 'A', detail: '' },
+        { rule: 'b', severity: 'error', title: 'B', detail: '' },
+        { rule: 'c', severity: 'warning', title: 'C', detail: '' },
+      ],
+    };
+    const output = formatResult(result);
+    expect(output).toContain('2 errors');
+    expect(output).toContain('1 warning');
+  });
+
+  it('should include file path when present', () => {
+    const result: ValidationResult = {
+      valid: false,
+      diagnostics: [{ rule: 'test', severity: 'error', file: 'docs/page.md', title: 'Problem', detail: '' }],
+    };
+    const output = formatResult(result);
+    expect(output).toContain('docs/page.md');
+  });
+
+  it('should show file:line when line number is present', () => {
+    const result: ValidationResult = {
+      valid: false,
+      diagnostics: [{ rule: 'test', severity: 'error', file: 'page.md', line: 7, title: 'H1', detail: '' }],
+    };
+    const output = formatResult(result);
+    expect(output).toContain('page.md:7');
+  });
+
+  it('should handle mixed severities', () => {
+    const result: ValidationResult = {
+      valid: false,
+      diagnostics: [
+        { rule: 'a', severity: 'error', title: 'Error', detail: '' },
+        { rule: 'b', severity: 'warning', title: 'Warning', detail: '' },
+        { rule: 'c', severity: 'info', title: 'Info', detail: '' },
+      ],
+    };
+    const output = formatResult(result);
+    expect(output).toContain('1 error');
+    expect(output).toContain('1 warning');
+    expect(output).toContain('1 info');
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/format.ts
+++ b/packages/plugin-docs-cli/src/validation/format.ts
@@ -1,14 +1,10 @@
-import type { Diagnostic, ValidationResult } from './types.js';
+import type { Severity, ValidationResult } from './types.js';
 
-const SEVERITY_LABEL: Record<string, string> = {
+const SEVERITY_LABEL: Record<Severity, string> = {
   error: 'error',
   warning: 'warn ',
   info: 'info ',
 };
-
-function countBySeverity(diagnostics: Diagnostic[], severity: string): number {
-  return diagnostics.filter((d) => d.severity === severity).length;
-}
 
 /**
  * Formats a validation result as human-readable text.
@@ -21,9 +17,11 @@ export function formatResult(result: ValidationResult): string {
     return lines.join('\n');
   }
 
-  const errors = countBySeverity(result.diagnostics, 'error');
-  const warnings = countBySeverity(result.diagnostics, 'warning');
-  const infos = countBySeverity(result.diagnostics, 'info');
+  const counts: Record<Severity, number> = { error: 0, warning: 0, info: 0 };
+  for (const d of result.diagnostics) {
+    counts[d.severity]++;
+  }
+  const { error: errors, warning: warnings, info: infos } = counts;
 
   // summary line
   const parts: string[] = [];

--- a/packages/plugin-docs-cli/src/validation/format.ts
+++ b/packages/plugin-docs-cli/src/validation/format.ts
@@ -1,0 +1,56 @@
+import type { Diagnostic, ValidationResult } from './types.js';
+
+const SEVERITY_LABEL: Record<string, string> = {
+  error: 'error',
+  warning: 'warn ',
+  info: 'info ',
+};
+
+function countBySeverity(diagnostics: Diagnostic[], severity: string): number {
+  return diagnostics.filter((d) => d.severity === severity).length;
+}
+
+/**
+ * Formats a validation result as human-readable text.
+ */
+export function formatResult(result: ValidationResult): string {
+  const lines: string[] = [];
+
+  if (result.diagnostics.length === 0) {
+    lines.push('✓ Documentation is valid');
+    return lines.join('\n');
+  }
+
+  const errors = countBySeverity(result.diagnostics, 'error');
+  const warnings = countBySeverity(result.diagnostics, 'warning');
+  const infos = countBySeverity(result.diagnostics, 'info');
+
+  // summary line
+  const parts: string[] = [];
+  if (errors > 0) {
+    parts.push(`${errors} error${errors !== 1 ? 's' : ''}`);
+  }
+  if (warnings > 0) {
+    parts.push(`${warnings} warning${warnings !== 1 ? 's' : ''}`);
+  }
+  if (infos > 0) {
+    parts.push(`${infos} info`);
+  }
+
+  const icon = errors > 0 ? '✗' : '⚠';
+  lines.push(`${icon} Documentation has ${parts.join(' and ')}`);
+  lines.push('');
+
+  for (const d of result.diagnostics) {
+    const label = SEVERITY_LABEL[d.severity] ?? d.severity;
+    const location = d.file ? (d.line ? `  ${d.file}:${d.line}` : `  ${d.file}`) : '';
+    lines.push(`  ${label}${location}`);
+    lines.push(`         ${d.title}`);
+    if (d.detail) {
+      lines.push(`         ${d.detail}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
@@ -49,13 +49,12 @@ describe('checkFilesystem', () => {
     expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeDefined();
   });
 
-  it('should report nested-dir-has-index for subdirectory without index.md', async () => {
+  it('should not report nested-dir-has-index for directory with no markdown files', async () => {
     const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
-    // img/ has no .md files at all, so it definitely has no index.md
+    // img/ has no .md files at all - caught by no-empty-directories instead
     const finding = findings.find((f) => f.rule === 'nested-dir-has-index' && f.file?.endsWith('img'));
-    expect(finding).toBeDefined();
-    expect(finding!.severity).toBe('warning');
+    expect(finding).toBeUndefined();
   });
 
   it('should not report nested-dir-has-index for subdirectory with index.md', async () => {
@@ -88,13 +87,12 @@ describe('checkFilesystem', () => {
     expect(findings.find((f) => f.rule === 'nested-dir-has-index')).toBeUndefined();
   });
 
-  it('should report no-empty-directories for directory with no markdown files', async () => {
+  it('should not report no-empty-directories for img/ asset directory', async () => {
     const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
-    // img/ contains only test.png, no .md files
+    // img/ is the standard image directory and should be skipped
     const finding = findings.find((f) => f.rule === 'no-empty-directories' && f.file?.endsWith('img'));
-    expect(finding).toBeDefined();
-    expect(finding!.severity).toBe('error');
+    expect(finding).toBeUndefined();
   });
 
   it('should not report no-empty-directories for directory with markdown files', async () => {

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { checkFilesystem } from './filesystem.js';
 
@@ -47,5 +47,140 @@ describe('checkFilesystem', () => {
     const findings = await checkFilesystem({ docsPath: tmp });
 
     expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeDefined();
+  });
+
+  it('should report nested-dir-has-index for subdirectory without index.md', async () => {
+    const findings = await checkFilesystem({ docsPath: testDocsPath });
+
+    // img/ has no .md files at all, so it definitely has no index.md
+    const finding = findings.find((f) => f.rule === 'nested-dir-has-index' && f.file?.endsWith('img'));
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('warning');
+  });
+
+  it('should not report nested-dir-has-index for subdirectory with index.md', async () => {
+    const findings = await checkFilesystem({ docsPath: testDocsPath });
+
+    // config/ has an index.md directly inside it
+    const finding = findings.find((f) => f.rule === 'nested-dir-has-index' && f.file?.endsWith('config'));
+    expect(finding).toBeUndefined();
+  });
+
+  it('should report nested-dir-has-index when subdir lacks index.md', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'sub'));
+    await writeFile(join(tmp, 'sub', 'page.md'), '---\ntitle: Page\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    expect(findings.find((f) => f.rule === 'nested-dir-has-index')).toBeDefined();
+  });
+
+  it('should not report nested-dir-has-index when subdir has index.md', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'sub'));
+    await writeFile(join(tmp, 'sub', 'index.md'), '---\ntitle: Sub\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    expect(findings.find((f) => f.rule === 'nested-dir-has-index')).toBeUndefined();
+  });
+
+  it('should report no-empty-directories for directory with no markdown files', async () => {
+    const findings = await checkFilesystem({ docsPath: testDocsPath });
+
+    // img/ contains only test.png, no .md files
+    const finding = findings.find((f) => f.rule === 'no-empty-directories' && f.file?.endsWith('img'));
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('warning');
+  });
+
+  it('should not report no-empty-directories for directory with markdown files', async () => {
+    const findings = await checkFilesystem({ docsPath: testDocsPath });
+
+    // config/ has several .md files
+    const finding = findings.find((f) => f.rule === 'no-empty-directories' && f.file?.endsWith('config'));
+    expect(finding).toBeUndefined();
+  });
+
+  it('should report no-empty-directories for subdir with no markdown files', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'assets'));
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    expect(findings.find((f) => f.rule === 'no-empty-directories')).toBeDefined();
+  });
+
+  it('should not report no-empty-directories for subdir containing markdown files', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'sub'));
+    await writeFile(join(tmp, 'sub', 'index.md'), '---\ntitle: Sub\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    expect(findings.find((f) => f.rule === 'no-empty-directories')).toBeUndefined();
+  });
+
+  it('should not report naming rules for files and dirs with safe names', async () => {
+    const findings = await checkFilesystem({ docsPath: testDocsPath });
+
+    expect(findings.find((f) => f.rule === 'no-spaces-in-names')).toBeUndefined();
+    expect(findings.find((f) => f.rule === 'valid-file-naming')).toBeUndefined();
+  });
+
+  it('should report no-spaces-in-names for filename with a space', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await writeFile(join(tmp, 'my guide.md'), '---\ntitle: Guide\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    const finding = findings.find((f) => f.rule === 'no-spaces-in-names');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(finding!.file).toContain('my guide.md');
+  });
+
+  it('should report no-spaces-in-names for directory name with a space', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'my section'));
+    await writeFile(join(tmp, 'my section', 'index.md'), '---\ntitle: Section\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    const finding = findings.find((f) => f.rule === 'no-spaces-in-names' && f.file?.endsWith('my section'));
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+  });
+
+  it('should report valid-file-naming for filename with non-slug characters', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await writeFile(join(tmp, 'guide!important.md'), '---\ntitle: Guide\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    const finding = findings.find((f) => f.rule === 'valid-file-naming');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('info');
+  });
+
+  it('should report valid-file-naming for directory name with uppercase', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'MySection'));
+    await writeFile(join(tmp, 'MySection', 'index.md'), '---\ntitle: Section\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp });
+
+    const finding = findings.find((f) => f.rule === 'valid-file-naming' && f.file?.endsWith('MySection'));
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('info');
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
@@ -8,7 +8,7 @@ describe('checkFilesystem', () => {
   const testDocsPath = join(__dirname, '..', '..', '__fixtures__', 'test-docs');
 
   it('should report missing root index.md', async () => {
-    const findings = await checkFilesystem({ docsPath: testDocsPath });
+    const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
     const finding = findings.find((f) => f.rule === 'root-index-exists');
     expect(finding).toBeDefined();
@@ -16,7 +16,7 @@ describe('checkFilesystem', () => {
   });
 
   it('should not report has-markdown-files when docs folder has .md files', async () => {
-    const findings = await checkFilesystem({ docsPath: testDocsPath });
+    const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
     const finding = findings.find((f) => f.rule === 'has-markdown-files');
     expect(finding).toBeUndefined();
@@ -29,14 +29,14 @@ describe('checkFilesystem', () => {
       '---\ntitle: Home\ndescription: Home page\nsidebar_position: 1\n---\n# Home\n'
     );
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     expect(findings.find((f) => f.rule === 'root-index-exists')).toBeUndefined();
     expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeUndefined();
   });
 
   it('should report has-markdown-files when docs path does not exist', async () => {
-    const findings = await checkFilesystem({ docsPath: '/nonexistent/path' });
+    const findings = await checkFilesystem({ docsPath: '/nonexistent/path', strict: true });
 
     expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeDefined();
   });
@@ -44,13 +44,13 @@ describe('checkFilesystem', () => {
   it('should report has-markdown-files for empty directory', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'docs-empty-'));
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeDefined();
   });
 
   it('should report nested-dir-has-index for subdirectory without index.md', async () => {
-    const findings = await checkFilesystem({ docsPath: testDocsPath });
+    const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
     // img/ has no .md files at all, so it definitely has no index.md
     const finding = findings.find((f) => f.rule === 'nested-dir-has-index' && f.file?.endsWith('img'));
@@ -59,7 +59,7 @@ describe('checkFilesystem', () => {
   });
 
   it('should not report nested-dir-has-index for subdirectory with index.md', async () => {
-    const findings = await checkFilesystem({ docsPath: testDocsPath });
+    const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
     // config/ has an index.md directly inside it
     const finding = findings.find((f) => f.rule === 'nested-dir-has-index' && f.file?.endsWith('config'));
@@ -72,7 +72,7 @@ describe('checkFilesystem', () => {
     await mkdir(join(tmp, 'sub'));
     await writeFile(join(tmp, 'sub', 'page.md'), '---\ntitle: Page\n---\n');
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     expect(findings.find((f) => f.rule === 'nested-dir-has-index')).toBeDefined();
   });
@@ -83,22 +83,22 @@ describe('checkFilesystem', () => {
     await mkdir(join(tmp, 'sub'));
     await writeFile(join(tmp, 'sub', 'index.md'), '---\ntitle: Sub\n---\n');
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     expect(findings.find((f) => f.rule === 'nested-dir-has-index')).toBeUndefined();
   });
 
   it('should report no-empty-directories for directory with no markdown files', async () => {
-    const findings = await checkFilesystem({ docsPath: testDocsPath });
+    const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
     // img/ contains only test.png, no .md files
     const finding = findings.find((f) => f.rule === 'no-empty-directories' && f.file?.endsWith('img'));
     expect(finding).toBeDefined();
-    expect(finding!.severity).toBe('warning');
+    expect(finding!.severity).toBe('error');
   });
 
   it('should not report no-empty-directories for directory with markdown files', async () => {
-    const findings = await checkFilesystem({ docsPath: testDocsPath });
+    const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
     // config/ has several .md files
     const finding = findings.find((f) => f.rule === 'no-empty-directories' && f.file?.endsWith('config'));
@@ -110,7 +110,7 @@ describe('checkFilesystem', () => {
     await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
     await mkdir(join(tmp, 'assets'));
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     expect(findings.find((f) => f.rule === 'no-empty-directories')).toBeDefined();
   });
@@ -121,13 +121,13 @@ describe('checkFilesystem', () => {
     await mkdir(join(tmp, 'sub'));
     await writeFile(join(tmp, 'sub', 'index.md'), '---\ntitle: Sub\n---\n');
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     expect(findings.find((f) => f.rule === 'no-empty-directories')).toBeUndefined();
   });
 
   it('should not report naming rules for files and dirs with safe names', async () => {
-    const findings = await checkFilesystem({ docsPath: testDocsPath });
+    const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
     expect(findings.find((f) => f.rule === 'no-spaces-in-names')).toBeUndefined();
     expect(findings.find((f) => f.rule === 'valid-file-naming')).toBeUndefined();
@@ -138,7 +138,7 @@ describe('checkFilesystem', () => {
     await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
     await writeFile(join(tmp, 'my guide.md'), '---\ntitle: Guide\n---\n');
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     const finding = findings.find((f) => f.rule === 'no-spaces-in-names');
     expect(finding).toBeDefined();
@@ -152,7 +152,7 @@ describe('checkFilesystem', () => {
     await mkdir(join(tmp, 'my section'));
     await writeFile(join(tmp, 'my section', 'index.md'), '---\ntitle: Section\n---\n');
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     const finding = findings.find((f) => f.rule === 'no-spaces-in-names' && f.file?.endsWith('my section'));
     expect(finding).toBeDefined();
@@ -164,11 +164,11 @@ describe('checkFilesystem', () => {
     await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
     await writeFile(join(tmp, 'guide!important.md'), '---\ntitle: Guide\n---\n');
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     const finding = findings.find((f) => f.rule === 'valid-file-naming');
     expect(finding).toBeDefined();
-    expect(finding!.severity).toBe('info');
+    expect(finding!.severity).toBe('error');
   });
 
   it('should report valid-file-naming for directory name with uppercase', async () => {
@@ -177,10 +177,36 @@ describe('checkFilesystem', () => {
     await mkdir(join(tmp, 'MySection'));
     await writeFile(join(tmp, 'MySection', 'index.md'), '---\ntitle: Section\n---\n');
 
-    const findings = await checkFilesystem({ docsPath: tmp });
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
     const finding = findings.find((f) => f.rule === 'valid-file-naming' && f.file?.endsWith('MySection'));
     expect(finding).toBeDefined();
-    expect(finding!.severity).toBe('info');
+    expect(finding!.severity).toBe('error');
+  });
+
+  describe('non-strict mode', () => {
+    it('should report valid-file-naming as warning in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+      await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+      await writeFile(join(tmp, 'guide!important.md'), '---\ntitle: Guide\n---\n');
+
+      const findings = await checkFilesystem({ docsPath: tmp, strict: false });
+
+      const finding = findings.find((f) => f.rule === 'valid-file-naming');
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('warning');
+    });
+
+    it('should report no-empty-directories as warning in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+      await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+      await mkdir(join(tmp, 'assets'));
+
+      const findings = await checkFilesystem({ docsPath: tmp, strict: false });
+
+      const finding = findings.find((f) => f.rule === 'no-empty-directories');
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('warning');
+    });
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -1,23 +1,33 @@
-import { access, readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { readdir } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { join, sep } from 'node:path';
 import type { Diagnostic, ValidationInput } from '../types.js';
 
 const RULE_HAS_MARKDOWN = 'has-markdown-files';
 const RULE_ROOT_INDEX = 'root-index-exists';
+const RULE_NESTED_DIR_INDEX = 'nested-dir-has-index';
+const RULE_NO_SPACES = 'no-spaces-in-names';
+const RULE_VALID_NAMING = 'valid-file-naming';
+const RULE_NO_EMPTY_DIR = 'no-empty-directories';
+
+// slug-safe: lowercase letters, digits and hyphens only
+const SLUG_SAFE_RE = /^[a-z0-9-]+$/;
 
 export async function checkFilesystem(input: ValidationInput): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];
 
-  // check for at least one .md file
-  let hasMarkdown = false;
+  let entries: Dirent[] = [];
   try {
-    const entries = await readdir(input.docsPath, { recursive: true });
-    hasMarkdown = entries.some((entry) => entry.endsWith('.md'));
+    entries = await readdir(input.docsPath, { recursive: true, withFileTypes: true });
   } catch {
-    // docsPath doesn't exist or isn't readable - will be caught by has-markdown-files
+    // docsPath doesn't exist or isn't readable
   }
 
-  if (!hasMarkdown) {
+  const mdFiles = entries.filter((e) => e.isFile() && e.name.endsWith('.md'));
+  const dirs = entries.filter((e) => e.isDirectory());
+
+  // has-markdown-files
+  if (mdFiles.length === 0) {
     diagnostics.push({
       rule: RULE_HAS_MARKDOWN,
       severity: 'error',
@@ -27,10 +37,9 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     });
   }
 
-  // check for root index.md
-  try {
-    await access(join(input.docsPath, 'index.md'));
-  } catch {
+  // root-index-exists
+  const hasRootIndex = mdFiles.some((e) => e.name === 'index.md' && e.parentPath === input.docsPath);
+  if (!hasRootIndex) {
     diagnostics.push({
       rule: RULE_ROOT_INDEX,
       severity: 'error',
@@ -38,6 +47,59 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
       detail:
         'The docs folder must contain an index.md file at its root. This serves as the landing page for your plugin documentation.',
     });
+  }
+
+  for (const dir of dirs) {
+    const dirPath = join(dir.parentPath, dir.name);
+
+    // nested-dir-has-index: subdirectories without index.md become unnamed categories
+    const hasIndex = mdFiles.some((e) => e.name === 'index.md' && e.parentPath === dirPath);
+    if (!hasIndex) {
+      diagnostics.push({
+        rule: RULE_NESTED_DIR_INDEX,
+        severity: 'warning',
+        file: dirPath,
+        title: 'Subdirectory is missing index.md',
+        detail: `"${dir.name}" has no index.md. Without one, it will appear as an unnamed category using a title-cased directory name.`,
+      });
+    }
+
+    // no-empty-directories: directories with no .md files at any depth serve no purpose
+    const hasMd = mdFiles.some((e) => e.parentPath === dirPath || e.parentPath.startsWith(dirPath + sep));
+    if (!hasMd) {
+      diagnostics.push({
+        rule: RULE_NO_EMPTY_DIR,
+        severity: 'warning',
+        file: dirPath,
+        title: 'Directory contains no markdown files',
+        detail: `"${dir.name}" contains no .md files and serves no purpose in the documentation structure. Remove it or add documentation files.`,
+      });
+    }
+  }
+
+  // no-spaces-in-names (error) and valid-file-naming (info): applies to file stems and dir names
+  const namesToCheck = [
+    ...mdFiles.map((e) => ({ slug: e.name.slice(0, -3), label: e.name, path: join(e.parentPath, e.name) })),
+    ...dirs.map((e) => ({ slug: e.name, label: e.name, path: join(e.parentPath, e.name) })),
+  ];
+  for (const item of namesToCheck) {
+    if (/\s/.test(item.slug)) {
+      diagnostics.push({
+        rule: RULE_NO_SPACES,
+        severity: 'error',
+        file: item.path,
+        title: 'Name contains spaces',
+        detail: `"${item.label}" contains spaces which break URL slugs. Use hyphens instead.`,
+      });
+    } else if (!SLUG_SAFE_RE.test(item.slug)) {
+      diagnostics.push({
+        rule: RULE_VALID_NAMING,
+        severity: 'info',
+        file: item.path,
+        title: 'Name contains non-slug characters',
+        detail: `"${item.label}" should use only lowercase letters, digits and hyphens for clean URL slugs.`,
+      });
+    }
   }
 
   return diagnostics;

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -69,7 +69,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     if (!hasMd) {
       diagnostics.push({
         rule: RULE_NO_EMPTY_DIR,
-        severity: 'warning',
+        severity: input.strict ? 'error' : 'warning',
         file: dirPath,
         title: 'Directory contains no markdown files',
         detail: `"${dir.name}" contains no .md files and serves no purpose in the documentation structure. Remove it or add documentation files.`,
@@ -77,7 +77,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     }
   }
 
-  // no-spaces-in-names (error) and valid-file-naming (info): applies to file stems and dir names
+  // no-spaces-in-names (error) and valid-file-naming (strict-dependent): applies to file stems and dir names
   const namesToCheck = [
     ...mdFiles.map((e) => ({ slug: e.name.slice(0, -3), label: e.name, path: join(e.parentPath, e.name) })),
     ...dirs.map((e) => ({ slug: e.name, label: e.name, path: join(e.parentPath, e.name) })),
@@ -94,7 +94,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     } else if (!SLUG_SAFE_RE.test(item.slug)) {
       diagnostics.push({
         rule: RULE_VALID_NAMING,
-        severity: 'info',
+        severity: input.strict ? 'error' : 'warning',
         file: item.path,
         title: 'Name contains non-slug characters',
         detail: `"${item.label}" should use only lowercase letters, digits and hyphens for clean URL slugs.`,

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -28,10 +28,10 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     // docsPath doesn't exist or isn't readable
   }
 
-  const mdFiles = entries.filter((e) => e.isFile() && e.name.endsWith('.md'));
+  const mdFiles = entries.filter((e) => e.isFile() && extname(e.name).toLowerCase() === '.md');
   const dirs = entries.filter((e) => e.isDirectory());
   const symlinks = entries.filter((e) => e.isSymbolicLink());
-  const nonMdFiles = entries.filter((e) => e.isFile() && !e.name.endsWith('.md'));
+  const nonMdFiles = entries.filter((e) => e.isFile() && extname(e.name).toLowerCase() !== '.md');
 
   // no-symlinks
   for (const link of symlinks) {

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -17,6 +17,7 @@ export interface Diagnostic {
  */
 export interface ValidationInput {
   docsPath: string;
+  strict: boolean;
 }
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds six filesystem validation rules.

- \`no-spaces-in-names\` — spaces in file or folder names break URL slugs
- \`valid-file-naming\` — file and folder names should only use \`[a-z0-9-]\` for clean slugs
- \`nested-dir-has-index\` — subdirectories without \`index.md\` appear as unnamed categories
- \`no-empty-directories\` — directories with zero allowed files (md or images) serve no purpose
- \`no-symlinks\` — symlinks are not allowed in the docs folder
- \`allowed-file-types\` — only \`.md\` and permitted image formats (png, jpg, jpeg, webp, gif) are allowed

A strict mode (\`--strict\` flag, on by default) controls whether certain rules report as errors or warnings. Serve-time validation with \`strict: false\` is planned in a follow-up PR.

It also adds \`formatResult\` for human-readable CLI output and a \`--json\` flag for machine-readable output, and syncs the build command's copy filter with the \`allowed-file-types\` rule.

**Which issue(s) this PR fixes**:

Part of https://github.com/issues/assigned?issue=grafana%7Cgrafana-catalog-team%7C769

**Special notes for your reviewer**: