### PR TITLE
Plugin E2E: Use right selector version for viz tab

### DIFF
--- a/packages/plugin-e2e/src/selectors/versionedConstants.ts
+++ b/packages/plugin-e2e/src/selectors/versionedConstants.ts
@@ -23,7 +23,7 @@ export const versionedConstants = {
   },
   Tab: {
     title: {
-      '12.4.0': 'Visualizations',
+      '13.0.0': 'Visualizations',
       [MIN_GRAFANA_VERSION]: 'All visualizations',
     },
   },


### PR DESCRIPTION
**What this PR does / why we need it**:

The corresponding [Grafana change](https://github.com/grafana/grafana/pull/117817) didn't make it to the 12.4 release as intended. 

```shell
rrc whereis pr 117817
Commit is found in:
 ENVIRONMENT / RELEASE CHANNEL  CURRENT VERSION
 instant                        13.0.0-22350019450
 fast                           13.0.0-22184160961 --> 13.0.0-22326976726 **
```

This is causing issues here for example: https://github.com/grafana/plugin-tools/pull/2478

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-docs-cli@0.0.3-canary.2479.22359816249.0
  npm install @grafana/plugin-docs-parser@0.0.2-canary.2479.22359816249.0
  npm install @grafana/plugin-e2e@3.3.3-canary.2479.22359816249.0
  # or 
  yarn add @grafana/plugin-docs-cli@0.0.3-canary.2479.22359816249.0
  yarn add @grafana/plugin-docs-parser@0.0.2-canary.2479.22359816249.0
  yarn add @grafana/plugin-e2e@3.3.3-canary.2479.22359816249.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
