### PR TITLE
Docs: document `group` property for panel menu link extensions

### DIFF
--- a/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
+++ b/docusaurus/docs/how-to-guides/ui-extensions/register-an-extension.md
@@ -132,7 +132,8 @@ export const plugin = new AppPlugin().addLink({
       // - description
       // - path
       // - icon
-      // - category
+      // - group
+      // - category (deprecated, use group instead)
       return {
         path: `/a/${pluginJson.id}/foo/timeseries`,
       };
@@ -222,6 +223,44 @@ export const plugin = new AppPlugin().addLink({
 ```
 
 </details>
+
+### Place a link in the panel menu root
+
+:::info
+Available in Grafana >=v11.5.0.
+:::
+
+By default, plugin link extensions targeting `DashboardPanelMenu` are placed under an **Extensions** submenu. You can use the `group` property to place a link at the root level of the panel menu (alongside View, Edit, Share, and so on), or to create a custom root-level submenu.
+
+| `group` configuration | Where the link appears |
+| --- | --- |
+| _(omitted)_ | Under the **Extensions** submenu (default) |
+| `{ name: '${root}' }` | At the root level of the panel menu |
+| `{ name: '${root}/My submenu' }` | In a **My submenu** root-level submenu |
+| `{ name: '${root}/My submenu', icon: 'heart' }` | In a **My submenu** root-level submenu with a custom icon |
+| `{ name: 'Custom' }` (no `${root}` prefix) | Under the **Extensions** submenu, grouped by "Custom" |
+
+```tsx title="src/module.tsx"
+import { PluginExtensionPoints } from '@grafana/data';
+import pluginJson from './plugin.json';
+
+export const plugin = new AppPlugin().addLink({
+  title: 'Declare incident',
+  description: 'Declare an incident from the panel menu',
+  targets: [PluginExtensionPoints.DashboardPanelMenu],
+  path: `/a/${pluginJson.id}/declare-incident`,
+  // Place this link at the root level of the panel menu
+  group: { name: '${root}' },
+});
+```
+
+:::note
+The following reserved group names **cannot** be used at the root level: `View`, `Edit`, `Share`, `Inspect`, `More...`, `Remove`, `Extensions`.
+:::
+
+:::note
+The `category` property is deprecated. Use `group` instead.
+:::
 
 ### Open a link in a new tab
 

--- a/docusaurus/docs/reference/ui-extensions-reference/extension-points.md
+++ b/docusaurus/docs/reference/ui-extensions-reference/extension-points.md
@@ -29,7 +29,7 @@ The following Extension Points are available:
 | **`AlertingRecordingRuleAction`** | Link      | Extend the alert rule menu with custom actions for recording rules.  |
 | **`AlertInstanceAction`**         | Link      | Extend the alert instances table with custom actions.                |
 | **`CommandPalette`**              | Link      | Extend the command palette with custom actions.                      |
-| **`DashboardPanelMenu`**          | Link      | Extend the panel menu with custom actions.                           |
+| **`DashboardPanelMenu`**          | Link      | Extend the panel menu with custom actions. Supports the `group` property to place links at the root level or in root-level submenus. |
 | **`ExploreToolbarAction`**        | Link      | Extend the "Add" button on the Explore page with custom actions.     |
 | **`UserProfileTab`**              | Component | Extend the user profile page with custom tabs.                       |
 

--- a/docusaurus/docs/reference/ui-extensions-reference/ui-extensions.md
+++ b/docusaurus/docs/reference/ui-extensions-reference/ui-extensions.md
@@ -100,7 +100,8 @@ The `addLink()` method takes a single `config` object with the following propert
 | **`description`**   | A human readable description for the link.                                                                                                                                                                                         | true     |
 | **`path?`**         | A path within your app plugin where you would like to send users when they click the link. (Use either `path` or `onClick`.) <br /> _Example: `"/a/myorg-incidents-app/incidents"`_                                                | true     |
 | **`onClick?`**      | A callback that should be triggered when the user clicks the link. (Use either `path` or `onClick`.)                                                                                                                               | false    |
-| **`category?`**     | A category that should be used to group your link with other links.                                                                                                                                                                | false    |
+| **`group?`**        | An object (`{ name: string; icon?: IconName }`) that controls where the link appears in extension points that support grouping, such as the dashboard panel menu. Use `{ name: '${root}' }` to place the link at the root level, or `{ name: '${root}/Submenu name' }` to create a root-level submenu. Available in Grafana >=v11.5.0. | false    |
+| **`category?`**     | _Deprecated: use `group` instead._ A category that should be used to group your link with other links.                                                                                                                             | false    |
 | **`icon?`**         | An icon that should be used while displaying your link. <br /> _Example: `"edit"` or `"bookmark"`. [See all available icon names &rarr;](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/icon.ts#L1)_ | false    |
 | **`openInNewTab?`** | A hint to the extension point that this link should be opened in a new tab. The extension point implementation determines how this hint is used. <br /> _Example: `true`_                                                        | false    |
 | **`configure?`**    | A function that is called prior to displaying the link which enables you to dynamically change or hide your link depending on its `context`.                                                                                       | false    |
@@ -114,6 +115,7 @@ The method returns the `AppPlugin` instance to allow for chaining.
 - [Hide a link in certain conditions](../../how-to-guides/ui-extensions/register-an-extension.md#hide-a-link-in-certain-conditions)
 - [Update the path based on the context](../../how-to-guides/ui-extensions/register-an-extension.md#update-the-path-based-on-the-context)
 - [Open a modal from the `onClick()`](../../how-to-guides/ui-extensions/register-an-extension.md#open-a-modal-from-the-onclick)
+- [Place a link in the panel menu root](../../how-to-guides/ui-extensions/register-an-extension.md#place-a-link-in-the-panel-menu-root)
 
 ### `addFunction`
 


### PR DESCRIPTION
## Summary

- Documents the new `group` property on `addLink()` that allows plugin link extensions to appear at the root level of the dashboard panel menu, instead of being nested under the "Extensions" submenu
- Adds a new "Place a link in the panel menu root" how-to section with a summary table, code example, reserved group names, and deprecation notes
- Updates the `addLink()` API reference table with the new `group?` parameter and marks `category` as deprecated
- Updates the `DashboardPanelMenu` extension point description to mention `group` support

Relates to [grafana/grafana#116481](https://github.com/grafana/grafana/pull/116481).

## Test plan

- [ ] Run `npm install && npm run docs` and verify the updated pages render correctly
- [ ] Confirm the new "Place a link in the panel menu root" section appears after "Open a modal from the onClick()" in the how-to guide
- [ ] Confirm the `group?` row appears in the `addLink()` parameters table in the reference
- [ ] Confirm the `category?` row shows the deprecation notice
- [ ] Confirm the `DashboardPanelMenu` row description mentions `group`
- [ ] Verify all internal links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)