### PR TITLE
A11y: make the axe peer deps optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40310,6 +40310,14 @@
         "@axe-core/playwright": "^4.11.1",
         "@playwright/test": "^1.52.0",
         "axe-core": "^4.11.1"
+      },
+      "peerDependenciesMeta": {
+        "@axe-core/playwright": {
+          "optional": true
+        },
+        "axe-core": {
+          "optional": true
+        }
       }
     },
     "packages/plugin-e2e/node_modules/dotenv": {

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -36,21 +36,16 @@
   "peerDependenciesMeta": {
     "@axe-core/playwright": {
       "optional": true
-    },
-    "axe-core": {
-      "optional": true
     }
   },
   "peerDependencies": {
     "@axe-core/playwright": "^4.11.1",
-    "@playwright/test": "^1.52.0",
-    "axe-core": "^4.11.1"
+    "@playwright/test": "^1.52.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.58.1",
     "@types/uuid": "^11.0.0",
-    "axe-core": "^4.11.1",
     "dotenv": "^17.2.4"
   },
   "dependencies": {

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -33,6 +33,14 @@
   "engines": {
     "node": ">=20 <=24"
   },
+  "peerDependenciesMeta": {
+    "@axe-core/playwright": {
+      "optional": true
+    },
+    "axe-core": {
+      "optional": true
+    }
+  },
   "peerDependencies": {
     "@axe-core/playwright": "^4.11.1",
     "@playwright/test": "^1.52.0",

--- a/packages/plugin-e2e/src/matchers/toHaveNoA11yViolations.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveNoA11yViolations.ts
@@ -1,5 +1,5 @@
-import { MatcherReturnType } from '@playwright/test';
-import { AxeResults } from 'axe-core';
+import type { MatcherReturnType } from '@playwright/test';
+import type { AxeResults } from 'axe-core';
 
 import { A11yViolationsOptions } from '../types';
 


### PR DESCRIPTION
I'm a little concerned about the peerDependencies in 3.4.0 after integrating in Grafana, in case some plugin authors don't want to use the a11y tests, so I'm going to see if they can be made optional in an elegant way. We should maybe release this as 3.4.1 in case 3.4.0 is a problem for folks.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.4.1-canary.2485.22450892976.0
  # or 
  yarn add @grafana/plugin-e2e@3.4.1-canary.2485.22450892976.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
