### PR TITLE
Create Plugin: Bump plugin-e2e 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,7 +476,7 @@ jobs:
           npx -y knip --config ../packed-artifacts/knip.json --reporter markdown --no-exit-code
         working-directory: ./${{ matrix.workingDir }}
 
-      - name: Failing build due to test failures (canary versions)
+      - name: Failing build due to test failures (latest versions)
         if: steps.run-e2e-tests.outcome != 'success' || steps.run-e2e-tests-min-version.outcome != 'success'
         run: exit 1
 

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
-    "@grafana/plugin-e2e": "^3.3.0",
+    "@grafana/plugin-e2e": "^3.3.3",
     "@grafana/tsconfig": "^2.0.1",
     "@playwright/test": "^1.57.0",{{#if useExperimentalRspack}}
     "@rspack/core": "^1.6.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump plugin-e2e to get this fix: https://github.com/grafana/plugin-tools/pull/2479

Cannot be merged before https://github.com/grafana/plugin-tools/pull/2479 is merged and released. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@6.10.2-canary.2480.22367170342.0
  # or 
  yarn add @grafana/create-plugin@6.10.2-canary.2480.22367170342.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
