### PR TITLE
Plugin E2E: Expand provisioning file variables

### DIFF
--- a/packages/plugin-e2e/src/fixtures/commands/readProvisionedAlertRule.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/readProvisionedAlertRule.ts
@@ -14,7 +14,12 @@ const ALERTING_DIR = 'alerting';
 export const readProvisionedAlertRule: ReadProvisionedAlertRuleFixture = async ({ provisioningRootDir }, use) => {
   await use(async ({ fileName, groupName, ruleTitle }) => {
     const resolvedPath = path.resolve(path.join(provisioningRootDir, ALERTING_DIR, fileName));
-    const contents = await promises.readFile(resolvedPath, 'utf8');
+    const raw = await promises.readFile(resolvedPath, 'utf8');
+    // expand env vars the same way Grafana does when loading provisioning YAML
+    const contents = raw.replace(/\$\{(\w+)(?::-(.*?))?\}|\$(\w+)/g, (_, braced, fallback, plain) => {
+      const varName = braced ?? plain;
+      return process.env[varName] ?? fallback ?? '';
+    });
     const yml = parseYml(contents);
     let group = yml.groups[0];
     if (groupName) {

--- a/packages/plugin-e2e/src/fixtures/commands/readProvisionedAlertRule.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/readProvisionedAlertRule.ts
@@ -17,7 +17,11 @@ export const readProvisionedAlertRule: ReadProvisionedAlertRuleFixture = async (
     const raw = await promises.readFile(resolvedPath, 'utf8');
     const contents = raw.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*?))?\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (_, braced, fallback, plain) => {
       const varName = braced ?? plain;
-      return process.env[varName] ?? fallback ?? '';
+      const envValue = process.env[varName];
+      if (envValue === undefined || envValue === '') {
+        return fallback ?? '';
+      }
+      return envValue;
     });
     const yml = parseYml(contents);
     let group = yml.groups[0];

--- a/packages/plugin-e2e/src/fixtures/commands/readProvisionedAlertRule.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/readProvisionedAlertRule.ts
@@ -15,7 +15,7 @@ export const readProvisionedAlertRule: ReadProvisionedAlertRuleFixture = async (
   await use(async ({ fileName, groupName, ruleTitle }) => {
     const resolvedPath = path.resolve(path.join(provisioningRootDir, ALERTING_DIR, fileName));
     const raw = await promises.readFile(resolvedPath, 'utf8');
-    const contents = raw.replace(/\$\{(\w+)(?::-(.*?))?\}|\$(\w+)/g, (_, braced, fallback, plain) => {
+    const contents = raw.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*?))?\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (_, braced, fallback, plain) => {
       const varName = braced ?? plain;
       return process.env[varName] ?? fallback ?? '';
     });

--- a/packages/plugin-e2e/src/fixtures/commands/readProvisionedAlertRule.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/readProvisionedAlertRule.ts
@@ -15,7 +15,6 @@ export const readProvisionedAlertRule: ReadProvisionedAlertRuleFixture = async (
   await use(async ({ fileName, groupName, ruleTitle }) => {
     const resolvedPath = path.resolve(path.join(provisioningRootDir, ALERTING_DIR, fileName));
     const raw = await promises.readFile(resolvedPath, 'utf8');
-    // expand env vars the same way Grafana does when loading provisioning YAML
     const contents = raw.replace(/\$\{(\w+)(?::-(.*?))?\}|\$(\w+)/g, (_, braced, fallback, plain) => {
       const varName = braced ?? plain;
       return process.env[varName] ?? fallback ?? '';

--- a/packages/plugin-e2e/src/fixtures/commands/readProvisionedDataSource.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/readProvisionedDataSource.ts
@@ -19,7 +19,13 @@ export const readProvisionedDataSource: ReadProvisionedDataSourceFixture = async
     // supports $VAR, ${VAR} and ${VAR:-default} syntax.
     const contents = raw.replace(/\$\{(\w+)(?::-(.*?))?\}|\$(\w+)/g, (_, braced, fallback, plain) => {
       const varName = braced ?? plain;
-      return process.env[varName] ?? fallback ?? '';
+      const value = process.env[varName];
+      // For ${VAR:-default}, treat empty string as unset, matching shell/Grafana semantics.
+      if (fallback !== undefined) {
+        return value === undefined || value === '' ? fallback : value ?? '';
+      }
+      // For $VAR or ${VAR} without fallback, preserve existing behavior.
+      return value ?? '';
     });
     const yml = parseYml(contents);
     if (!name) {

--- a/packages/plugin-e2e/src/fixtures/commands/readProvisionedDataSource.ts
+++ b/packages/plugin-e2e/src/fixtures/commands/readProvisionedDataSource.ts
@@ -14,7 +14,13 @@ const DATASOURCES_DIR = 'datasources';
 export const readProvisionedDataSource: ReadProvisionedDataSourceFixture = async ({ provisioningRootDir }, use) => {
   await use(async ({ fileName: filePath, name }) => {
     const resolvedPath = path.resolve(path.join(provisioningRootDir, DATASOURCES_DIR, filePath));
-    const contents = await promises.readFile(resolvedPath, 'utf8');
+    const raw = await promises.readFile(resolvedPath, 'utf8');
+    // expand env vars the same way Grafana does when loading provisioning YAML.
+    // supports $VAR, ${VAR} and ${VAR:-default} syntax.
+    const contents = raw.replace(/\$\{(\w+)(?::-(.*?))?\}|\$(\w+)/g, (_, braced, fallback, plain) => {
+      const varName = braced ?? plain;
+      return process.env[varName] ?? fallback ?? '';
+    });
     const yml = parseYml(contents);
     if (!name) {
       return yml.datasources[0];


### PR DESCRIPTION
## Summary
- Expand environment variables in provisioning YAML files when reading them with `readProvisionedDataSource` and `readProvisionedAlertRule`
- Supports `$VAR`, `${VAR}` and `${VAR:-default}` syntax, matching how Grafana interpolates env vars in provisioning files

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.4.2-canary.2512.22723302789.0
  # or 
  yarn add @grafana/plugin-e2e@3.4.2-canary.2512.22723302789.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
