### PR TITLE
Plugin Docs: Add asset validation rules

### DIFF
--- a/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
@@ -1,0 +1,484 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { checkAssets } from './assets.js';
+import { Rule } from '../types.js';
+
+const input = (docsPath: string, strict = true) => ({ docsPath, strict });
+
+// helper: valid frontmatter markdown file content
+const md = (body = '') => `---\ntitle: Page\ndescription: A page\n---\n${body}`;
+
+// helper: creates a buffer of a given size in bytes
+function bufferOfSize(bytes: number): Buffer {
+  return Buffer.alloc(bytes, 0);
+}
+
+describe('checkAssets', () => {
+  it('should return empty for nonexistent path', async () => {
+    const findings = await checkAssets(input('/nonexistent/path'));
+    expect(findings).toHaveLength(0);
+  });
+
+  it('should return empty for docs with no images', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+    await writeFile(join(tmp, 'index.md'), md('## Hello'));
+
+    const findings = await checkAssets(input(tmp));
+    expect(findings).toHaveLength(0);
+  });
+
+  // --- no-svg-files ---
+
+  describe('no-svg-files', () => {
+    it('should report SVG files as error', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'icon.svg'), '<svg></svg>');
+
+      const findings = await checkAssets(input(tmp));
+
+      const svg = findings.find((f) => f.rule === Rule.NoSvg);
+      expect(svg).toBeDefined();
+      expect(svg!.severity).toBe('error');
+      expect(svg!.file).toContain('icon.svg');
+    });
+
+    it('should report SVG files as error even in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await writeFile(join(tmp, 'diagram.svg'), '<svg></svg>');
+
+      const findings = await checkAssets(input(tmp, false));
+
+      const svg = findings.find((f) => f.rule === Rule.NoSvg);
+      expect(svg).toBeDefined();
+      expect(svg!.severity).toBe('error');
+    });
+  });
+
+  // --- images-in-img-dir ---
+
+  describe('images-in-img-dir', () => {
+    it('should not report images inside img/ directory', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](img/screenshot.png)'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'screenshot.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeUndefined();
+    });
+
+    it('should not report images inside nested img/ directory', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'sub'), { recursive: true });
+      await mkdir(join(tmp, 'sub', 'img'));
+      await writeFile(join(tmp, 'sub', 'img', 'diagram.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeUndefined();
+    });
+
+    it('should report images in docs root', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await writeFile(join(tmp, 'screenshot.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ImagesInImgDir);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report images in non-img directory', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'assets'));
+      await writeFile(join(tmp, 'assets', 'photo.jpg'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ImagesInImgDir);
+      expect(finding).toBeDefined();
+      expect(finding!.file).toContain('photo.jpg');
+    });
+
+    it('should report as info in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await writeFile(join(tmp, 'screenshot.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.ImagesInImgDir);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('info');
+    });
+  });
+
+  // --- allowed-image-formats ---
+
+  describe('allowed-image-formats', () => {
+    it('should not report allowed image formats in img/', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'a.png'), '');
+      await writeFile(join(tmp, 'img', 'b.jpg'), '');
+      await writeFile(join(tmp, 'img', 'c.jpeg'), '');
+      await writeFile(join(tmp, 'img', 'd.webp'), '');
+      await writeFile(join(tmp, 'img', 'e.gif'), '');
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AllowedImageFormats)).toBeUndefined();
+    });
+
+    it('should report disallowed formats in img/', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'photo.bmp'), '');
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.AllowedImageFormats);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+      expect(finding!.file).toContain('photo.bmp');
+    });
+
+    it('should report as info in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'photo.tiff'), '');
+
+      const findings = await checkAssets(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.AllowedImageFormats);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('info');
+    });
+
+    it('should not flag SVG in img/ (handled by no-svg-files)', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'icon.svg'), '<svg></svg>');
+
+      const findings = await checkAssets(input(tmp));
+
+      // should have no-svg-files but not allowed-image-formats
+      expect(findings.find((f) => f.rule === Rule.NoSvg)).toBeDefined();
+      expect(findings.find((f) => f.rule === Rule.AllowedImageFormats)).toBeUndefined();
+    });
+
+    it('should not report files outside img/', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await writeFile(join(tmp, 'notes.txt'), 'hello');
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AllowedImageFormats)).toBeUndefined();
+    });
+  });
+
+  // --- image-file-naming ---
+
+  describe('image-file-naming', () => {
+    it('should not report valid image filenames', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'my-screenshot_01.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ImageFileNaming)).toBeUndefined();
+    });
+
+    it('should report uppercase in image filename', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'Screenshot.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ImageFileNaming);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report spaces in image filename', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'my screenshot.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ImageFileNaming);
+      expect(finding).toBeDefined();
+    });
+
+    it('should report as info in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'BadName.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.ImageFileNaming);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('info');
+    });
+  });
+
+  // --- max-image-size ---
+
+  describe('max-image-size', () => {
+    it('should not report images under the size limit', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'small.png'), bufferOfSize(100 * 1024)); // 100KB
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.MaxImageSize)).toBeUndefined();
+    });
+
+    it('should report static images over 300KB', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'large.png'), bufferOfSize(400 * 1024)); // 400KB
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.MaxImageSize);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+      expect(finding!.title).toContain('300KB');
+    });
+
+    it('should not report GIF under 1MB', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'animation.gif'), bufferOfSize(500 * 1024)); // 500KB
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.MaxImageSize)).toBeUndefined();
+    });
+
+    it('should report GIF over 1MB', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'heavy.gif'), bufferOfSize(1.5 * 1024 * 1024)); // 1.5MB
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.MaxImageSize);
+      expect(finding).toBeDefined();
+      expect(finding!.title).toContain('1MB');
+    });
+
+    it('should report as info in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'large.png'), bufferOfSize(400 * 1024));
+
+      const findings = await checkAssets(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.MaxImageSize);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('info');
+    });
+  });
+
+  // --- max-total-images-size ---
+
+  describe('max-total-images-size', () => {
+    it('should not report when total is under 5MB', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'a.png'), bufferOfSize(1024 * 1024)); // 1MB
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.MaxTotalImagesSize)).toBeUndefined();
+    });
+
+    it('should report when total exceeds 5MB in strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      // write 6 images at 1MB each = 6MB total
+      for (let i = 0; i < 6; i++) {
+        await writeFile(join(tmp, 'img', `img-${i}.png`), bufferOfSize(1024 * 1024));
+      }
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.MaxTotalImagesSize);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('warning');
+    });
+
+    it('should not report in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img'));
+      for (let i = 0; i < 6; i++) {
+        await writeFile(join(tmp, 'img', `img-${i}.png`), bufferOfSize(1024 * 1024));
+      }
+
+      const findings = await checkAssets(input(tmp, false));
+      expect(findings.find((f) => f.rule === Rule.MaxTotalImagesSize)).toBeUndefined();
+    });
+  });
+
+  // --- referenced-images-exist ---
+
+  describe('referenced-images-exist', () => {
+    it('should not report when referenced image exists', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'screenshot.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('![alt](img/screenshot.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+    });
+
+    it('should report when referenced image does not exist', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](img/missing.png)'));
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+      expect(finding!.detail).toContain('missing.png');
+    });
+
+    it('should include line number for broken reference', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('\n\n![alt](img/gone.png)\n'));
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(finding).toBeDefined();
+      expect(finding!.line).toBeDefined();
+      expect(finding!.line).toBeGreaterThan(1);
+    });
+
+    it('should resolve references relative to the markdown file', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'sub'));
+      await mkdir(join(tmp, 'sub', 'img'));
+      await writeFile(join(tmp, 'sub', 'img', 'diagram.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'sub', 'page.md'), md('![diagram](img/diagram.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+    });
+
+    it('should skip external URLs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![logo](https://example.com/logo.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+    });
+
+    it('should skip data URIs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![pixel](data:image/png;base64,abc123)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+    });
+
+    it('should report multiple broken references in the same file', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![a](img/one.png)\n![b](img/two.png)'));
+
+      const findings = await checkAssets(input(tmp));
+
+      const refs = findings.filter((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(refs).toHaveLength(2);
+    });
+  });
+
+  // --- no-orphaned-images ---
+
+  describe('no-orphaned-images', () => {
+    it('should not report referenced images', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'used.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('![alt](img/used.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+    });
+
+    it('should report unreferenced images in img/ in strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'orphan.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('## No images here'));
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoOrphanedImages);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('info');
+      expect(finding!.file).toContain('orphan.png');
+    });
+
+    it('should not report in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'orphan.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('## No images'));
+
+      const findings = await checkAssets(input(tmp, false));
+      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+    });
+
+    it('should not report images outside img/ as orphaned', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'stray.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('## No images'));
+
+      const findings = await checkAssets(input(tmp));
+      // should have images-in-img-dir but not no-orphaned-images
+      expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeDefined();
+      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+    });
+
+    it('should detect references from different markdown files', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'shared.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('## Home'));
+      // referenced from a different file
+      await writeFile(join(tmp, 'other.md'), md('![pic](img/shared.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+    });
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
@@ -318,6 +318,17 @@ describe('checkAssets', () => {
       expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
     });
 
+    it('should report references that escape the docs root via ../../../', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![escape](../../etc/passwd)'));
+
+      const findings = await checkAssets(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
     it('should report multiple broken references in the same file', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
       await writeFile(join(tmp, 'index.md'), md('![a](img/one.png)\n![b](img/two.png)'));

--- a/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
@@ -422,6 +422,33 @@ describe('checkAssets', () => {
       expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
     });
 
+    it('should skip protocol-relative URLs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![logo](//cdn.example.com/logo.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+    });
+
+    it('should skip blob URLs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![img](blob:http://localhost/abc)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+    });
+
+    it('should resolve root-relative paths against docs root', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'logo.png'), bufferOfSize(100));
+      await mkdir(join(tmp, 'sub'));
+      await writeFile(join(tmp, 'sub', 'page.md'), md('![logo](/img/logo.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+    });
+
     it('should skip data URIs', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
       await writeFile(join(tmp, 'index.md'), md('![pixel](data:image/png;base64,abc123)'));

--- a/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
@@ -83,6 +83,16 @@ describe('checkAssets', () => {
       expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeUndefined();
     });
 
+    it('should not report images inside img/ subdirectory', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md());
+      await mkdir(join(tmp, 'img', 'screenshots'), { recursive: true });
+      await writeFile(join(tmp, 'img', 'screenshots', 'step1.png'), bufferOfSize(100));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeUndefined();
+    });
+
     it('should report images in docs root', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
       await writeFile(join(tmp, 'index.md'), md());
@@ -394,6 +404,16 @@ describe('checkAssets', () => {
       expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
     });
 
+    it('should handle ./ prefix in image refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'screenshot.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('![alt](./img/screenshot.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+    });
+
     it('should skip external URLs', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
       await writeFile(join(tmp, 'index.md'), md('![logo](https://example.com/logo.png)'));
@@ -467,6 +487,17 @@ describe('checkAssets', () => {
       // should have images-in-img-dir but not no-orphaned-images
       expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeDefined();
       expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+    });
+
+    it('should handle references to img subdirectories', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img', 'screenshots'), { recursive: true });
+      await writeFile(join(tmp, 'img', 'screenshots', 'step1.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('![step](img/screenshots/step1.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
     });
 
     it('should detect references from different markdown files', async () => {

--- a/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
@@ -15,6 +15,12 @@ function bufferOfSize(bytes: number): Buffer {
   return Buffer.alloc(bytes, 0);
 }
 
+// helper: creates a base64 string of approximately the given byte size
+function base64OfSize(bytes: number): string {
+  const buf = Buffer.alloc(bytes, 0);
+  return buf.toString('base64');
+}
+
 describe('checkAssets', () => {
   it('should return empty for nonexistent path', async () => {
     const findings = await checkAssets(input('/nonexistent/path'));
@@ -40,10 +46,10 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const svg = findings.find((f) => f.rule === Rule.NoSvg);
-      expect(svg).toBeDefined();
-      expect(svg!.severity).toBe('error');
-      expect(svg!.file).toContain('icon.svg');
+      const svgs = findings.filter((f) => f.rule === Rule.NoSvg);
+      expect(svgs).toHaveLength(1);
+      expect(svgs[0].severity).toBe('error');
+      expect(svgs[0].file).toContain('icon.svg');
     });
 
     it('should report SVG files as error even in non-strict mode', async () => {
@@ -53,9 +59,9 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp, false));
 
-      const svg = findings.find((f) => f.rule === Rule.NoSvg);
-      expect(svg).toBeDefined();
-      expect(svg!.severity).toBe('error');
+      const svgs = findings.filter((f) => f.rule === Rule.NoSvg);
+      expect(svgs).toHaveLength(1);
+      expect(svgs[0].severity).toBe('error');
     });
   });
 
@@ -69,20 +75,17 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'img', 'my-screenshot_01.png'), bufferOfSize(100));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ImageFileNaming)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ImageFileNaming)).toHaveLength(0);
     });
 
-    it('should report uppercase in image filename', async () => {
+    it('should not report uppercase in image filename', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
       await writeFile(join(tmp, 'index.md'), md());
       await mkdir(join(tmp, 'img'));
       await writeFile(join(tmp, 'img', 'Screenshot.png'), bufferOfSize(100));
 
       const findings = await checkAssets(input(tmp));
-
-      const finding = findings.find((f) => f.rule === Rule.ImageFileNaming);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('error');
+      expect(findings.filter((f) => f.rule === Rule.ImageFileNaming)).toHaveLength(0);
     });
 
     it('should report spaces in image filename', async () => {
@@ -93,21 +96,21 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.ImageFileNaming);
-      expect(finding).toBeDefined();
+      const naming = findings.filter((f) => f.rule === Rule.ImageFileNaming);
+      expect(naming).toHaveLength(1);
     });
 
     it('should report as info in non-strict mode', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
       await writeFile(join(tmp, 'index.md'), md());
       await mkdir(join(tmp, 'img'));
-      await writeFile(join(tmp, 'img', 'BadName.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'img', 'my screenshot.png'), bufferOfSize(100));
 
       const findings = await checkAssets(input(tmp, false));
 
-      const finding = findings.find((f) => f.rule === Rule.ImageFileNaming);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('info');
+      const naming = findings.filter((f) => f.rule === Rule.ImageFileNaming);
+      expect(naming).toHaveLength(1);
+      expect(naming[0].severity).toBe('info');
     });
   });
 
@@ -121,7 +124,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'img', 'small.png'), bufferOfSize(100 * 1024)); // 100KB
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.MaxImageSize)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.MaxImageSize)).toHaveLength(0);
     });
 
     it('should report static images over 300KB', async () => {
@@ -132,10 +135,10 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.MaxImageSize);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('error');
-      expect(finding!.title).toContain('300KB');
+      const size = findings.filter((f) => f.rule === Rule.MaxImageSize);
+      expect(size).toHaveLength(1);
+      expect(size[0].severity).toBe('error');
+      expect(size[0].title).toContain('300KB');
     });
 
     it('should not report GIF under 1MB', async () => {
@@ -145,7 +148,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'img', 'animation.gif'), bufferOfSize(500 * 1024)); // 500KB
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.MaxImageSize)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.MaxImageSize)).toHaveLength(0);
     });
 
     it('should report GIF over 1MB', async () => {
@@ -156,9 +159,9 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.MaxImageSize);
-      expect(finding).toBeDefined();
-      expect(finding!.title).toContain('1MB');
+      const size = findings.filter((f) => f.rule === Rule.MaxImageSize);
+      expect(size).toHaveLength(1);
+      expect(size[0].title).toContain('1MB');
     });
 
     it('should report as info in non-strict mode', async () => {
@@ -169,9 +172,9 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp, false));
 
-      const finding = findings.find((f) => f.rule === Rule.MaxImageSize);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('info');
+      const size = findings.filter((f) => f.rule === Rule.MaxImageSize);
+      expect(size).toHaveLength(1);
+      expect(size[0].severity).toBe('info');
     });
   });
 
@@ -185,7 +188,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'img', 'a.png'), bufferOfSize(1024 * 1024)); // 1MB
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.MaxTotalImagesSize)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.MaxTotalImagesSize)).toHaveLength(0);
     });
 
     it('should report when total exceeds 5MB in strict mode', async () => {
@@ -199,9 +202,9 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.MaxTotalImagesSize);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('warning');
+      const total = findings.filter((f) => f.rule === Rule.MaxTotalImagesSize);
+      expect(total).toHaveLength(1);
+      expect(total[0].severity).toBe('warning');
     });
 
     it('should not report in non-strict mode', async () => {
@@ -213,7 +216,54 @@ describe('checkAssets', () => {
       }
 
       const findings = await checkAssets(input(tmp, false));
-      expect(findings.find((f) => f.rule === Rule.MaxTotalImagesSize)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.MaxTotalImagesSize)).toHaveLength(0);
+    });
+  });
+
+  // --- max-data-uri-size ---
+
+  describe('max-data-uri-size', () => {
+    it('should not report small data URIs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      const smallB64 = base64OfSize(100);
+      await writeFile(join(tmp, 'index.md'), md(`![pixel](data:image/png;base64,${smallB64})`));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.filter((f) => f.rule === Rule.MaxDataUriSize)).toHaveLength(0);
+    });
+
+    it('should report data URIs over 300KB', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      const largeB64 = base64OfSize(400 * 1024);
+      await writeFile(join(tmp, 'index.md'), md(`![big](data:image/png;base64,${largeB64})`));
+
+      const findings = await checkAssets(input(tmp));
+
+      const dataUri = findings.filter((f) => f.rule === Rule.MaxDataUriSize);
+      expect(dataUri).toHaveLength(1);
+      expect(dataUri[0].severity).toBe('error');
+      expect(dataUri[0].title).toContain('300KB');
+    });
+
+    it('should report as info in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      const largeB64 = base64OfSize(400 * 1024);
+      await writeFile(join(tmp, 'index.md'), md(`![big](data:image/png;base64,${largeB64})`));
+
+      const findings = await checkAssets(input(tmp, false));
+
+      const dataUri = findings.filter((f) => f.rule === Rule.MaxDataUriSize);
+      expect(dataUri).toHaveLength(1);
+      expect(dataUri[0].severity).toBe('info');
+    });
+
+    it('should not report data URIs for the referenced-images-exist rule', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      const largeB64 = base64OfSize(400 * 1024);
+      await writeFile(join(tmp, 'index.md'), md(`![big](data:image/png;base64,${largeB64})`));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
   });
 
@@ -227,7 +277,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('![alt](img/screenshot.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should report when referenced image does not exist', async () => {
@@ -236,10 +286,10 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.ReferencedImagesExist);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('error');
-      expect(finding!.detail).toContain('missing.png');
+      const refs = findings.filter((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(refs).toHaveLength(1);
+      expect(refs[0].severity).toBe('error');
+      expect(refs[0].detail).toContain('missing.png');
     });
 
     it('should include line number for broken reference', async () => {
@@ -248,10 +298,10 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.ReferencedImagesExist);
-      expect(finding).toBeDefined();
-      expect(finding!.line).toBeDefined();
-      expect(finding!.line).toBeGreaterThan(1);
+      const refs = findings.filter((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(refs).toHaveLength(1);
+      expect(refs[0].line).toBeDefined();
+      expect(refs[0].line).toBeGreaterThan(1);
     });
 
     it('should resolve references relative to the markdown file', async () => {
@@ -262,7 +312,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'sub', 'page.md'), md('![diagram](img/diagram.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should handle ./ prefix in image refs', async () => {
@@ -272,7 +322,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('![alt](./img/screenshot.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should skip external URLs', async () => {
@@ -280,7 +330,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('![logo](https://example.com/logo.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should skip protocol-relative URLs', async () => {
@@ -288,7 +338,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('![logo](//cdn.example.com/logo.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should skip blob URLs', async () => {
@@ -296,7 +346,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('![img](blob:http://localhost/abc)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should resolve root-relative paths against docs root', async () => {
@@ -307,7 +357,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'sub', 'page.md'), md('![logo](/img/logo.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should skip data URIs', async () => {
@@ -315,7 +365,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('![pixel](data:image/png;base64,abc123)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should report references that escape the docs root via ../../../', async () => {
@@ -324,9 +374,9 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.ReferencedImagesExist);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('error');
+      const refs = findings.filter((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(refs).toHaveLength(1);
+      expect(refs[0].severity).toBe('error');
     });
 
     it('should report multiple broken references in the same file', async () => {
@@ -337,6 +387,72 @@ describe('checkAssets', () => {
 
       const refs = findings.filter((f) => f.rule === Rule.ReferencedImagesExist);
       expect(refs).toHaveLength(2);
+    });
+
+    it('should resolve ../img/ references from a subdirectory', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'logo.png'), bufferOfSize(100));
+      await mkdir(join(tmp, 'docs', 'getting-started'), { recursive: true });
+      await writeFile(join(tmp, 'docs', 'getting-started', 'index.md'), md('![logo](../../img/logo.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
+    });
+
+    it('should handle image refs with title attributes', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'chart.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'index.md'), md('![chart](img/chart.png "A chart showing data")'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
+    });
+
+    it('should report broken ref with title attribute', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![chart](img/missing.png "A chart")'));
+
+      const findings = await checkAssets(input(tmp));
+
+      const refs = findings.filter((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(refs).toHaveLength(1);
+    });
+
+    it('should handle multiple markdown files with mixed valid and broken refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'img'));
+      await writeFile(join(tmp, 'img', 'valid.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'page1.md'), md('![ok](img/valid.png)\n![broken](img/nope.png)'));
+      await writeFile(join(tmp, 'page2.md'), md('![also-broken](img/missing.png)'));
+
+      const findings = await checkAssets(input(tmp));
+
+      const refs = findings.filter((f) => f.rule === Rule.ReferencedImagesExist);
+      expect(refs).toHaveLength(2);
+      const files = refs.map((r) => r.file);
+      expect(files).toContain('page1.md');
+      expect(files).toContain('page2.md');
+    });
+
+    it('should handle deeply nested directories with relative refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await mkdir(join(tmp, 'a', 'b', 'c', 'img'), { recursive: true });
+      await writeFile(join(tmp, 'a', 'b', 'c', 'img', 'deep.png'), bufferOfSize(100));
+      await writeFile(join(tmp, 'a', 'b', 'c', 'page.md'), md('![deep](img/deep.png)'));
+
+      const findings = await checkAssets(input(tmp));
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
+    });
+
+    it('should not match HTML img tags', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<img src="img/photo.png" />'));
+
+      const findings = await checkAssets(input(tmp));
+      // html img tags are not matched by the markdown regex, so no broken ref reported
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
   });
 
@@ -350,7 +466,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('![alt](img/used.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.NoOrphanedImages)).toHaveLength(0);
     });
 
     it('should report unreferenced images in img/ in strict mode', async () => {
@@ -361,10 +477,10 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.NoOrphanedImages);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('info');
-      expect(finding!.file).toContain('orphan.png');
+      const orphans = findings.filter((f) => f.rule === Rule.NoOrphanedImages);
+      expect(orphans).toHaveLength(1);
+      expect(orphans[0].severity).toBe('info');
+      expect(orphans[0].file).toContain('orphan.png');
     });
 
     it('should not report in non-strict mode', async () => {
@@ -374,7 +490,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('## No images'));
 
       const findings = await checkAssets(input(tmp, false));
-      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.NoOrphanedImages)).toHaveLength(0);
     });
 
     it('should report unreferenced images anywhere as orphaned', async () => {
@@ -384,10 +500,10 @@ describe('checkAssets', () => {
 
       const findings = await checkAssets(input(tmp));
 
-      const finding = findings.find((f) => f.rule === Rule.NoOrphanedImages);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('info');
-      expect(finding!.file).toContain('stray.png');
+      const orphans = findings.filter((f) => f.rule === Rule.NoOrphanedImages);
+      expect(orphans).toHaveLength(1);
+      expect(orphans[0].severity).toBe('info');
+      expect(orphans[0].file).toContain('stray.png');
     });
 
     it('should handle references to img subdirectories', async () => {
@@ -397,8 +513,8 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'index.md'), md('![step](img/screenshots/step1.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
-      expect(findings.find((f) => f.rule === Rule.ReferencedImagesExist)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.NoOrphanedImages)).toHaveLength(0);
+      expect(findings.filter((f) => f.rule === Rule.ReferencedImagesExist)).toHaveLength(0);
     });
 
     it('should detect references from different markdown files', async () => {
@@ -410,7 +526,7 @@ describe('checkAssets', () => {
       await writeFile(join(tmp, 'other.md'), md('![pic](img/shared.png)'));
 
       const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+      expect(findings.filter((f) => f.rule === Rule.NoOrphanedImages)).toHaveLength(0);
     });
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.test.ts
@@ -59,145 +59,6 @@ describe('checkAssets', () => {
     });
   });
 
-  // --- images-in-img-dir ---
-
-  describe('images-in-img-dir', () => {
-    it('should not report images inside img/ directory', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md('![alt](img/screenshot.png)'));
-      await mkdir(join(tmp, 'img'));
-      await writeFile(join(tmp, 'img', 'screenshot.png'), bufferOfSize(100));
-
-      const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeUndefined();
-    });
-
-    it('should not report images inside nested img/ directory', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await mkdir(join(tmp, 'sub'), { recursive: true });
-      await mkdir(join(tmp, 'sub', 'img'));
-      await writeFile(join(tmp, 'sub', 'img', 'diagram.png'), bufferOfSize(100));
-
-      const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeUndefined();
-    });
-
-    it('should not report images inside img/ subdirectory', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await mkdir(join(tmp, 'img', 'screenshots'), { recursive: true });
-      await writeFile(join(tmp, 'img', 'screenshots', 'step1.png'), bufferOfSize(100));
-
-      const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeUndefined();
-    });
-
-    it('should report images in docs root', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await writeFile(join(tmp, 'screenshot.png'), bufferOfSize(100));
-
-      const findings = await checkAssets(input(tmp));
-
-      const finding = findings.find((f) => f.rule === Rule.ImagesInImgDir);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('error');
-    });
-
-    it('should report images in non-img directory', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await mkdir(join(tmp, 'assets'));
-      await writeFile(join(tmp, 'assets', 'photo.jpg'), bufferOfSize(100));
-
-      const findings = await checkAssets(input(tmp));
-
-      const finding = findings.find((f) => f.rule === Rule.ImagesInImgDir);
-      expect(finding).toBeDefined();
-      expect(finding!.file).toContain('photo.jpg');
-    });
-
-    it('should report as info in non-strict mode', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await writeFile(join(tmp, 'screenshot.png'), bufferOfSize(100));
-
-      const findings = await checkAssets(input(tmp, false));
-
-      const finding = findings.find((f) => f.rule === Rule.ImagesInImgDir);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('info');
-    });
-  });
-
-  // --- allowed-image-formats ---
-
-  describe('allowed-image-formats', () => {
-    it('should not report allowed image formats in img/', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await mkdir(join(tmp, 'img'));
-      await writeFile(join(tmp, 'img', 'a.png'), '');
-      await writeFile(join(tmp, 'img', 'b.jpg'), '');
-      await writeFile(join(tmp, 'img', 'c.jpeg'), '');
-      await writeFile(join(tmp, 'img', 'd.webp'), '');
-      await writeFile(join(tmp, 'img', 'e.gif'), '');
-
-      const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.AllowedImageFormats)).toBeUndefined();
-    });
-
-    it('should report disallowed formats in img/', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await mkdir(join(tmp, 'img'));
-      await writeFile(join(tmp, 'img', 'photo.bmp'), '');
-
-      const findings = await checkAssets(input(tmp));
-
-      const finding = findings.find((f) => f.rule === Rule.AllowedImageFormats);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('error');
-      expect(finding!.file).toContain('photo.bmp');
-    });
-
-    it('should report as info in non-strict mode', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await mkdir(join(tmp, 'img'));
-      await writeFile(join(tmp, 'img', 'photo.tiff'), '');
-
-      const findings = await checkAssets(input(tmp, false));
-
-      const finding = findings.find((f) => f.rule === Rule.AllowedImageFormats);
-      expect(finding).toBeDefined();
-      expect(finding!.severity).toBe('info');
-    });
-
-    it('should not flag SVG in img/ (handled by no-svg-files)', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await mkdir(join(tmp, 'img'));
-      await writeFile(join(tmp, 'img', 'icon.svg'), '<svg></svg>');
-
-      const findings = await checkAssets(input(tmp));
-
-      // should have no-svg-files but not allowed-image-formats
-      expect(findings.find((f) => f.rule === Rule.NoSvg)).toBeDefined();
-      expect(findings.find((f) => f.rule === Rule.AllowedImageFormats)).toBeUndefined();
-    });
-
-    it('should not report files outside img/', async () => {
-      const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
-      await writeFile(join(tmp, 'index.md'), md());
-      await writeFile(join(tmp, 'notes.txt'), 'hello');
-
-      const findings = await checkAssets(input(tmp));
-      expect(findings.find((f) => f.rule === Rule.AllowedImageFormats)).toBeUndefined();
-    });
-  });
-
   // --- image-file-naming ---
 
   describe('image-file-naming', () => {
@@ -505,15 +366,17 @@ describe('checkAssets', () => {
       expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
     });
 
-    it('should not report images outside img/ as orphaned', async () => {
+    it('should report unreferenced images anywhere as orphaned', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'asset-test-'));
       await writeFile(join(tmp, 'stray.png'), bufferOfSize(100));
       await writeFile(join(tmp, 'index.md'), md('## No images'));
 
       const findings = await checkAssets(input(tmp));
-      // should have images-in-img-dir but not no-orphaned-images
-      expect(findings.find((f) => f.rule === Rule.ImagesInImgDir)).toBeDefined();
-      expect(findings.find((f) => f.rule === Rule.NoOrphanedImages)).toBeUndefined();
+
+      const finding = findings.find((f) => f.rule === Rule.NoOrphanedImages);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('info');
+      expect(finding!.file).toContain('stray.png');
     });
 
     it('should handle references to img subdirectories', async () => {

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -1,6 +1,6 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
-import { join, extname, dirname, relative, sep, normalize } from 'node:path';
+import { join, extname, dirname, relative, normalize } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 import { ALLOWED_IMAGE_EXTENSIONS } from './filesystem.js';
 
@@ -8,15 +8,6 @@ const IMAGE_FILE_NAME_RE = /^[a-z0-9\-_.]+$/;
 const MAX_STATIC_SIZE = 300 * 1024; // 300KB
 const MAX_GIF_SIZE = 1024 * 1024; // 1MB
 const MAX_TOTAL_SIZE = 5 * 1024 * 1024; // 5MB
-
-/**
- * Checks whether a relative path is inside a directory named `img`.
- */
-function isInImgDir(relativePath: string): boolean {
-  const parts = relativePath.split(sep);
-  // check directory components (everything except the filename)
-  return parts.slice(0, -1).includes('img');
-}
 
 /**
  * Formats a byte count as a human-readable string.
@@ -75,42 +66,6 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
       title: 'SVG files are not allowed',
       detail: `"${svg.name}" is an SVG file. SVG files can contain embedded scripts and pose an XSS risk. Use PNG or WebP instead.`,
     });
-  }
-
-  // images-in-img-dir: all image files must be inside an img/ directory
-  for (const img of imageFiles) {
-    const relPath = rel(img);
-    if (!isInImgDir(relPath)) {
-      diagnostics.push({
-        rule: Rule.ImagesInImgDir,
-        severity: input.strict ? 'error' : 'info',
-        file: relPath,
-        title: 'Image not in img/ directory',
-        detail: `"${img.name}" must be inside an img/ directory. Move it to the img/ folder next to the markdown files that reference it.`,
-      });
-    }
-  }
-
-  // allowed-image-formats: files in img/ dirs must be allowed image formats
-  for (const file of allFiles) {
-    const relPath = rel(file);
-    if (!isInImgDir(relPath)) {
-      continue;
-    }
-    const ext = extname(file.name).toLowerCase();
-    if (ext === '.svg') {
-      // handled by no-svg-files
-      continue;
-    }
-    if (!ALLOWED_IMAGE_EXTENSIONS.has(ext)) {
-      diagnostics.push({
-        rule: Rule.AllowedImageFormats,
-        severity: input.strict ? 'error' : 'info',
-        file: relPath,
-        title: 'Image format not allowed',
-        detail: `"${file.name}" is not an allowed image format. Only png, jpg, jpeg, webp and gif files are permitted.`,
-      });
-    }
   }
 
   // image-file-naming: image filenames must use only [a-z0-9-_.]
@@ -209,10 +164,6 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
   if (input.strict) {
     for (const img of imageFiles) {
       const relPath = rel(img);
-      // only check images that are in img/ directories
-      if (!isInImgDir(relPath)) {
-        continue;
-      }
       if (!referencedPaths.has(relPath)) {
         diagnostics.push({
           rule: Rule.NoOrphanedImages,

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -4,10 +4,11 @@ import { join, extname, dirname, relative, normalize } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 import { ALLOWED_IMAGE_EXTENSIONS } from './filesystem.js';
 
-const IMAGE_FILE_NAME_RE = /^[a-z0-9\-_.]+$/;
+const IMAGE_FILE_NAME_RE = /^[a-zA-Z0-9\-_.]+$/;
 const MAX_STATIC_SIZE = 300 * 1024; // 300KB
 const MAX_GIF_SIZE = 1024 * 1024; // 1MB
 const MAX_TOTAL_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_DATA_URI_SIZE = 300 * 1024; // 300KB
 
 /**
  * Formats a byte count as a human-readable string.
@@ -68,7 +69,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
     });
   }
 
-  // image-file-naming: image filenames must use only [a-z0-9-_.]
+  // image-file-naming: image filenames must use only [a-zA-Z0-9-_.]
   for (const img of imageFiles) {
     if (!IMAGE_FILE_NAME_RE.test(img.name)) {
       diagnostics.push({
@@ -76,7 +77,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
         severity: input.strict ? 'error' : 'info',
         file: rel(img),
         title: 'Image filename contains invalid characters',
-        detail: `"${img.name}" should use only lowercase letters, digits, hyphens, underscores and dots.`,
+        detail: `"${img.name}" should use only letters, digits, hyphens, underscores and dots.`,
       });
     }
   }
@@ -137,8 +138,29 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
     let match: RegExpExecArray | null;
     while ((match = imageRefRe.exec(content)) !== null) {
       const ref = match[2];
-      // skip external URLs, protocol-relative URLs, blob URLs and data URIs
-      if (/^https?:\/\//i.test(ref) || /^\/\//.test(ref) || /^blob:/i.test(ref) || /^data:/i.test(ref)) {
+      // skip external URLs, protocol-relative URLs and blob URLs
+      if (/^https?:\/\//i.test(ref) || /^\/\//.test(ref) || /^blob:/i.test(ref)) {
+        continue;
+      }
+
+      // max-data-uri-size: check size of inline data URIs
+      if (/^data:/i.test(ref)) {
+        const commaIdx = ref.indexOf(',');
+        if (commaIdx !== -1) {
+          const encoded = ref.slice(commaIdx + 1);
+          const isBase64 = /;base64$/i.test(ref.slice(0, commaIdx));
+          const byteSize = isBase64 ? Math.ceil((encoded.length * 3) / 4) : encoded.length;
+          if (byteSize > MAX_DATA_URI_SIZE) {
+            diagnostics.push({
+              rule: Rule.MaxDataUriSize,
+              severity: input.strict ? 'error' : 'info',
+              file: mdRelPath,
+              line: findRefLine(content, ref),
+              title: 'Data URI exceeds 300KB limit',
+              detail: `Inline data URI is approximately ${formatBytes(byteSize)} which exceeds the 300KB limit. Use a file reference instead.`,
+            });
+          }
+        }
         continue;
       }
 

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -182,11 +182,13 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
     let match: RegExpExecArray | null;
     while ((match = imageRefRe.exec(content)) !== null) {
       const ref = match[2];
-      // skip external URLs and data URIs
-      if (/^https?:\/\//i.test(ref) || /^data:/i.test(ref)) {
+      // skip external URLs, protocol-relative URLs, blob URLs and data URIs
+      if (/^https?:\/\//i.test(ref) || /^\/\//.test(ref) || /^blob:/i.test(ref) || /^data:/i.test(ref)) {
         continue;
       }
-      const resolvedPath = normalize(join(dirname(mdRelPath), ref));
+
+      // root-relative paths (e.g. /img/foo.png) resolve against docs root
+      const resolvedPath = ref.startsWith('/') ? normalize(ref.slice(1)) : normalize(join(dirname(mdRelPath), ref));
       referencedPaths.add(resolvedPath);
 
       // referenced-images-exist: check that the target file exists on disk

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -1,0 +1,227 @@
+import { readFile, readdir, stat } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { join, extname, dirname, relative, sep, normalize } from 'node:path';
+import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+
+const ALLOWED_IMAGE_EXT = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif']);
+const IMAGE_FILE_NAME_RE = /^[a-z0-9\-_.]+$/;
+const MAX_STATIC_SIZE = 300 * 1024; // 300KB
+const MAX_GIF_SIZE = 1024 * 1024; // 1MB
+const MAX_TOTAL_SIZE = 5 * 1024 * 1024; // 5MB
+
+/**
+ * Checks whether a relative path is inside a directory named `img`.
+ */
+function isInImgDir(relativePath: string): boolean {
+  const parts = relativePath.split(sep);
+  // check directory components (everything except the filename)
+  return parts.slice(0, -1).includes('img');
+}
+
+/**
+ * Formats a byte count as a human-readable string.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${Math.round(kb)}KB`;
+  }
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)}MB`;
+}
+
+/**
+ * Finds the 1-based line number of the first occurrence of a string in content.
+ */
+function findRefLine(content: string, ref: string): number | undefined {
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(ref)) {
+      return i + 1;
+    }
+  }
+  return undefined;
+}
+
+export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = [];
+
+  let entries: Dirent[] = [];
+  try {
+    entries = await readdir(input.docsPath, { recursive: true, withFileTypes: true });
+  } catch {
+    return diagnostics;
+  }
+
+  const allFiles = entries.filter((e) => e.isFile());
+  const imageFiles = allFiles.filter((e) => ALLOWED_IMAGE_EXT.has(extname(e.name).toLowerCase()));
+  const svgFiles = allFiles.filter((e) => extname(e.name).toLowerCase() === '.svg');
+  const mdFiles = allFiles.filter((e) => e.name.endsWith('.md'));
+
+  // helper to get path relative to docsPath
+  function rel(entry: Dirent): string {
+    return relative(input.docsPath, join(entry.parentPath, entry.name));
+  }
+
+  // no-svg-files: SVG is an XSS risk
+  for (const svg of svgFiles) {
+    diagnostics.push({
+      rule: Rule.NoSvg,
+      severity: 'error',
+      file: rel(svg),
+      title: 'SVG files are not allowed',
+      detail: `"${svg.name}" is an SVG file. SVG files can contain embedded scripts and pose an XSS risk. Use PNG or WebP instead.`,
+    });
+  }
+
+  // images-in-img-dir: all image files must be inside an img/ directory
+  for (const img of imageFiles) {
+    const relPath = rel(img);
+    if (!isInImgDir(relPath)) {
+      diagnostics.push({
+        rule: Rule.ImagesInImgDir,
+        severity: input.strict ? 'error' : 'info',
+        file: relPath,
+        title: 'Image not in img/ directory',
+        detail: `"${img.name}" must be inside an img/ directory. Move it to the img/ folder next to the markdown files that reference it.`,
+      });
+    }
+  }
+
+  // allowed-image-formats: files in img/ dirs must be allowed image formats
+  for (const file of allFiles) {
+    const relPath = rel(file);
+    if (!isInImgDir(relPath)) {
+      continue;
+    }
+    const ext = extname(file.name).toLowerCase();
+    if (ext === '.svg') {
+      // handled by no-svg-files
+      continue;
+    }
+    if (!ALLOWED_IMAGE_EXT.has(ext)) {
+      diagnostics.push({
+        rule: Rule.AllowedImageFormats,
+        severity: input.strict ? 'error' : 'info',
+        file: relPath,
+        title: 'Image format not allowed',
+        detail: `"${file.name}" is not an allowed image format. Only png, jpg, jpeg, webp and gif files are permitted.`,
+      });
+    }
+  }
+
+  // image-file-naming: image filenames must use only [a-z0-9-_.]
+  for (const img of imageFiles) {
+    if (!IMAGE_FILE_NAME_RE.test(img.name)) {
+      diagnostics.push({
+        rule: Rule.ImageFileNaming,
+        severity: input.strict ? 'error' : 'info',
+        file: rel(img),
+        title: 'Image filename contains invalid characters',
+        detail: `"${img.name}" should use only lowercase letters, digits, hyphens, underscores and dots.`,
+      });
+    }
+  }
+
+  // max-image-size and max-total-images-size: check individual and total sizes
+  let totalSize = 0;
+  for (const img of imageFiles) {
+    const absPath = join(img.parentPath, img.name);
+    let size: number;
+    try {
+      const st = await stat(absPath);
+      size = st.size;
+    } catch {
+      continue;
+    }
+    totalSize += size;
+
+    const ext = extname(img.name).toLowerCase();
+    const isGif = ext === '.gif';
+    const maxSize = isGif ? MAX_GIF_SIZE : MAX_STATIC_SIZE;
+    const maxLabel = isGif ? '1MB' : '300KB';
+    if (size > maxSize) {
+      diagnostics.push({
+        rule: Rule.MaxImageSize,
+        severity: input.strict ? 'error' : 'info',
+        file: rel(img),
+        title: `Image exceeds ${maxLabel} limit`,
+        detail: `"${img.name}" is ${formatBytes(size)} which exceeds the ${maxLabel} limit for ${isGif ? 'GIF' : 'static'} images. Compress or resize the image.`,
+      });
+    }
+  }
+
+  // max-total-images-size: only in strict mode (serve = '-')
+  if (input.strict && totalSize > MAX_TOTAL_SIZE) {
+    diagnostics.push({
+      rule: Rule.MaxTotalImagesSize,
+      severity: 'warning',
+      title: 'Total image size exceeds 5MB',
+      detail: `Total image size is ${formatBytes(totalSize)} which exceeds the 5MB limit. Reduce the number or size of images.`,
+    });
+  }
+
+  // referenced-images-exist and no-orphaned-images: parse markdown for image refs
+  const referencedPaths = new Set<string>();
+
+  for (const md of mdFiles) {
+    const absPath = join(md.parentPath, md.name);
+    const mdRelPath = rel(md);
+    let content: string;
+    try {
+      content = await readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const imageRefRe = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+    let match: RegExpExecArray | null;
+    while ((match = imageRefRe.exec(content)) !== null) {
+      const ref = match[2];
+      // skip external URLs and data URIs
+      if (/^https?:\/\//i.test(ref) || /^data:/i.test(ref)) {
+        continue;
+      }
+      const resolvedPath = normalize(join(dirname(mdRelPath), ref));
+      referencedPaths.add(resolvedPath);
+
+      // referenced-images-exist: check that the target file exists on disk
+      const entryExists = allFiles.some((e) => rel(e) === resolvedPath);
+      if (!entryExists) {
+        diagnostics.push({
+          rule: Rule.ReferencedImagesExist,
+          severity: 'error',
+          file: mdRelPath,
+          line: findRefLine(content, ref),
+          title: 'Referenced image does not exist',
+          detail: `Image "${ref}" referenced in markdown does not exist on disk.`,
+        });
+      }
+    }
+  }
+
+  // no-orphaned-images: only in strict mode (serve = '-')
+  if (input.strict) {
+    for (const img of imageFiles) {
+      const relPath = rel(img);
+      // only check images that are in img/ directories
+      if (!isInImgDir(relPath)) {
+        continue;
+      }
+      if (!referencedPaths.has(relPath)) {
+        diagnostics.push({
+          rule: Rule.NoOrphanedImages,
+          severity: 'info',
+          file: relPath,
+          title: 'Unreferenced image',
+          detail: `"${img.name}" is not referenced by any markdown file. Remove it if it is no longer needed.`,
+        });
+      }
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -2,8 +2,7 @@ import { readFile, readdir, stat } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, extname, dirname, relative, sep, normalize } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
-
-const ALLOWED_IMAGE_EXT = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif']);
+import { ALLOWED_IMAGE_EXTENSIONS } from './filesystem.js';
 const IMAGE_FILE_NAME_RE = /^[a-z0-9\-_.]+$/;
 const MAX_STATIC_SIZE = 300 * 1024; // 300KB
 const MAX_GIF_SIZE = 1024 * 1024; // 1MB
@@ -57,7 +56,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
   }
 
   const allFiles = entries.filter((e) => e.isFile());
-  const imageFiles = allFiles.filter((e) => ALLOWED_IMAGE_EXT.has(extname(e.name).toLowerCase()));
+  const imageFiles = allFiles.filter((e) => ALLOWED_IMAGE_EXTENSIONS.has(extname(e.name).toLowerCase()));
   const svgFiles = allFiles.filter((e) => extname(e.name).toLowerCase() === '.svg');
   const mdFiles = allFiles.filter((e) => e.name.endsWith('.md'));
 
@@ -102,7 +101,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
       // handled by no-svg-files
       continue;
     }
-    if (!ALLOWED_IMAGE_EXT.has(ext)) {
+    if (!ALLOWED_IMAGE_EXTENSIONS.has(ext)) {
       diagnostics.push({
         rule: Rule.AllowedImageFormats,
         severity: input.strict ? 'error' : 'info',

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -3,6 +3,7 @@ import type { Dirent } from 'node:fs';
 import { join, extname, dirname, relative, sep, normalize } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 import { ALLOWED_IMAGE_EXTENSIONS } from './filesystem.js';
+
 const IMAGE_FILE_NAME_RE = /^[a-z0-9\-_.]+$/;
 const MAX_STATIC_SIZE = 300 * 1024; // 300KB
 const MAX_GIF_SIZE = 1024 * 1024; // 1MB
@@ -164,6 +165,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
   }
 
   // referenced-images-exist and no-orphaned-images: parse markdown for image refs
+  const allFilePaths = new Set(allFiles.map((e) => rel(e)));
   const referencedPaths = new Set<string>();
 
   for (const md of mdFiles) {
@@ -188,8 +190,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
       referencedPaths.add(resolvedPath);
 
       // referenced-images-exist: check that the target file exists on disk
-      const entryExists = allFiles.some((e) => rel(e) === resolvedPath);
-      if (!entryExists) {
+      if (!allFilePaths.has(resolvedPath)) {
         diagnostics.push({
           rule: Rule.ReferencedImagesExist,
           severity: 'error',

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -6,8 +6,11 @@ import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 // slug-safe: lowercase letters, digits and hyphens only
 const SLUG_SAFE_RE = /^[a-z0-9-]+$/;
 
+// permitted image formats shared across filesystem and asset rules
+export const ALLOWED_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif']);
+
 // allowed file extensions in the docs folder (.md + permitted image formats)
-export const ALLOWED_EXTENSIONS = new Set(['.md', '.png', '.jpg', '.jpeg', '.webp', '.gif']);
+export const ALLOWED_EXTENSIONS = new Set(['.md', ...ALLOWED_IMAGE_EXTENSIONS]);
 
 export async function checkFilesystem(input: ValidationInput): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];

--- a/packages/plugin-docs-cli/src/validation/rules/index.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/index.ts
@@ -1,5 +1,6 @@
 import type { RuleRunner } from '../types.js';
+import { checkAssets } from './assets.js';
 import { checkFilesystem } from './filesystem.js';
 import { checkFrontmatter } from './frontmatter.js';
 
-export const allRules: RuleRunner[] = [checkFilesystem, checkFrontmatter];
+export const allRules: RuleRunner[] = [checkFilesystem, checkFrontmatter, checkAssets];

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -26,6 +26,7 @@ export const Rule = {
   MaxTotalImagesSize: 'max-total-images-size',
   ImageFileNaming: 'image-file-naming',
   NoOrphanedImages: 'no-orphaned-images',
+  MaxDataUriSize: 'max-data-uri-size',
 } as const;
 
 export type Rule = (typeof Rule)[keyof typeof Rule];

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -20,8 +20,6 @@ export const Rule = {
   DuplicatePosition: 'no-duplicate-sidebar-position',
   DuplicateSlug: 'no-duplicate-slugs',
   // asset rules
-  ImagesInImgDir: 'images-in-img-dir',
-  AllowedImageFormats: 'allowed-image-formats',
   NoSvg: 'no-svg-files',
   ReferencedImagesExist: 'referenced-images-exist',
   MaxImageSize: 'max-image-size',

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -19,6 +19,15 @@ export const Rule = {
   NoH1: 'no-h1-heading',
   DuplicatePosition: 'no-duplicate-sidebar-position',
   DuplicateSlug: 'no-duplicate-slugs',
+  // asset rules
+  ImagesInImgDir: 'images-in-img-dir',
+  AllowedImageFormats: 'allowed-image-formats',
+  NoSvg: 'no-svg-files',
+  ReferencedImagesExist: 'referenced-images-exist',
+  MaxImageSize: 'max-image-size',
+  MaxTotalImagesSize: 'max-total-images-size',
+  ImageFileNaming: 'image-file-naming',
+  NoOrphanedImages: 'no-orphaned-images',
 } as const;
 
 export type Rule = (typeof Rule)[keyof typeof Rule];


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds 8 asset validation rules to the plugin-docs-cli validation engine. These rules enforce image hygiene in plugin documentation: images must live in `img/` directories, use allowed formats (no SVG due to XSS risk), stay within size limits (300KB static, 1MB GIF, 5MB total) and use clean filenames. The rules also detect broken image references in markdown and flag orphaned images that are no longer used.

Severity depends on the validation mode. In strict mode (`validate` command), most rules are errors that block. In non-strict mode (`serve` command), they surface as info-level hints. Two rules - total image size and orphan detection - only run in strict mode.

The epic lists `images-in-img-dir` and `no-images-outside-img` as separate rows but notes they are the same enforcement from opposite directions. They are consolidated into one rule here.

**Which issue(s) this PR fixes**:

Part of [#771](https://github.com/grafana/grafana-catalog-team/issues/769)

**Special notes for your reviewer**:
