### PR TITLE
Plugin Docs: Add frontmatter validation rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,10 +81,10 @@ module.exports = [
   },
   {
     name: 'plugin-tools/typescript-overrides',
-    files: ['**/*.{ts,tsx}'],
+    files: ['packages/plugin-docs-cli/**/*.{ts,tsx}'],
     rules: {
       'no-redeclare': 'off',
-      // TS compiler enforces redeclaration rules; the const+type same-name pattern (as-const maps) would be a false positive
+      // ts compiler handles redeclaration; using the same name for a const object and its derived type (e.g. `const Foo = {...} as const; type Foo = ...`) is valid ts but trips eslint
     },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,4 +79,12 @@ module.exports = [
       ...mdxPlugin.flatCodeBlocks.rules,
     },
   },
+  {
+    name: 'plugin-tools/typescript-overrides',
+    files: ['**/*.{ts,tsx}'],
+    rules: {
+      'no-redeclare': 'off',
+      // TS compiler enforces redeclaration rules; the const+type same-name pattern (as-const maps) would be a false positive
+    },
+  },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,7 +81,7 @@ module.exports = [
   },
   {
     name: 'plugin-tools/typescript-overrides',
-    files: ['packages/plugin-docs-cli/**/*.{ts,tsx}'],
+    files: ['packages/plugin-docs-cli/src/validation/types.ts'],
     rules: {
       'no-redeclare': 'off',
       // ts compiler handles redeclaration; using the same name for a const object and its derived type (e.g. `const Foo = {...} as const; type Foo = ...`) is valid ts but trips eslint

--- a/package-lock.json
+++ b/package-lock.json
@@ -38637,6 +38637,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/packages/plugin-docs-cli/src/scanner.ts
+++ b/packages/plugin-docs-cli/src/scanner.ts
@@ -133,13 +133,9 @@ async function scanMarkdownFiles(docsPath: string): Promise<ScannedFile[]> {
 
     // validate frontmatter has required fields with correct types
     const frontmatter = parsed.data as Partial<Frontmatter>;
-    if (
-      typeof frontmatter.title !== 'string' ||
-      typeof frontmatter.description !== 'string' ||
-      typeof frontmatter.sidebar_position !== 'number'
-    ) {
+    if (typeof frontmatter.title !== 'string' || typeof frontmatter.description !== 'string') {
       console.warn(
-        `Warning: ${relativePath} missing or invalid required frontmatter fields (title: string, description: string, sidebar_position: number)`
+        `Warning: ${relativePath} missing or invalid required frontmatter fields (title: string, description: string)`
       );
       continue;
     }

--- a/packages/plugin-docs-cli/src/server/server.test.ts
+++ b/packages/plugin-docs-cli/src/server/server.test.ts
@@ -26,7 +26,7 @@ describe('startServer', () => {
 
     expect(response.status).toBe(200);
     expect(response.text).toContain('<title>Home Page - Plugin Documentation</title>');
-    expect(response.text).toContain('<h1 id="welcome">Welcome</h1>');
+    expect(response.text).toContain('<h1 class="docs-page-title">Home Page</h1>');
     expect(response.text).toContain('This is the home page of the test documentation.');
   });
 
@@ -39,7 +39,7 @@ describe('startServer', () => {
 
     expect(response.status).toBe(200);
     expect(response.text).toContain('<title>User Guide - Plugin Documentation</title>');
-    expect(response.text).toContain('<h1 id="user-guide">User Guide</h1>');
+    expect(response.text).toContain('<h1 class="docs-page-title">User Guide</h1>');
     expect(response.text).toContain('This is a guide page.');
   });
 
@@ -51,7 +51,7 @@ describe('startServer', () => {
     const response = await request(app).get('/advanced');
 
     expect(response.status).toBe(200);
-    expect(response.text).toContain('<h1 id="advanced-topics">Advanced Topics</h1>');
+    expect(response.text).toContain('<h1 class="docs-page-title">Advanced Topics</h1>');
     expect(response.text).toContain('This covers advanced topics.');
   });
 
@@ -158,7 +158,7 @@ describe('startServer', () => {
 
     expect(response.status).toBe(200);
     expect(response.text).toContain('<title>Settings - Plugin Documentation</title>');
-    expect(response.text).toContain('<h1 id="settings">Settings</h1>');
+    expect(response.text).toContain('<h1 class="docs-page-title">Settings</h1>');
   });
 
   it('should render headings in the table of contents sidebar', async () => {

--- a/packages/plugin-docs-cli/src/server/views/docs-layout.ejs
+++ b/packages/plugin-docs-cli/src/server/views/docs-layout.ejs
@@ -10,7 +10,7 @@
   <!-- Header -->
   <header class="docs-header">
     <div class="docs-header-content">
-      <h1 class="docs-header-title">📦 <%= manifest.title %></h1>
+      <p class="docs-header-title">📦 <%= manifest.title %></p>
       <span class="docs-header-badge">Local Preview</span>
     </div>
   </header>

--- a/packages/plugin-docs-cli/src/server/views/docs-layout.ejs
+++ b/packages/plugin-docs-cli/src/server/views/docs-layout.ejs
@@ -25,6 +25,7 @@
 
     <!-- Center: Main content -->
     <main class="docs-content">
+      <h1 class="docs-page-title"><%= title %></h1>
       <%- content %>
     </main>
 

--- a/packages/plugin-docs-cli/src/validation/engine.test.ts
+++ b/packages/plugin-docs-cli/src/validation/engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { validate } from './engine.js';
-import type { RuleRunner, ValidationInput } from './types.js';
+import { Rule, type RuleRunner, type ValidationInput } from './types.js';
 
 describe('validate', () => {
   const input: ValidationInput = { docsPath: '/fake', strict: true };
@@ -12,7 +12,7 @@ describe('validate', () => {
   });
 
   it('should collect diagnostics from runners', async () => {
-    const runner: RuleRunner = () => [{ rule: 'test-rule', severity: 'error', title: 'Test', detail: 'Detail' }];
+    const runner: RuleRunner = () => [{ rule: Rule.HasMarkdown, severity: 'error', title: 'Test', detail: 'Detail' }];
 
     const result = await validate(input, [runner]);
     expect(result.diagnostics).toHaveLength(1);
@@ -20,7 +20,7 @@ describe('validate', () => {
   });
 
   it('should set valid to false when any diagnostic is an error', async () => {
-    const runner: RuleRunner = () => [{ rule: 'err', severity: 'error', title: 'Bad', detail: '' }];
+    const runner: RuleRunner = () => [{ rule: Rule.RootIndex, severity: 'error', title: 'Bad', detail: '' }];
 
     const result = await validate(input, [runner]);
     expect(result.valid).toBe(false);
@@ -28,8 +28,8 @@ describe('validate', () => {
 
   it('should set valid to true when all diagnostics are warnings or info', async () => {
     const runner: RuleRunner = () => [
-      { rule: 'w', severity: 'warning', title: 'Warn', detail: '' },
-      { rule: 'i', severity: 'info', title: 'Info', detail: '' },
+      { rule: Rule.NestedDirIndex, severity: 'warning', title: 'Warn', detail: '' },
+      { rule: Rule.ValidNaming, severity: 'info', title: 'Info', detail: '' },
     ];
 
     const result = await validate(input, [runner]);
@@ -38,15 +38,15 @@ describe('validate', () => {
   });
 
   it('should handle async rule runners', async () => {
-    const runner: RuleRunner = async () => [{ rule: 'async-rule', severity: 'error', title: 'Async', detail: '' }];
+    const runner: RuleRunner = async () => [{ rule: Rule.BlockExists, severity: 'error', title: 'Async', detail: '' }];
 
     const result = await validate(input, [runner]);
     expect(result.diagnostics).toHaveLength(1);
   });
 
   it('should collect diagnostics from multiple runners', async () => {
-    const runner1: RuleRunner = () => [{ rule: 'a', severity: 'error', title: 'A', detail: '' }];
-    const runner2: RuleRunner = () => [{ rule: 'b', severity: 'warning', title: 'B', detail: '' }];
+    const runner1: RuleRunner = () => [{ rule: Rule.NoSpaces, severity: 'error', title: 'A', detail: '' }];
+    const runner2: RuleRunner = () => [{ rule: Rule.NoEmptyDir, severity: 'warning', title: 'B', detail: '' }];
 
     const result = await validate(input, [runner1, runner2]);
     expect(result.diagnostics).toHaveLength(2);

--- a/packages/plugin-docs-cli/src/validation/format.test.ts
+++ b/packages/plugin-docs-cli/src/validation/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { formatResult } from './format.js';
-import type { ValidationResult } from './types.js';
+import { Rule, type ValidationResult } from './types.js';
 
 describe('formatResult', () => {
   it('should show success for valid result with no diagnostics', () => {
@@ -13,7 +13,7 @@ describe('formatResult', () => {
   it('should show error count and ✗ icon when errors exist', () => {
     const result: ValidationResult = {
       valid: false,
-      diagnostics: [{ rule: 'test', severity: 'error', title: 'Bad thing', detail: 'Fix it' }],
+      diagnostics: [{ rule: Rule.HasMarkdown, severity: 'error', title: 'Bad thing', detail: 'Fix it' }],
     };
     const output = formatResult(result);
     expect(output).toContain('✗');
@@ -25,7 +25,7 @@ describe('formatResult', () => {
   it('should show ⚠ icon when only warnings exist', () => {
     const result: ValidationResult = {
       valid: true,
-      diagnostics: [{ rule: 'test', severity: 'warning', title: 'Heads up', detail: '' }],
+      diagnostics: [{ rule: Rule.NestedDirIndex, severity: 'warning', title: 'Heads up', detail: '' }],
     };
     const output = formatResult(result);
     expect(output).toContain('⚠');
@@ -36,9 +36,9 @@ describe('formatResult', () => {
     const result: ValidationResult = {
       valid: false,
       diagnostics: [
-        { rule: 'a', severity: 'error', title: 'A', detail: '' },
-        { rule: 'b', severity: 'error', title: 'B', detail: '' },
-        { rule: 'c', severity: 'warning', title: 'C', detail: '' },
+        { rule: Rule.NoSpaces, severity: 'error', title: 'A', detail: '' },
+        { rule: Rule.ValidNaming, severity: 'error', title: 'B', detail: '' },
+        { rule: Rule.NoEmptyDir, severity: 'warning', title: 'C', detail: '' },
       ],
     };
     const output = formatResult(result);
@@ -49,7 +49,7 @@ describe('formatResult', () => {
   it('should include file path when present', () => {
     const result: ValidationResult = {
       valid: false,
-      diagnostics: [{ rule: 'test', severity: 'error', file: 'docs/page.md', title: 'Problem', detail: '' }],
+      diagnostics: [{ rule: Rule.RootIndex, severity: 'error', file: 'docs/page.md', title: 'Problem', detail: '' }],
     };
     const output = formatResult(result);
     expect(output).toContain('docs/page.md');
@@ -58,7 +58,7 @@ describe('formatResult', () => {
   it('should show file:line when line number is present', () => {
     const result: ValidationResult = {
       valid: false,
-      diagnostics: [{ rule: 'test', severity: 'error', file: 'page.md', line: 7, title: 'H1', detail: '' }],
+      diagnostics: [{ rule: Rule.NoH1, severity: 'error', file: 'page.md', line: 7, title: 'H1', detail: '' }],
     };
     const output = formatResult(result);
     expect(output).toContain('page.md:7');
@@ -68,9 +68,9 @@ describe('formatResult', () => {
     const result: ValidationResult = {
       valid: false,
       diagnostics: [
-        { rule: 'a', severity: 'error', title: 'Error', detail: '' },
-        { rule: 'b', severity: 'warning', title: 'Warning', detail: '' },
-        { rule: 'c', severity: 'info', title: 'Info', detail: '' },
+        { rule: Rule.BlockExists, severity: 'error', title: 'Error', detail: '' },
+        { rule: Rule.ValidSlug, severity: 'warning', title: 'Warning', detail: '' },
+        { rule: Rule.AllowedFileTypes, severity: 'info', title: 'Info', detail: '' },
       ],
     };
     const output = formatResult(result);

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { checkFilesystem } from './filesystem.js';
 
@@ -196,5 +196,57 @@ describe('checkFilesystem', () => {
       expect(finding).toBeDefined();
       expect(finding!.severity).toBe('warning');
     });
+  });
+
+  it('should report no-symlinks for a symlinked file', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    const target = join(tmp, 'index.md');
+    await symlink(target, join(tmp, 'link.md'));
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    const finding = findings.find((f) => f.rule === 'no-symlinks');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(finding!.file).toContain('link.md');
+  });
+
+  it('should report allowed-file-types as error in strict mode for disallowed extension', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await writeFile(join(tmp, 'config.json'), '{}');
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    const finding = findings.find((f) => f.rule === 'allowed-file-types');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(finding!.file).toContain('config.json');
+  });
+
+  it('should report allowed-file-types as info in non-strict mode', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await writeFile(join(tmp, 'notes.txt'), 'some notes');
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: false });
+
+    const finding = findings.find((f) => f.rule === 'allowed-file-types');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('info');
+  });
+
+  it('should not report allowed-file-types for permitted image formats', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await mkdir(join(tmp, 'img'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await writeFile(join(tmp, 'img', 'screenshot.png'), '');
+    await writeFile(join(tmp, 'img', 'photo.jpg'), '');
+    await writeFile(join(tmp, 'img', 'animation.gif'), '');
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    expect(findings.find((f) => f.rule === 'allowed-file-types')).toBeUndefined();
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { checkFilesystem } from './filesystem.js';
+import { Rule } from '../types.js';
 
 describe('checkFilesystem', () => {
   const testDocsPath = join(__dirname, '..', '..', '__fixtures__', 'test-docs');
@@ -10,7 +11,7 @@ describe('checkFilesystem', () => {
   it('should report missing root index.md', async () => {
     const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
-    const finding = findings.find((f) => f.rule === 'root-index-exists');
+    const finding = findings.find((f) => f.rule === Rule.RootIndex);
     expect(finding).toBeDefined();
     expect(finding!.title).toContain('index.md');
   });
@@ -18,7 +19,7 @@ describe('checkFilesystem', () => {
   it('should not report has-markdown-files when docs folder has .md files', async () => {
     const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
-    const finding = findings.find((f) => f.rule === 'has-markdown-files');
+    const finding = findings.find((f) => f.rule === Rule.HasMarkdown);
     expect(finding).toBeUndefined();
   });
 
@@ -31,14 +32,14 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'root-index-exists')).toBeUndefined();
-    expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.RootIndex)).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.HasMarkdown)).toBeUndefined();
   });
 
   it('should report has-markdown-files when docs path does not exist', async () => {
     const findings = await checkFilesystem({ docsPath: '/nonexistent/path', strict: true });
 
-    expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeDefined();
+    expect(findings.find((f) => f.rule === Rule.HasMarkdown)).toBeDefined();
   });
 
   it('should report has-markdown-files for empty directory', async () => {
@@ -46,7 +47,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'has-markdown-files')).toBeDefined();
+    expect(findings.find((f) => f.rule === Rule.HasMarkdown)).toBeDefined();
   });
 
   it('should report nested-dir-has-index when subdir lacks index.md', async () => {
@@ -57,7 +58,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'nested-dir-has-index')).toBeDefined();
+    expect(findings.find((f) => f.rule === Rule.NestedDirIndex)).toBeDefined();
   });
 
   it('should not report nested-dir-has-index when subdir has index.md', async () => {
@@ -68,7 +69,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'nested-dir-has-index')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.NestedDirIndex)).toBeUndefined();
   });
 
   it('should not report nested-dir-has-index for image-only subdir', async () => {
@@ -79,7 +80,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'nested-dir-has-index')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.NestedDirIndex)).toBeUndefined();
   });
 
   it('should not report no-empty-directories for directory with only image files', async () => {
@@ -90,7 +91,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'no-empty-directories')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.NoEmptyDir)).toBeUndefined();
   });
 
   it('should report no-empty-directories for subdir with no allowed files', async () => {
@@ -100,7 +101,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'no-empty-directories')).toBeDefined();
+    expect(findings.find((f) => f.rule === Rule.NoEmptyDir)).toBeDefined();
   });
 
   it('should not report no-empty-directories for subdir containing markdown files', async () => {
@@ -111,14 +112,14 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'no-empty-directories')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.NoEmptyDir)).toBeUndefined();
   });
 
   it('should not report naming rules for files and dirs with safe names', async () => {
     const findings = await checkFilesystem({ docsPath: testDocsPath, strict: true });
 
-    expect(findings.find((f) => f.rule === 'no-spaces-in-names')).toBeUndefined();
-    expect(findings.find((f) => f.rule === 'valid-file-naming')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.NoSpaces)).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.ValidNaming)).toBeUndefined();
   });
 
   it('should report no-spaces-in-names for filename with a space', async () => {
@@ -128,7 +129,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    const finding = findings.find((f) => f.rule === 'no-spaces-in-names');
+    const finding = findings.find((f) => f.rule === Rule.NoSpaces);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
     expect(finding!.file).toContain('my guide.md');
@@ -142,7 +143,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    const finding = findings.find((f) => f.rule === 'no-spaces-in-names' && f.file?.endsWith('my section'));
+    const finding = findings.find((f) => f.rule === Rule.NoSpaces && f.file?.endsWith('my section'));
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
   });
@@ -154,7 +155,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    const finding = findings.find((f) => f.rule === 'valid-file-naming');
+    const finding = findings.find((f) => f.rule === Rule.ValidNaming);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
   });
@@ -167,7 +168,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    const finding = findings.find((f) => f.rule === 'valid-file-naming' && f.file?.endsWith('MySection'));
+    const finding = findings.find((f) => f.rule === Rule.ValidNaming && f.file?.endsWith('MySection'));
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
   });
@@ -180,7 +181,7 @@ describe('checkFilesystem', () => {
 
       const findings = await checkFilesystem({ docsPath: tmp, strict: false });
 
-      const finding = findings.find((f) => f.rule === 'valid-file-naming');
+      const finding = findings.find((f) => f.rule === Rule.ValidNaming);
       expect(finding).toBeDefined();
       expect(finding!.severity).toBe('warning');
     });
@@ -192,7 +193,7 @@ describe('checkFilesystem', () => {
 
       const findings = await checkFilesystem({ docsPath: tmp, strict: false });
 
-      const finding = findings.find((f) => f.rule === 'no-empty-directories');
+      const finding = findings.find((f) => f.rule === Rule.NoEmptyDir);
       expect(finding).toBeDefined();
       expect(finding!.severity).toBe('warning');
     });
@@ -206,7 +207,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    const finding = findings.find((f) => f.rule === 'no-symlinks');
+    const finding = findings.find((f) => f.rule === Rule.NoSymlinks);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
     expect(finding!.file).toContain('link.md');
@@ -219,7 +220,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    const finding = findings.find((f) => f.rule === 'allowed-file-types');
+    const finding = findings.find((f) => f.rule === Rule.AllowedFileTypes);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
     expect(finding!.file).toContain('config.json');
@@ -232,7 +233,7 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: false });
 
-    const finding = findings.find((f) => f.rule === 'allowed-file-types');
+    const finding = findings.find((f) => f.rule === Rule.AllowedFileTypes);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('info');
   });
@@ -247,6 +248,6 @@ describe('checkFilesystem', () => {
 
     const findings = await checkFilesystem({ docsPath: tmp, strict: true });
 
-    expect(findings.find((f) => f.rule === 'allowed-file-types')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.AllowedFileTypes)).toBeUndefined();
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -1,16 +1,7 @@
 import { readdir } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, extname, sep } from 'node:path';
-import type { Diagnostic, ValidationInput } from '../types.js';
-
-const RULE_HAS_MARKDOWN = 'has-markdown-files';
-const RULE_ROOT_INDEX = 'root-index-exists';
-const RULE_NESTED_DIR_INDEX = 'nested-dir-has-index';
-const RULE_NO_SPACES = 'no-spaces-in-names';
-const RULE_VALID_NAMING = 'valid-file-naming';
-const RULE_NO_EMPTY_DIR = 'no-empty-directories';
-const RULE_NO_SYMLINKS = 'no-symlinks';
-const RULE_ALLOWED_FILE_TYPES = 'allowed-file-types';
+import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 
 // slug-safe: lowercase letters, digits and hyphens only
 const SLUG_SAFE_RE = /^[a-z0-9-]+$/;
@@ -36,7 +27,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
   // no-symlinks
   for (const link of symlinks) {
     diagnostics.push({
-      rule: RULE_NO_SYMLINKS,
+      rule: Rule.NoSymlinks,
       severity: 'error',
       file: join(link.parentPath, link.name),
       title: 'Symlinks are not allowed',
@@ -49,7 +40,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     const ext = extname(file.name).toLowerCase();
     if (!ALLOWED_EXTENSIONS.has(ext)) {
       diagnostics.push({
-        rule: RULE_ALLOWED_FILE_TYPES,
+        rule: Rule.AllowedFileTypes,
         severity: input.strict ? 'error' : 'info',
         file: join(file.parentPath, file.name),
         title: 'File type not allowed',
@@ -61,7 +52,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
   // has-markdown-files
   if (mdFiles.length === 0) {
     diagnostics.push({
-      rule: RULE_HAS_MARKDOWN,
+      rule: Rule.HasMarkdown,
       severity: 'error',
       title: 'Docs folder must contain at least one .md file',
       detail:
@@ -73,7 +64,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
   const hasRootIndex = mdFiles.some((e) => e.name === 'index.md' && e.parentPath === input.docsPath);
   if (!hasRootIndex) {
     diagnostics.push({
-      rule: RULE_ROOT_INDEX,
+      rule: Rule.RootIndex,
       severity: 'error',
       title: 'Root index.md must exist',
       detail:
@@ -93,7 +84,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     );
     if (!hasAllowed) {
       diagnostics.push({
-        rule: RULE_NO_EMPTY_DIR,
+        rule: Rule.NoEmptyDir,
         severity: input.strict ? 'error' : 'warning',
         file: dirPath,
         title: 'Directory contains no documentation files',
@@ -111,7 +102,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     const hasIndex = mdFiles.some((e) => e.name === 'index.md' && e.parentPath === dirPath);
     if (!hasIndex) {
       diagnostics.push({
-        rule: RULE_NESTED_DIR_INDEX,
+        rule: Rule.NestedDirIndex,
         severity: 'warning',
         file: dirPath,
         title: 'Subdirectory is missing index.md',
@@ -128,7 +119,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
   for (const item of namesToCheck) {
     if (/\s/.test(item.slug)) {
       diagnostics.push({
-        rule: RULE_NO_SPACES,
+        rule: Rule.NoSpaces,
         severity: 'error',
         file: item.path,
         title: 'Name contains spaces',
@@ -136,7 +127,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
       });
     } else if (!SLUG_SAFE_RE.test(item.slug)) {
       diagnostics.push({
-        rule: RULE_VALID_NAMING,
+        rule: Rule.ValidNaming,
         severity: input.strict ? 'error' : 'warning',
         file: item.path,
         title: 'Name contains non-slug characters',

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
@@ -13,6 +13,7 @@ describe('checkFrontmatter', () => {
     await writeFile(join(tmp, 'page.md'), '---\ntitle: Hello\n---\n# Hi\n');
 
     const findings = await checkFrontmatter(input(tmp));
+    expect(findings).toHaveLength(2); // 1 missing description + 1 h1 warning
 
     const missing = findings.filter((f) => f.rule === Rule.RequiredFields);
     expect(missing).toHaveLength(1);
@@ -24,7 +25,7 @@ describe('checkFrontmatter', () => {
     const findings = await checkFrontmatter(input(invalidDocs));
 
     const typeErrors = findings.filter((f) => f.rule === Rule.FieldTypes);
-    expect(typeErrors.length).toBeGreaterThanOrEqual(3);
+    expect(typeErrors).toHaveLength(3);
     expect(typeErrors.some((f) => f.title.includes('title'))).toBe(true);
     expect(typeErrors.some((f) => f.title.includes('description'))).toBe(true);
     expect(typeErrors.some((f) => f.title.includes('sidebar_position'))).toBe(true);
@@ -67,6 +68,7 @@ describe('checkFrontmatter', () => {
     await writeFile(join(tmp, 'page.md'), '---\ntitle: 123\ndescription: Valid\nsidebar_position: 1\n---\n');
 
     const findings = await checkFrontmatter(input(tmp));
+    expect(findings).toHaveLength(1);
     const titleError = findings.find((f) => f.rule === Rule.FieldTypes && f.title.includes('title'));
     expect(titleError).toBeDefined();
     expect(titleError!.line).toBe(2);
@@ -80,6 +82,7 @@ describe('checkFrontmatter', () => {
     );
 
     const findings = await checkFrontmatter(input(tmp));
+    expect(findings).toHaveLength(1);
     const h1 = findings.find((f) => f.rule === Rule.NoH1);
     expect(h1).toBeDefined();
     expect(h1!.severity).toBe('warning');
@@ -120,6 +123,7 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
 
+    expect(findings).toHaveLength(1);
     const finding = findings.find((f) => f.rule === Rule.BlockExists);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
@@ -143,6 +147,7 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
 
+    expect(findings).toHaveLength(1);
     const finding = findings.find((f) => f.rule === Rule.ValidYaml);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
@@ -198,6 +203,7 @@ describe('checkFrontmatter', () => {
     await writeFile(join(tmp, 'b.md'), fm(1));
 
     const findings = await checkFrontmatter({ docsPath: tmp, strict: false });
+    expect(findings).toHaveLength(2);
 
     const dup = findings.find((f) => f.rule === Rule.DuplicatePosition);
     expect(dup).toBeDefined();

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { checkFrontmatter } from './frontmatter.js';
+
+const input = (docsPath: string) => ({ docsPath, strict: true });
+
+describe('checkFrontmatter', () => {
+  it('should report missing required fields', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(join(tmp, 'page.md'), '---\ntitle: Hello\n---\n# Hi\n');
+
+    const findings = await checkFrontmatter(input(tmp));
+
+    const missing = findings.filter((f) => f.rule === 'frontmatter-required-fields');
+    expect(missing).toHaveLength(2);
+    expect(missing.map((f) => f.title)).toContain('Missing required field: description');
+    expect(missing.map((f) => f.title)).toContain('Missing required field: sidebar_position');
+  });
+
+  it('should report wrong field types', async () => {
+    const invalidDocs = join(__dirname, '..', '..', '__fixtures__', 'invalid-frontmatter-docs');
+    const findings = await checkFrontmatter(input(invalidDocs));
+
+    const typeErrors = findings.filter((f) => f.rule === 'frontmatter-field-types');
+    expect(typeErrors.length).toBeGreaterThanOrEqual(3);
+    expect(typeErrors.some((f) => f.title.includes('title'))).toBe(true);
+    expect(typeErrors.some((f) => f.title.includes('description'))).toBe(true);
+    expect(typeErrors.some((f) => f.title.includes('sidebar_position'))).toBe(true);
+  });
+
+  it('should report invalid custom slug', async () => {
+    const unsafeDocs = join(__dirname, '..', '..', '__fixtures__', 'unsafe-slug-docs');
+    const findings = await checkFrontmatter(input(unsafeDocs));
+
+    const slugWarning = findings.find((f) => f.rule === 'frontmatter-valid-slug');
+    expect(slugWarning).toBeDefined();
+    expect(slugWarning!.severity).toBe('warning');
+  });
+
+  it('should not report for valid frontmatter', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(
+      join(tmp, 'index.md'),
+      '---\ntitle: Home\ndescription: Welcome\nsidebar_position: 1\n---\n# Home\n'
+    );
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings).toHaveLength(0);
+  });
+
+  it('should not report slug warning when slug is valid', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(
+      join(tmp, 'page.md'),
+      '---\ntitle: Page\ndescription: A page\nsidebar_position: 1\nslug: custom-slug\n---\n# Page\n'
+    );
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings).toHaveLength(0);
+  });
+
+  it('should check files in subdirectories', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await mkdir(join(tmp, 'sub'));
+    await writeFile(join(tmp, 'sub', 'page.md'), '---\n---\n# Empty frontmatter\n');
+
+    const findings = await checkFrontmatter(input(tmp));
+
+    const missing = findings.filter((f) => f.rule === 'frontmatter-required-fields');
+    expect(missing).toHaveLength(3);
+    expect(missing[0].file).toContain('sub');
+  });
+
+  it('should return empty for nonexistent path', async () => {
+    const findings = await checkFrontmatter(input('/nonexistent/path'));
+    expect(findings).toHaveLength(0);
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
@@ -160,6 +160,26 @@ describe('checkFrontmatter', () => {
     const dups = findings.filter((f) => f.rule === Rule.DuplicatePosition);
     expect(dups).toHaveLength(2);
     expect(dups[0].title).toContain('1');
+    const files = dups.map((d) => d.file);
+    expect(files).toContain('a.md');
+    expect(files).toContain('b.md');
+  });
+
+  it('should report no-duplicate-sidebar-position for all three files when three siblings share a position', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const fm = (pos: number) => `---\ntitle: Page\ndescription: A page\nsidebar_position: ${pos}\n---\n`;
+    await writeFile(join(tmp, 'a.md'), fm(1));
+    await writeFile(join(tmp, 'b.md'), fm(1));
+    await writeFile(join(tmp, 'c.md'), fm(1));
+
+    const findings = await checkFrontmatter(input(tmp));
+
+    const dups = findings.filter((f) => f.rule === Rule.DuplicatePosition);
+    expect(dups).toHaveLength(3);
+    const files = dups.map((d) => d.file);
+    expect(files).toContain('a.md');
+    expect(files).toContain('b.md');
+    expect(files).toContain('c.md');
   });
 
   it('should not report no-duplicate-sidebar-position for unique positions', async () => {
@@ -170,6 +190,19 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
     expect(findings.find((f) => f.rule === Rule.DuplicatePosition)).toBeUndefined();
+  });
+
+  it('should report no-duplicate-sidebar-position as warning in non-strict mode', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const fm = (pos: number) => `---\ntitle: Page\ndescription: A page\nsidebar_position: ${pos}\n---\n`;
+    await writeFile(join(tmp, 'a.md'), fm(1));
+    await writeFile(join(tmp, 'b.md'), fm(1));
+
+    const findings = await checkFrontmatter({ docsPath: tmp, strict: false });
+
+    const dup = findings.find((f) => f.rule === Rule.DuplicatePosition);
+    expect(dup).toBeDefined();
+    expect(dup!.severity).toBe('warning');
   });
 
   it('should not report no-duplicate-sidebar-position for same position in different dirs', async () => {
@@ -196,6 +229,9 @@ describe('checkFrontmatter', () => {
     expect(dups).toHaveLength(2);
     expect(dups[0].severity).toBe('error');
     expect(dups[0].title).toContain('same-slug');
+    const files = dups.map((d) => d.file);
+    expect(files).toContain('a.md');
+    expect(files).toContain('b.md');
   });
 
   it('should not report no-duplicate-slugs for unique custom slugs', async () => {

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
@@ -39,11 +39,11 @@ describe('checkFrontmatter', () => {
     expect(slugWarning!.severity).toBe('warning');
   });
 
-  it('should not report for valid frontmatter', async () => {
+  it('should not report for valid frontmatter without h1', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
     await writeFile(
       join(tmp, 'index.md'),
-      '---\ntitle: Home\ndescription: Welcome\nsidebar_position: 1\n---\n# Home\n'
+      '---\ntitle: Home\ndescription: Welcome\nsidebar_position: 1\n---\n## Introduction\n'
     );
 
     const findings = await checkFrontmatter(input(tmp));
@@ -54,17 +54,53 @@ describe('checkFrontmatter', () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
     await writeFile(
       join(tmp, 'page.md'),
-      '---\ntitle: Page\ndescription: A page\nsidebar_position: 1\nslug: custom-slug\n---\n# Page\n'
+      '---\ntitle: Page\ndescription: A page\nsidebar_position: 1\nslug: custom-slug\n---\n## Content\n'
     );
 
     const findings = await checkFrontmatter(input(tmp));
     expect(findings).toHaveLength(0);
   });
 
+  it('should include line numbers for wrong field types', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    // title on line 2, description on line 3
+    await writeFile(join(tmp, 'page.md'), '---\ntitle: 123\ndescription: Valid\nsidebar_position: 1\n---\n');
+
+    const findings = await checkFrontmatter(input(tmp));
+    const titleError = findings.find((f) => f.rule === 'frontmatter-field-types' && f.title.includes('title'));
+    expect(titleError).toBeDefined();
+    expect(titleError!.line).toBe(2);
+  });
+
+  it('should report h1 heading in body', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(
+      join(tmp, 'page.md'),
+      '---\ntitle: Page\ndescription: A page\nsidebar_position: 1\n---\n\n# Big Heading\n'
+    );
+
+    const findings = await checkFrontmatter(input(tmp));
+    const h1 = findings.find((f) => f.rule === 'no-h1-heading');
+    expect(h1).toBeDefined();
+    expect(h1!.severity).toBe('warning');
+    expect(h1!.line).toBe(7);
+  });
+
+  it('should not report h2 or lower headings', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(
+      join(tmp, 'page.md'),
+      '---\ntitle: Page\ndescription: A page\nsidebar_position: 1\n---\n## Fine\n### Also fine\n'
+    );
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings.find((f) => f.rule === 'no-h1-heading')).toBeUndefined();
+  });
+
   it('should check files in subdirectories', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
     await mkdir(join(tmp, 'sub'));
-    await writeFile(join(tmp, 'sub', 'page.md'), '---\n---\n# Empty frontmatter\n');
+    await writeFile(join(tmp, 'sub', 'page.md'), '---\n---\n');
 
     const findings = await checkFrontmatter(input(tmp));
 
@@ -76,5 +112,99 @@ describe('checkFrontmatter', () => {
   it('should return empty for nonexistent path', async () => {
     const findings = await checkFrontmatter(input('/nonexistent/path'));
     expect(findings).toHaveLength(0);
+  });
+
+  it('should report frontmatter-block-exists when file has no frontmatter', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(join(tmp, 'page.md'), '# Just a heading\n\nNo frontmatter here.\n');
+
+    const findings = await checkFrontmatter(input(tmp));
+
+    const finding = findings.find((f) => f.rule === 'frontmatter-block-exists');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(finding!.line).toBe(1);
+  });
+
+  it('should not report frontmatter-block-exists when file starts with ---', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(
+      join(tmp, 'page.md'),
+      '---\ntitle: Page\ndescription: A page\nsidebar_position: 1\n---\n## Content\n'
+    );
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings.find((f) => f.rule === 'frontmatter-block-exists')).toBeUndefined();
+  });
+
+  it('should report frontmatter-valid-yaml for invalid YAML', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(join(tmp, 'page.md'), '---\ntitle: [unclosed\n---\n## Content\n');
+
+    const findings = await checkFrontmatter(input(tmp));
+
+    const finding = findings.find((f) => f.rule === 'frontmatter-valid-yaml');
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+  });
+
+  it('should report no-duplicate-sidebar-position for siblings with same position', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const fm = (pos: number) => `---\ntitle: Page\ndescription: A page\nsidebar_position: ${pos}\n---\n`;
+    await writeFile(join(tmp, 'a.md'), fm(1));
+    await writeFile(join(tmp, 'b.md'), fm(1));
+
+    const findings = await checkFrontmatter(input(tmp));
+
+    const dups = findings.filter((f) => f.rule === 'no-duplicate-sidebar-position');
+    expect(dups).toHaveLength(2);
+    expect(dups[0].title).toContain('1');
+  });
+
+  it('should not report no-duplicate-sidebar-position for unique positions', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const fm = (pos: number) => `---\ntitle: Page\ndescription: A page\nsidebar_position: ${pos}\n---\n`;
+    await writeFile(join(tmp, 'a.md'), fm(1));
+    await writeFile(join(tmp, 'b.md'), fm(2));
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings.find((f) => f.rule === 'no-duplicate-sidebar-position')).toBeUndefined();
+  });
+
+  it('should not report no-duplicate-sidebar-position for same position in different dirs', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await mkdir(join(tmp, 'sub'));
+    const fm = (pos: number) => `---\ntitle: Page\ndescription: A page\nsidebar_position: ${pos}\n---\n`;
+    await writeFile(join(tmp, 'a.md'), fm(1));
+    await writeFile(join(tmp, 'sub', 'b.md'), fm(1));
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings.find((f) => f.rule === 'no-duplicate-sidebar-position')).toBeUndefined();
+  });
+
+  it('should report no-duplicate-slugs for two files with the same custom slug', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const fm = (pos: number) =>
+      `---\ntitle: Page\ndescription: A page\nsidebar_position: ${pos}\nslug: same-slug\n---\n`;
+    await writeFile(join(tmp, 'a.md'), fm(1));
+    await writeFile(join(tmp, 'b.md'), fm(2));
+
+    const findings = await checkFrontmatter(input(tmp));
+
+    const dups = findings.filter((f) => f.rule === 'no-duplicate-slugs');
+    expect(dups).toHaveLength(2);
+    expect(dups[0].severity).toBe('error');
+    expect(dups[0].title).toContain('same-slug');
+  });
+
+  it('should not report no-duplicate-slugs for unique custom slugs', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const fm = (pos: number, slug: string) =>
+      `---\ntitle: Page\ndescription: A page\nsidebar_position: ${pos}\nslug: ${slug}\n---\n`;
+    await writeFile(join(tmp, 'a.md'), fm(1, 'slug-one'));
+    await writeFile(join(tmp, 'b.md'), fm(2, 'slug-two'));
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings.find((f) => f.rule === 'no-duplicate-slugs')).toBeUndefined();
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
@@ -15,9 +15,8 @@ describe('checkFrontmatter', () => {
     const findings = await checkFrontmatter(input(tmp));
 
     const missing = findings.filter((f) => f.rule === Rule.RequiredFields);
-    expect(missing).toHaveLength(2);
+    expect(missing).toHaveLength(1);
     expect(missing.map((f) => f.title)).toContain('Missing required field: description');
-    expect(missing.map((f) => f.title)).toContain('Missing required field: sidebar_position');
   });
 
   it('should report wrong field types', async () => {
@@ -106,7 +105,7 @@ describe('checkFrontmatter', () => {
     const findings = await checkFrontmatter(input(tmp));
 
     const missing = findings.filter((f) => f.rule === Rule.RequiredFields);
-    expect(missing).toHaveLength(3);
+    expect(missing).toHaveLength(2);
     expect(missing[0].file).toContain('sub');
   });
 

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { checkFrontmatter } from './frontmatter.js';
+import { Rule } from '../types.js';
 
 const input = (docsPath: string) => ({ docsPath, strict: true });
 
@@ -13,7 +14,7 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
 
-    const missing = findings.filter((f) => f.rule === 'frontmatter-required-fields');
+    const missing = findings.filter((f) => f.rule === Rule.RequiredFields);
     expect(missing).toHaveLength(2);
     expect(missing.map((f) => f.title)).toContain('Missing required field: description');
     expect(missing.map((f) => f.title)).toContain('Missing required field: sidebar_position');
@@ -23,7 +24,7 @@ describe('checkFrontmatter', () => {
     const invalidDocs = join(__dirname, '..', '..', '__fixtures__', 'invalid-frontmatter-docs');
     const findings = await checkFrontmatter(input(invalidDocs));
 
-    const typeErrors = findings.filter((f) => f.rule === 'frontmatter-field-types');
+    const typeErrors = findings.filter((f) => f.rule === Rule.FieldTypes);
     expect(typeErrors.length).toBeGreaterThanOrEqual(3);
     expect(typeErrors.some((f) => f.title.includes('title'))).toBe(true);
     expect(typeErrors.some((f) => f.title.includes('description'))).toBe(true);
@@ -34,7 +35,7 @@ describe('checkFrontmatter', () => {
     const unsafeDocs = join(__dirname, '..', '..', '__fixtures__', 'unsafe-slug-docs');
     const findings = await checkFrontmatter(input(unsafeDocs));
 
-    const slugWarning = findings.find((f) => f.rule === 'frontmatter-valid-slug');
+    const slugWarning = findings.find((f) => f.rule === Rule.ValidSlug);
     expect(slugWarning).toBeDefined();
     expect(slugWarning!.severity).toBe('warning');
   });
@@ -67,7 +68,7 @@ describe('checkFrontmatter', () => {
     await writeFile(join(tmp, 'page.md'), '---\ntitle: 123\ndescription: Valid\nsidebar_position: 1\n---\n');
 
     const findings = await checkFrontmatter(input(tmp));
-    const titleError = findings.find((f) => f.rule === 'frontmatter-field-types' && f.title.includes('title'));
+    const titleError = findings.find((f) => f.rule === Rule.FieldTypes && f.title.includes('title'));
     expect(titleError).toBeDefined();
     expect(titleError!.line).toBe(2);
   });
@@ -80,7 +81,7 @@ describe('checkFrontmatter', () => {
     );
 
     const findings = await checkFrontmatter(input(tmp));
-    const h1 = findings.find((f) => f.rule === 'no-h1-heading');
+    const h1 = findings.find((f) => f.rule === Rule.NoH1);
     expect(h1).toBeDefined();
     expect(h1!.severity).toBe('warning');
     expect(h1!.line).toBe(7);
@@ -94,7 +95,7 @@ describe('checkFrontmatter', () => {
     );
 
     const findings = await checkFrontmatter(input(tmp));
-    expect(findings.find((f) => f.rule === 'no-h1-heading')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.NoH1)).toBeUndefined();
   });
 
   it('should check files in subdirectories', async () => {
@@ -104,7 +105,7 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
 
-    const missing = findings.filter((f) => f.rule === 'frontmatter-required-fields');
+    const missing = findings.filter((f) => f.rule === Rule.RequiredFields);
     expect(missing).toHaveLength(3);
     expect(missing[0].file).toContain('sub');
   });
@@ -120,7 +121,7 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
 
-    const finding = findings.find((f) => f.rule === 'frontmatter-block-exists');
+    const finding = findings.find((f) => f.rule === Rule.BlockExists);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
     expect(finding!.line).toBe(1);
@@ -134,7 +135,7 @@ describe('checkFrontmatter', () => {
     );
 
     const findings = await checkFrontmatter(input(tmp));
-    expect(findings.find((f) => f.rule === 'frontmatter-block-exists')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.BlockExists)).toBeUndefined();
   });
 
   it('should report frontmatter-valid-yaml for invalid YAML', async () => {
@@ -143,7 +144,7 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
 
-    const finding = findings.find((f) => f.rule === 'frontmatter-valid-yaml');
+    const finding = findings.find((f) => f.rule === Rule.ValidYaml);
     expect(finding).toBeDefined();
     expect(finding!.severity).toBe('error');
   });
@@ -156,7 +157,7 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
 
-    const dups = findings.filter((f) => f.rule === 'no-duplicate-sidebar-position');
+    const dups = findings.filter((f) => f.rule === Rule.DuplicatePosition);
     expect(dups).toHaveLength(2);
     expect(dups[0].title).toContain('1');
   });
@@ -168,7 +169,7 @@ describe('checkFrontmatter', () => {
     await writeFile(join(tmp, 'b.md'), fm(2));
 
     const findings = await checkFrontmatter(input(tmp));
-    expect(findings.find((f) => f.rule === 'no-duplicate-sidebar-position')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.DuplicatePosition)).toBeUndefined();
   });
 
   it('should not report no-duplicate-sidebar-position for same position in different dirs', async () => {
@@ -179,7 +180,7 @@ describe('checkFrontmatter', () => {
     await writeFile(join(tmp, 'sub', 'b.md'), fm(1));
 
     const findings = await checkFrontmatter(input(tmp));
-    expect(findings.find((f) => f.rule === 'no-duplicate-sidebar-position')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.DuplicatePosition)).toBeUndefined();
   });
 
   it('should report no-duplicate-slugs for two files with the same custom slug', async () => {
@@ -191,7 +192,7 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
 
-    const dups = findings.filter((f) => f.rule === 'no-duplicate-slugs');
+    const dups = findings.filter((f) => f.rule === Rule.DuplicateSlug);
     expect(dups).toHaveLength(2);
     expect(dups[0].severity).toBe('error');
     expect(dups[0].title).toContain('same-slug');
@@ -205,6 +206,6 @@ describe('checkFrontmatter', () => {
     await writeFile(join(tmp, 'b.md'), fm(2, 'slug-two'));
 
     const findings = await checkFrontmatter(input(tmp));
-    expect(findings.find((f) => f.rule === 'no-duplicate-slugs')).toBeUndefined();
+    expect(findings.find((f) => f.rule === Rule.DuplicateSlug)).toBeUndefined();
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import type { Dirent } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
 import matter from 'gray-matter';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 
@@ -33,7 +34,7 @@ function findFieldLine(raw: string, key: string): number | undefined {
   const lines = raw.split('\n');
   // frontmatter starts after the opening ---, so skip line 0
   for (let i = 1; i < lines.length; i++) {
-    if (lines[i] === '---') {
+    if (lines[i].trim() === '---') {
       break;
     }
     if (lines[i].startsWith(`${key}:`)) {
@@ -44,13 +45,14 @@ function findFieldLine(raw: string, key: string): number | undefined {
 }
 
 /**
- * Finds the 1-based line number of the first h1 heading (# ) in the markdown body.
+ * Finds the 1-based line numbers of all h1 headings (# ) in the markdown body.
  * The body starts after the closing --- of frontmatter.
  */
-function findH1Line(raw: string): number | undefined {
+function findH1Lines(raw: string): number[] {
   const lines = raw.split('\n');
   let inFrontmatter = false;
   let passedFrontmatter = false;
+  const result: number[] = [];
   for (let i = 0; i < lines.length; i++) {
     if (lines[i].trim() === '---') {
       if (!inFrontmatter) {
@@ -61,10 +63,10 @@ function findH1Line(raw: string): number | undefined {
       continue;
     }
     if (passedFrontmatter && /^# /.test(lines[i])) {
-      return i + 1;
+      result.push(i + 1);
     }
   }
-  return undefined;
+  return result;
 }
 
 // tracks per-file data needed for cross-file duplicate checks
@@ -80,22 +82,24 @@ interface FileRecord {
 export async function checkFrontmatter(input: ValidationInput): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];
 
-  let entries: string[] = [];
+  let entries: Dirent[] = [];
   try {
-    entries = await readdir(input.docsPath, { recursive: true });
+    entries = await readdir(input.docsPath, { recursive: true, withFileTypes: true });
   } catch {
     // docsPath doesn't exist - filesystem rules handle this
     return diagnostics;
   }
 
   const mdFiles = entries.filter(
-    (entry) => entry.endsWith('.md') && !entry.includes('node_modules') && !entry.includes('dist')
+    (e) =>
+      e.isFile() && e.name.endsWith('.md') && !e.parentPath.includes('node_modules') && !e.parentPath.includes('dist')
   );
 
   const records: FileRecord[] = [];
 
-  for (const relativePath of mdFiles) {
-    const absolutePath = join(input.docsPath, relativePath);
+  for (const file of mdFiles) {
+    const absolutePath = join(file.parentPath, file.name);
+    const relativePath = relative(input.docsPath, absolutePath);
     let raw: string;
     try {
       raw = await readFile(absolutePath, 'utf-8');
@@ -168,8 +172,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
     }
 
     // check for h1 headings in body - title comes from frontmatter
-    const h1Line = findH1Line(raw);
-    if (h1Line) {
+    for (const h1Line of findH1Lines(raw)) {
       diagnostics.push({
         rule: Rule.NoH1,
         severity: 'warning',
@@ -229,26 +232,25 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
   }
 
   // no-duplicate-slugs: custom slugs must be unique across all files
-  const slugSeen = new Map<string, FileRecord>();
+  // two-pass: count occurrences first, then report every file that uses a duplicate slug
+  const slugCounts = new Map<string, number>();
   for (const record of records) {
-    if (!record.customSlug) {
+    if (record.customSlug) {
+      slugCounts.set(record.customSlug, (slugCounts.get(record.customSlug) ?? 0) + 1);
+    }
+  }
+  for (const record of records) {
+    if (!record.customSlug || (slugCounts.get(record.customSlug) ?? 0) <= 1) {
       continue;
     }
-    const prev = slugSeen.get(record.customSlug);
-    if (prev) {
-      for (const dup of [prev, record]) {
-        diagnostics.push({
-          rule: Rule.DuplicateSlug,
-          severity: 'error',
-          file: dup.relativePath,
-          line: dup.customSlugLine,
-          title: `Duplicate slug: "${record.customSlug}"`,
-          detail: `"${prev.relativePath}" and "${record.relativePath}" both use slug "${record.customSlug}". Each page must have a unique URL slug.`,
-        });
-      }
-    } else {
-      slugSeen.set(record.customSlug, record);
-    }
+    diagnostics.push({
+      rule: Rule.DuplicateSlug,
+      severity: 'error',
+      file: record.relativePath,
+      line: record.customSlugLine,
+      title: `Duplicate slug: "${record.customSlug}"`,
+      detail: `Slug "${record.customSlug}" is used by multiple pages. Each page must have a unique URL slug.`,
+    });
   }
 
   return diagnostics;

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -117,7 +117,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
         file: relativePath,
         line: 1,
         title: 'Missing frontmatter block',
-        detail: 'Every page must start with a frontmatter block (---). Add title, description and sidebar_position.',
+        detail: 'Every page must start with a frontmatter block (---). Add at least title and description.',
       });
       continue;
     }
@@ -206,7 +206,8 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
       parentDir: dirname(relativePath),
       sidebarPosition: typeof data.sidebar_position === 'number' ? data.sidebar_position : undefined,
       sidebarPositionLine: findFieldLine(raw, 'sidebar_position'),
-      customSlug: typeof data.slug === 'string' && isSlugSafe(data.slug) ? data.slug : undefined,
+      customSlug:
+        typeof data.slug === 'string' && isSlugSafe(data.slug) ? data.slug.trim().replace(/^\/+|\/+$/g, '') : undefined,
       customSlugLine: findFieldLine(raw, 'slug'),
     });
   }

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -167,7 +167,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
         file: relativePath,
         line: findFieldLine(raw, 'slug'),
         title: 'Invalid custom slug',
-        detail: `The slug "${data.slug}" contains unsafe characters. Only letters, digits, hyphens and forward slashes are allowed.`,
+        detail: `The slug "${data.slug}" contains unsafe characters. Only letters, digits, underscores, hyphens and forward slashes are allowed.`,
       });
     }
 
@@ -196,38 +196,27 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
   }
 
   // no-duplicate-sidebar-position: siblings (same parent dir) must have unique positions
+  // two-pass: count occurrences first, then report every sibling that uses a duplicate position
   const byDir = Map.groupBy(records, (r) => r.parentDir);
   for (const siblings of byDir.values()) {
-    const seen = new Map<number, FileRecord | null>();
+    const posCounts = new Map<number, number>();
     for (const record of siblings) {
-      if (record.sidebarPosition === undefined) {
+      if (record.sidebarPosition !== undefined) {
+        posCounts.set(record.sidebarPosition, (posCounts.get(record.sidebarPosition) ?? 0) + 1);
+      }
+    }
+    for (const record of siblings) {
+      if (record.sidebarPosition === undefined || (posCounts.get(record.sidebarPosition) ?? 0) <= 1) {
         continue;
       }
-      const prev = seen.get(record.sidebarPosition);
-      if (prev) {
-        // report current file; only report prev on the first collision (when prev is still set)
-        if (prev !== null) {
-          diagnostics.push({
-            rule: Rule.DuplicatePosition,
-            severity: input.strict ? 'error' : 'warning',
-            file: prev.relativePath,
-            line: prev.sidebarPositionLine,
-            title: `Duplicate sidebar_position: ${record.sidebarPosition}`,
-            detail: `"${prev.relativePath}" and "${record.relativePath}" share sidebar_position ${record.sidebarPosition}. Each sibling page must have a unique position.`,
-          });
-          seen.set(record.sidebarPosition, null);
-        }
-        diagnostics.push({
-          rule: Rule.DuplicatePosition,
-          severity: input.strict ? 'error' : 'warning',
-          file: record.relativePath,
-          line: record.sidebarPositionLine,
-          title: `Duplicate sidebar_position: ${record.sidebarPosition}`,
-          detail: `"${prev.relativePath}" and "${record.relativePath}" share sidebar_position ${record.sidebarPosition}. Each sibling page must have a unique position.`,
-        });
-      } else {
-        seen.set(record.sidebarPosition, record);
-      }
+      diagnostics.push({
+        rule: Rule.DuplicatePosition,
+        severity: input.strict ? 'error' : 'warning',
+        file: record.relativePath,
+        line: record.sidebarPositionLine,
+        title: `Duplicate sidebar_position: ${record.sidebarPosition}`,
+        detail: `sidebar_position ${record.sidebarPosition} is shared by multiple siblings. Each sibling page must have a unique position.`,
+      });
     }
   }
 

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -1,0 +1,92 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+import type { Diagnostic, ValidationInput } from '../types.js';
+
+const RULE_REQUIRED_FIELDS = 'frontmatter-required-fields';
+const RULE_FIELD_TYPES = 'frontmatter-field-types';
+const RULE_VALID_SLUG = 'frontmatter-valid-slug';
+
+const REQUIRED_FIELDS: Array<{ key: string; type: string }> = [
+  { key: 'title', type: 'string' },
+  { key: 'description', type: 'string' },
+  { key: 'sidebar_position', type: 'number' },
+];
+
+/**
+ * Checks whether a custom slug is safe for use in URLs.
+ * Mirrors the logic in scanner.ts normalizeCustomSlug.
+ */
+function isSlugSafe(raw: string): boolean {
+  const trimmed = raw.trim().replace(/^\/+|\/+$/g, '');
+  if (!trimmed) {
+    return false;
+  }
+  if (!/^[A-Za-z0-9/_-]+$/.test(trimmed)) {
+    return false;
+  }
+  const segments = trimmed.split('/');
+  return !segments.some((s) => !s || s === '.' || s === '..');
+}
+
+export async function checkFrontmatter(input: ValidationInput): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = [];
+
+  let entries: string[] = [];
+  try {
+    entries = await readdir(input.docsPath, { recursive: true });
+  } catch {
+    // docsPath doesn't exist - filesystem rules handle this
+    return diagnostics;
+  }
+
+  const mdFiles = entries.filter(
+    (entry) => entry.endsWith('.md') && !entry.includes('node_modules') && !entry.includes('dist')
+  );
+
+  for (const relativePath of mdFiles) {
+    const absolutePath = join(input.docsPath, relativePath);
+    let raw: string;
+    try {
+      raw = await readFile(absolutePath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const { data } = matter(raw);
+
+    // check required fields are present and have correct types
+    for (const { key, type } of REQUIRED_FIELDS) {
+      if (!(key in data)) {
+        diagnostics.push({
+          rule: RULE_REQUIRED_FIELDS,
+          severity: 'error',
+          file: relativePath,
+          title: `Missing required field: ${key}`,
+          detail: `Every page needs a "${key}" (${type}) in its frontmatter.`,
+        });
+      } else if (typeof data[key] !== type) {
+        diagnostics.push({
+          rule: RULE_FIELD_TYPES,
+          severity: 'error',
+          file: relativePath,
+          title: `Wrong type for field: ${key}`,
+          detail: `"${key}" should be a ${type} but got ${typeof data[key]}.`,
+        });
+      }
+    }
+
+    // check custom slug if present
+    if ('slug' in data && typeof data.slug === 'string' && !isSlugSafe(data.slug)) {
+      diagnostics.push({
+        rule: RULE_VALID_SLUG,
+        severity: 'warning',
+        file: relativePath,
+        title: 'Invalid custom slug',
+        detail: `The slug "${data.slug}" contains unsafe characters. Only letters, digits, hyphens and forward slashes are allowed.`,
+      });
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -1,16 +1,7 @@
 import { readFile, readdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import matter from 'gray-matter';
-import type { Diagnostic, ValidationInput } from '../types.js';
-
-const RULE_BLOCK_EXISTS = 'frontmatter-block-exists';
-const RULE_VALID_YAML = 'frontmatter-valid-yaml';
-const RULE_REQUIRED_FIELDS = 'frontmatter-required-fields';
-const RULE_FIELD_TYPES = 'frontmatter-field-types';
-const RULE_VALID_SLUG = 'frontmatter-valid-slug';
-const RULE_NO_H1 = 'no-h1-heading';
-const RULE_DUPLICATE_POSITION = 'no-duplicate-sidebar-position';
-const RULE_DUPLICATE_SLUG = 'no-duplicate-slugs';
+import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 
 const REQUIRED_FIELDS: Array<{ key: string; type: string }> = [
   { key: 'title', type: 'string' },
@@ -115,7 +106,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
     // frontmatter-block-exists: file must start with ---
     if (!raw.startsWith('---')) {
       diagnostics.push({
-        rule: RULE_BLOCK_EXISTS,
+        rule: Rule.BlockExists,
         severity: 'error',
         file: relativePath,
         line: 1,
@@ -131,7 +122,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
       ({ data } = matter(raw));
     } catch (err) {
       diagnostics.push({
-        rule: RULE_VALID_YAML,
+        rule: Rule.ValidYaml,
         severity: 'error',
         file: relativePath,
         line: 1,
@@ -145,7 +136,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
     for (const { key, type } of REQUIRED_FIELDS) {
       if (!(key in data)) {
         diagnostics.push({
-          rule: RULE_REQUIRED_FIELDS,
+          rule: Rule.RequiredFields,
           severity: 'error',
           file: relativePath,
           line: 1,
@@ -154,7 +145,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
         });
       } else if (typeof data[key] !== type) {
         diagnostics.push({
-          rule: RULE_FIELD_TYPES,
+          rule: Rule.FieldTypes,
           severity: 'error',
           file: relativePath,
           line: findFieldLine(raw, key),
@@ -167,7 +158,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
     // check custom slug if present
     if ('slug' in data && typeof data.slug === 'string' && !isSlugSafe(data.slug)) {
       diagnostics.push({
-        rule: RULE_VALID_SLUG,
+        rule: Rule.ValidSlug,
         severity: 'warning',
         file: relativePath,
         line: findFieldLine(raw, 'slug'),
@@ -180,7 +171,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
     const h1Line = findH1Line(raw);
     if (h1Line) {
       diagnostics.push({
-        rule: RULE_NO_H1,
+        rule: Rule.NoH1,
         severity: 'warning',
         file: relativePath,
         line: h1Line,
@@ -213,7 +204,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
       if (prev) {
         for (const dup of [prev, record]) {
           diagnostics.push({
-            rule: RULE_DUPLICATE_POSITION,
+            rule: Rule.DuplicatePosition,
             severity: input.strict ? 'error' : 'warning',
             file: dup.relativePath,
             line: dup.sidebarPositionLine,
@@ -237,7 +228,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
     if (prev) {
       for (const dup of [prev, record]) {
         diagnostics.push({
-          rule: RULE_DUPLICATE_SLUG,
+          rule: Rule.DuplicateSlug,
           severity: 'error',
           file: dup.relativePath,
           line: dup.customSlugLine,

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -1,11 +1,16 @@
 import { readFile, readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import matter from 'gray-matter';
 import type { Diagnostic, ValidationInput } from '../types.js';
 
+const RULE_BLOCK_EXISTS = 'frontmatter-block-exists';
+const RULE_VALID_YAML = 'frontmatter-valid-yaml';
 const RULE_REQUIRED_FIELDS = 'frontmatter-required-fields';
 const RULE_FIELD_TYPES = 'frontmatter-field-types';
 const RULE_VALID_SLUG = 'frontmatter-valid-slug';
+const RULE_NO_H1 = 'no-h1-heading';
+const RULE_DUPLICATE_POSITION = 'no-duplicate-sidebar-position';
+const RULE_DUPLICATE_SLUG = 'no-duplicate-slugs';
 
 const REQUIRED_FIELDS: Array<{ key: string; type: string }> = [
   { key: 'title', type: 'string' },
@@ -29,6 +34,58 @@ function isSlugSafe(raw: string): boolean {
   return !segments.some((s) => !s || s === '.' || s === '..');
 }
 
+/**
+ * Finds the 1-based line number of a frontmatter key in the raw file content.
+ * Returns undefined if the key isn't found.
+ */
+function findFieldLine(raw: string, key: string): number | undefined {
+  const lines = raw.split('\n');
+  // frontmatter starts after the opening ---, so skip line 0
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i] === '---') {
+      break;
+    }
+    if (lines[i].startsWith(`${key}:`)) {
+      return i + 1;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Finds the 1-based line number of the first h1 heading (# ) in the markdown body.
+ * The body starts after the closing --- of frontmatter.
+ */
+function findH1Line(raw: string): number | undefined {
+  const lines = raw.split('\n');
+  let inFrontmatter = false;
+  let passedFrontmatter = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      if (!inFrontmatter) {
+        inFrontmatter = true;
+      } else {
+        passedFrontmatter = true;
+      }
+      continue;
+    }
+    if (passedFrontmatter && /^# /.test(lines[i])) {
+      return i + 1;
+    }
+  }
+  return undefined;
+}
+
+// tracks per-file data needed for cross-file duplicate checks
+interface FileRecord {
+  relativePath: string;
+  parentDir: string;
+  sidebarPosition: number | undefined;
+  sidebarPositionLine: number | undefined;
+  customSlug: string | undefined;
+  customSlugLine: number | undefined;
+}
+
 export async function checkFrontmatter(input: ValidationInput): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];
 
@@ -44,6 +101,8 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
     (entry) => entry.endsWith('.md') && !entry.includes('node_modules') && !entry.includes('dist')
   );
 
+  const records: FileRecord[] = [];
+
   for (const relativePath of mdFiles) {
     const absolutePath = join(input.docsPath, relativePath);
     let raw: string;
@@ -53,7 +112,34 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
       continue;
     }
 
-    const { data } = matter(raw);
+    // frontmatter-block-exists: file must start with ---
+    if (!raw.startsWith('---')) {
+      diagnostics.push({
+        rule: RULE_BLOCK_EXISTS,
+        severity: 'error',
+        file: relativePath,
+        line: 1,
+        title: 'Missing frontmatter block',
+        detail: 'Every page must start with a frontmatter block (---). Add title, description and sidebar_position.',
+      });
+      continue;
+    }
+
+    // frontmatter-valid-yaml: gray-matter throws on invalid YAML
+    let data: Record<string, unknown>;
+    try {
+      ({ data } = matter(raw));
+    } catch (err) {
+      diagnostics.push({
+        rule: RULE_VALID_YAML,
+        severity: 'error',
+        file: relativePath,
+        line: 1,
+        title: 'Invalid YAML in frontmatter',
+        detail: err instanceof Error ? err.message : 'YAML parse error.',
+      });
+      continue;
+    }
 
     // check required fields are present and have correct types
     for (const { key, type } of REQUIRED_FIELDS) {
@@ -62,6 +148,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
           rule: RULE_REQUIRED_FIELDS,
           severity: 'error',
           file: relativePath,
+          line: 1,
           title: `Missing required field: ${key}`,
           detail: `Every page needs a "${key}" (${type}) in its frontmatter.`,
         });
@@ -70,6 +157,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
           rule: RULE_FIELD_TYPES,
           severity: 'error',
           file: relativePath,
+          line: findFieldLine(raw, key),
           title: `Wrong type for field: ${key}`,
           detail: `"${key}" should be a ${type} but got ${typeof data[key]}.`,
         });
@@ -82,9 +170,83 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
         rule: RULE_VALID_SLUG,
         severity: 'warning',
         file: relativePath,
+        line: findFieldLine(raw, 'slug'),
         title: 'Invalid custom slug',
         detail: `The slug "${data.slug}" contains unsafe characters. Only letters, digits, hyphens and forward slashes are allowed.`,
       });
+    }
+
+    // check for h1 headings in body - title comes from frontmatter
+    const h1Line = findH1Line(raw);
+    if (h1Line) {
+      diagnostics.push({
+        rule: RULE_NO_H1,
+        severity: 'warning',
+        file: relativePath,
+        line: h1Line,
+        title: 'Avoid h1 headings in content',
+        detail:
+          'The page title comes from frontmatter. Any h1 in the body will be stripped by the parser. Use h2 (##) or lower.',
+      });
+    }
+
+    // collect for cross-file checks
+    records.push({
+      relativePath,
+      parentDir: dirname(relativePath),
+      sidebarPosition: typeof data.sidebar_position === 'number' ? data.sidebar_position : undefined,
+      sidebarPositionLine: findFieldLine(raw, 'sidebar_position'),
+      customSlug: typeof data.slug === 'string' && isSlugSafe(data.slug) ? data.slug : undefined,
+      customSlugLine: findFieldLine(raw, 'slug'),
+    });
+  }
+
+  // no-duplicate-sidebar-position: siblings (same parent dir) must have unique positions
+  const byDir = Map.groupBy(records, (r) => r.parentDir);
+  for (const siblings of byDir.values()) {
+    const seen = new Map<number, FileRecord>();
+    for (const record of siblings) {
+      if (record.sidebarPosition === undefined) {
+        continue;
+      }
+      const prev = seen.get(record.sidebarPosition);
+      if (prev) {
+        for (const dup of [prev, record]) {
+          diagnostics.push({
+            rule: RULE_DUPLICATE_POSITION,
+            severity: input.strict ? 'error' : 'warning',
+            file: dup.relativePath,
+            line: dup.sidebarPositionLine,
+            title: `Duplicate sidebar_position: ${record.sidebarPosition}`,
+            detail: `"${prev.relativePath}" and "${record.relativePath}" share sidebar_position ${record.sidebarPosition}. Each sibling page must have a unique position.`,
+          });
+        }
+      } else {
+        seen.set(record.sidebarPosition, record);
+      }
+    }
+  }
+
+  // no-duplicate-slugs: custom slugs must be unique across all files
+  const slugSeen = new Map<string, FileRecord>();
+  for (const record of records) {
+    if (!record.customSlug) {
+      continue;
+    }
+    const prev = slugSeen.get(record.customSlug);
+    if (prev) {
+      for (const dup of [prev, record]) {
+        diagnostics.push({
+          rule: RULE_DUPLICATE_SLUG,
+          severity: 'error',
+          file: dup.relativePath,
+          line: dup.customSlugLine,
+          title: `Duplicate slug: "${record.customSlug}"`,
+          detail: `"${prev.relativePath}" and "${record.relativePath}" both use slug "${record.customSlug}". Each page must have a unique URL slug.`,
+        });
+      }
+    } else {
+      slugSeen.set(record.customSlug, record);
     }
   }
 

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -7,8 +7,10 @@ import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 const REQUIRED_FIELDS: Array<{ key: string; type: string }> = [
   { key: 'title', type: 'string' },
   { key: 'description', type: 'string' },
-  { key: 'sidebar_position', type: 'number' },
 ];
+
+// optional fields: validated only when present
+const OPTIONAL_FIELDS: Array<{ key: string; type: string }> = [{ key: 'sidebar_position', type: 'number' }];
 
 /**
  * Checks whether a custom slug is safe for use in URLs.
@@ -148,6 +150,20 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
           detail: `Every page needs a "${key}" (${type}) in its frontmatter.`,
         });
       } else if (typeof data[key] !== type) {
+        diagnostics.push({
+          rule: Rule.FieldTypes,
+          severity: 'error',
+          file: relativePath,
+          line: findFieldLine(raw, key),
+          title: `Wrong type for field: ${key}`,
+          detail: `"${key}" should be a ${type} but got ${typeof data[key]}.`,
+        });
+      }
+    }
+
+    // check optional fields: wrong type only when the field is present
+    for (const { key, type } of OPTIONAL_FIELDS) {
+      if (key in data && typeof data[key] !== type) {
         diagnostics.push({
           rule: Rule.FieldTypes,
           severity: 'error',

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -177,7 +177,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
         line: h1Line,
         title: 'Avoid h1 headings in content',
         detail:
-          'The page title comes from frontmatter. Any h1 in the body will be stripped by the parser. Use h2 (##) or lower.',
+          'The page title comes from frontmatter. Any h1 in the body will be stripped by the parser and replaced by the frontmatter title. Use h2 (##) or lower.',
       });
     }
 
@@ -195,23 +195,33 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
   // no-duplicate-sidebar-position: siblings (same parent dir) must have unique positions
   const byDir = Map.groupBy(records, (r) => r.parentDir);
   for (const siblings of byDir.values()) {
-    const seen = new Map<number, FileRecord>();
+    const seen = new Map<number, FileRecord | null>();
     for (const record of siblings) {
       if (record.sidebarPosition === undefined) {
         continue;
       }
       const prev = seen.get(record.sidebarPosition);
       if (prev) {
-        for (const dup of [prev, record]) {
+        // report current file; only report prev on the first collision (when prev is still set)
+        if (prev !== null) {
           diagnostics.push({
             rule: Rule.DuplicatePosition,
             severity: input.strict ? 'error' : 'warning',
-            file: dup.relativePath,
-            line: dup.sidebarPositionLine,
+            file: prev.relativePath,
+            line: prev.sidebarPositionLine,
             title: `Duplicate sidebar_position: ${record.sidebarPosition}`,
             detail: `"${prev.relativePath}" and "${record.relativePath}" share sidebar_position ${record.sidebarPosition}. Each sibling page must have a unique position.`,
           });
+          seen.set(record.sidebarPosition, null);
         }
+        diagnostics.push({
+          rule: Rule.DuplicatePosition,
+          severity: input.strict ? 'error' : 'warning',
+          file: record.relativePath,
+          line: record.sidebarPositionLine,
+          title: `Duplicate sidebar_position: ${record.sidebarPosition}`,
+          detail: `"${prev.relativePath}" and "${record.relativePath}" share sidebar_position ${record.sidebarPosition}. Each sibling page must have a unique position.`,
+        });
       } else {
         seen.set(record.sidebarPosition, record);
       }

--- a/packages/plugin-docs-cli/src/validation/rules/index.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/index.ts
@@ -1,4 +1,5 @@
 import type { RuleRunner } from '../types.js';
 import { checkFilesystem } from './filesystem.js';
+import { checkFrontmatter } from './frontmatter.js';
 
-export const allRules: RuleRunner[] = [checkFilesystem];
+export const allRules: RuleRunner[] = [checkFilesystem, checkFrontmatter];

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -1,25 +1,27 @@
 export type Severity = 'error' | 'warning' | 'info';
 
-export enum Rule {
+export const Rule = {
   // filesystem rules
-  HasMarkdown = 'has-markdown-files',
-  RootIndex = 'root-index-exists',
-  NestedDirIndex = 'nested-dir-has-index',
-  NoSpaces = 'no-spaces-in-names',
-  ValidNaming = 'valid-file-naming',
-  NoEmptyDir = 'no-empty-directories',
-  NoSymlinks = 'no-symlinks',
-  AllowedFileTypes = 'allowed-file-types',
+  HasMarkdown: 'has-markdown-files',
+  RootIndex: 'root-index-exists',
+  NestedDirIndex: 'nested-dir-has-index',
+  NoSpaces: 'no-spaces-in-names',
+  ValidNaming: 'valid-file-naming',
+  NoEmptyDir: 'no-empty-directories',
+  NoSymlinks: 'no-symlinks',
+  AllowedFileTypes: 'allowed-file-types',
   // frontmatter rules
-  BlockExists = 'frontmatter-block-exists',
-  ValidYaml = 'frontmatter-valid-yaml',
-  RequiredFields = 'frontmatter-required-fields',
-  FieldTypes = 'frontmatter-field-types',
-  ValidSlug = 'frontmatter-valid-slug',
-  NoH1 = 'no-h1-heading',
-  DuplicatePosition = 'no-duplicate-sidebar-position',
-  DuplicateSlug = 'no-duplicate-slugs',
-}
+  BlockExists: 'frontmatter-block-exists',
+  ValidYaml: 'frontmatter-valid-yaml',
+  RequiredFields: 'frontmatter-required-fields',
+  FieldTypes: 'frontmatter-field-types',
+  ValidSlug: 'frontmatter-valid-slug',
+  NoH1: 'no-h1-heading',
+  DuplicatePosition: 'no-duplicate-sidebar-position',
+  DuplicateSlug: 'no-duplicate-slugs',
+} as const;
+
+export type Rule = (typeof Rule)[keyof typeof Rule];
 
 /**
  * A diagnostic reported by a rule runner.

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -1,10 +1,31 @@
 export type Severity = 'error' | 'warning' | 'info';
 
+export enum Rule {
+  // filesystem rules
+  HasMarkdown = 'has-markdown-files',
+  RootIndex = 'root-index-exists',
+  NestedDirIndex = 'nested-dir-has-index',
+  NoSpaces = 'no-spaces-in-names',
+  ValidNaming = 'valid-file-naming',
+  NoEmptyDir = 'no-empty-directories',
+  NoSymlinks = 'no-symlinks',
+  AllowedFileTypes = 'allowed-file-types',
+  // frontmatter rules
+  BlockExists = 'frontmatter-block-exists',
+  ValidYaml = 'frontmatter-valid-yaml',
+  RequiredFields = 'frontmatter-required-fields',
+  FieldTypes = 'frontmatter-field-types',
+  ValidSlug = 'frontmatter-valid-slug',
+  NoH1 = 'no-h1-heading',
+  DuplicatePosition = 'no-duplicate-sidebar-position',
+  DuplicateSlug = 'no-duplicate-slugs',
+}
+
 /**
  * A diagnostic reported by a rule runner.
  */
 export interface Diagnostic {
-  rule: string;
+  rule: Rule;
   severity: Severity;
   file?: string;
   line?: number;

--- a/packages/plugin-docs-parser/src/parser.test.ts
+++ b/packages/plugin-docs-parser/src/parser.test.ts
@@ -4,7 +4,7 @@ import { parseMarkdown } from './parser.js';
 
 describe('parseMarkdown', () => {
   it('should return a valid HAST root node', () => {
-    const markdown = '# Hello World';
+    const markdown = '## Hello World';
     const result = parseMarkdown(markdown);
 
     expect(result.hast).toBeDefined();
@@ -17,9 +17,19 @@ describe('parseMarkdown', () => {
     const result = parseMarkdown(markdown);
     const html = toHtml(result.hast);
 
-    expect(html).toContain('<h1 id="hello-world">Hello World</h1>');
+    expect(html).not.toContain('<h1');
     expect(html).toContain('<p>This is a paragraph.</p>');
     expect(result.frontmatter).toEqual({});
+  });
+
+  it('should strip h1 headings from the body', () => {
+    const markdown = '# Page Title\n\n## Section\n\nContent.';
+    const result = parseMarkdown(markdown);
+    const html = toHtml(result.hast);
+
+    expect(html).not.toContain('<h1');
+    expect(html).toContain('<h2');
+    expect(html).toContain('Content.');
   });
 
   it('should extract frontmatter', () => {
@@ -38,7 +48,7 @@ Body text here.`;
       title: 'Test Page',
       description: 'A test page',
     });
-    expect(html).toContain('<h1 id="content">Content</h1>');
+    expect(html).not.toContain('<h1');
     expect(html).toContain('<p>Body text here.</p>');
   });
 
@@ -67,7 +77,7 @@ Body text here.`;
   it('should handle empty frontmatter', () => {
     const markdown = `---
 ---
-# Title`;
+## Title`;
 
     const result = parseMarkdown(markdown);
     const html = toHtml(result.hast);
@@ -77,7 +87,7 @@ Body text here.`;
   });
 
   it('should preserve safe raw HTML elements like <details>', () => {
-    const markdown = `# FAQ
+    const markdown = `## FAQ
 
 <details>
 <summary>How does it work?</summary>
@@ -115,8 +125,8 @@ Regular content.
     // event handlers should be removed
     expect(html).not.toContain('onerror');
 
-    // safe content should remain
-    expect(html).toContain('<h1 id="test">Test</h1>');
+    // safe content should remain (h1 is stripped, paragraph is kept)
+    expect(html).not.toContain('<h1');
     expect(html).toContain('<p>Regular content.</p>');
   });
 

--- a/packages/plugin-docs-parser/src/parser.ts
+++ b/packages/plugin-docs-parser/src/parser.ts
@@ -11,6 +11,7 @@ import type { Root as HastRoot } from 'hast';
 import { rehypeRewriteAssetPaths } from './plugins/rehype-rewrite-asset-paths.js';
 import { rehypeRewriteDocLinks } from './plugins/rehype-rewrite-doc-links.js';
 import { rehypeExtractHeadings } from './plugins/rehype-extract-headings.js';
+import { rehypeStripH1 } from './plugins/rehype-strip-h1.js';
 import type { Heading } from './types.js';
 export type { Heading } from './types.js';
 
@@ -84,6 +85,7 @@ export function parseMarkdown(content: string, options?: ParseOptions): ParsedMa
     // rehype-sanitize can inspect and strip anything dangerous
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)
+    .use(rehypeStripH1)
     .use(rehypeSlug);
 
   // rewrite asset paths before sanitization so URLs are final

--- a/packages/plugin-docs-parser/src/plugins/rehype-strip-h1.test.ts
+++ b/packages/plugin-docs-parser/src/plugins/rehype-strip-h1.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { toHtml } from 'hast-util-to-html';
+import type { Root, Element, Text } from 'hast';
+import { rehypeStripH1 } from './rehype-strip-h1.js';
+
+function el(tag: string, text: string): Element {
+  const child: Text = { type: 'text', value: text };
+  return { type: 'element', tagName: tag, properties: {}, children: [child] };
+}
+
+function tree(...children: Element[]): Root {
+  return { type: 'root', children };
+}
+
+describe('rehypeStripH1', () => {
+  const transform = rehypeStripH1();
+
+  it('should remove an h1 element', () => {
+    const root = tree(el('h1', 'Page Title'));
+    transform(root);
+
+    expect(root.children).toHaveLength(0);
+  });
+
+  it('should remove h1 but keep other elements', () => {
+    const root = tree(el('h1', 'Title'), el('h2', 'Section'), el('p', 'Body'));
+    transform(root);
+
+    expect(root.children).toHaveLength(2);
+    expect(toHtml(root)).toContain('<h2>');
+    expect(toHtml(root)).toContain('<p>');
+    expect(toHtml(root)).not.toContain('<h1');
+  });
+
+  it('should remove multiple h1 elements', () => {
+    const root = tree(el('h1', 'First'), el('p', 'Middle'), el('h1', 'Second'));
+    transform(root);
+
+    expect(root.children).toHaveLength(1);
+    expect(toHtml(root)).toContain('<p>');
+    expect(toHtml(root)).not.toContain('<h1');
+  });
+
+  it('should leave h2 and lower headings untouched', () => {
+    const root = tree(el('h2', 'Section'), el('h3', 'Subsection'), el('h4', 'Deep'));
+    transform(root);
+
+    expect(root.children).toHaveLength(3);
+  });
+
+  it('should be a no-op on a tree with no h1', () => {
+    const root = tree(el('p', 'Just a paragraph.'));
+    transform(root);
+
+    expect(root.children).toHaveLength(1);
+  });
+
+  it('should handle an empty tree', () => {
+    const root = tree();
+    transform(root);
+
+    expect(root.children).toHaveLength(0);
+  });
+});

--- a/packages/plugin-docs-parser/src/plugins/rehype-strip-h1.ts
+++ b/packages/plugin-docs-parser/src/plugins/rehype-strip-h1.ts
@@ -1,0 +1,17 @@
+import type { Root, Element, Parent } from 'hast';
+import { visit, SKIP } from 'unist-util-visit';
+
+/**
+ * Rehype plugin that removes h1 elements from the tree.
+ * Page titles come from frontmatter and are rendered by the platform layout.
+ */
+export function rehypeStripH1() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node: Element, index, parent: Parent | null) => {
+      if (node.tagName === 'h1' && parent !== null && index !== undefined) {
+        parent.children.splice(index, 1);
+        return [SKIP, index];
+      }
+    });
+  };
+}

--- a/packages/plugin-docs-parser/src/plugins/rehype-strip-h1.ts
+++ b/packages/plugin-docs-parser/src/plugins/rehype-strip-h1.ts
@@ -12,6 +12,7 @@ export function rehypeStripH1() {
         parent.children.splice(index, 1);
         return [SKIP, index];
       }
+      return;
     });
   };
 }

--- a/packages/plugin-docs-parser/src/types.ts
+++ b/packages/plugin-docs-parser/src/types.ts
@@ -86,7 +86,7 @@ export interface Frontmatter {
    * The position of this page in the sidebar navigation (used for sorting).
    * Pages with lower numbers appear first.
    */
-  sidebar_position: number;
+  sidebar_position?: number;
 
   /**
    * Optional custom URL slug. If not provided, generated from file path.


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds frontmatter validation to the docs CLI and a `rehype-strip-h1` plugin to the docs parser. The validator checks that every markdown page has a frontmatter block with `title` and `description` as strings, catches wrong types, flags invalid or duplicate custom slugs and detects duplicate `sidebar_position` values among sibling pages. The h1-stripping plugin ensures rendered pages don't show a double title — since the page title comes from frontmatter any `# Heading` in the body is silently dropped by the parser. `sidebar_position` is optional - pages without it sort last.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
Part of https://github.com/grafana/grafana-catalog-team/issues/769

**Special notes for your reviewer**:

- Duplicate position/slug checks use a two-pass approach (count then report) so every offending file is flagged, not just the second one
- `no-redeclare` ESLint override is scoped to `plugin-docs-cli` only, to allow the `const Foo = {} as const; type Foo = ...` pattern in `types.ts`
- All diagnostics include file path and line number for editor integration
