### PR TITLE
fix: exit migrate command if plugin is using create-plugin

### DIFF
--- a/packages/create-plugin/src/commands/migrate.command.ts
+++ b/packages/create-plugin/src/commands/migrate.command.ts
@@ -39,7 +39,7 @@ export const migrate = async (argv: minimist.ParsedArgs) => {
       title: `Your plugin is already using create-plugin.`,
       body: [
         'This command is designed to migrate plugins from @grafana/toolkit to @grafana/create-plugin, it should not be used to update plugins that already use @grafana/create-plugin.',
-        'To update your plugin to the latest version of @grafana/create-plugin please use the `update` command instead.',
+        `To update your plugin to the latest version of @grafana/create-plugin please use the ${output.formatCode('update')} command instead.`,
       ],
     });
     process.exit(1);


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

I've discovered developers are running the `migrate` command in plugins that already use create-plugin (a very old, unloved, command that was originally designed to migrate from toolkit -> create-plugin [docs](https://grafana.com/developers/plugin-tools/migration-guides/migrate-from-toolkit)). This creates multiple issues of which the biggest is replacing the entire .config dir.

This PR blocks attempts to run `migrate` if the plugin is already using create-plugin.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.5.1-canary.2510.22710977378.0
  npm install @grafana/create-plugin@7.0.3-canary.2510.22710977378.0
  npm install @grafana/plugin-docs-cli@0.0.6-canary.2510.22710977378.0
  npm install @grafana/plugin-docs-parser@0.0.3-canary.2510.22710977378.0
  # or 
  yarn add website@5.5.1-canary.2510.22710977378.0
  yarn add @grafana/create-plugin@7.0.3-canary.2510.22710977378.0
  yarn add @grafana/plugin-docs-cli@0.0.6-canary.2510.22710977378.0
  yarn add @grafana/plugin-docs-parser@0.0.3-canary.2510.22710977378.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
