### PR TITLE
Create Plugin: Fast-track plugin-e2e template updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -120,7 +120,7 @@
       "labels": ["dependencies", "javascript", "release", "patch"],
       "matchManagers": ["custom.regex"],
       "matchPackageNames": ["@grafana/plugin-e2e"],
-      "minimumReleaseAge": "0",
+      "minimumReleaseAge": null,
       "prPriority": 10,
       "prConcurrentLimit": 0
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -116,6 +116,16 @@
     },
     {
       "automerge": false,
+      "groupName": "plugin-e2e template version",
+      "labels": ["dependencies", "javascript", "release", "patch"],
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["@grafana/plugin-e2e"],
+      "minimumReleaseAge": "0",
+      "prPriority": 10,
+      "prConcurrentLimit": 0
+    },
+    {
+      "automerge": false,
       "groupName": "create-plugin template github actions",
       "labels": ["release", "patch", "create-plugin"],
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -115,7 +115,7 @@
       "matchPackageNames": ["!/^@?docusaurus/", "!/@grafana/*/"]
     },
     {
-      "automerge": false,
+      "automerge": true,
       "groupName": "plugin-e2e template version",
       "labels": ["dependencies", "javascript", "release", "patch"],
       "matchManagers": ["custom.regex"],


### PR DESCRIPTION
**What this PR does / why we need it**:

Most times we release plugin-e2e, we want to bump the create-plugin package.json template right away. We already have a [custom manager ](https://github.com/grafana/plugin-tools/blob/chore/renovate-plugin-e2e-template-rule/.github/renovate.json#L37-L44)that makes Renovate open a PR for this, but PR WIP limits, minimum release age and similar constraints can delay it. As a result, we often end up doing the bump manually.

This PR adds a package rule that fast-tracks plugin-e2e so Renovate can open the template bump PR sooner.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
