### PR TITLE
fix: set config version only if migrations ran

### DIFF
--- a/packages/create-plugin/src/codemods/migrations/manager.test.ts
+++ b/packages/create-plugin/src/codemods/migrations/manager.test.ts
@@ -223,18 +223,6 @@ describe('Migrations', () => {
       expect(setRootConfig).toHaveBeenCalledWith({ version: '2.0.0' });
     });
 
-    it('should NOT update version in ".config/.cprc.json" if there are no migrations to run', async () => {
-      await runMigrations([]);
-
-      expect(setRootConfig).not.toHaveBeenCalled();
-    });
-
-    it('should NOT create any commits if there are no migrations to run, even when commitEachMigration is true', async () => {
-      await runMigrations([], { commitEachMigration: true });
-
-      expect(setRootConfig).not.toHaveBeenCalled();
-      expect(gitCommitNoVerify).not.toHaveBeenCalled();
-    });
     it('should NOT update version in ".config/.cprc.json" if any of the migrations fail', async () => {
       migrationTwoFn.mockImplementation(async () => {
         throw new Error('Unknown error.');

--- a/packages/create-plugin/src/codemods/migrations/manager.ts
+++ b/packages/create-plugin/src/codemods/migrations/manager.ts
@@ -28,8 +28,7 @@ type RunMigrationsOptions = {
 export async function runMigrations(migrations: Migration[], options: RunMigrationsOptions = {}) {
   const migrationList = migrations.map((meta) => `${meta.name} (${meta.description})`);
 
-  const migrationListBody =
-    migrationList.length > 0 ? output.bulletList(migrationList) : ['No migrations to run. Exiting.'];
+  const migrationListBody = migrationList.length > 0 ? output.bulletList(migrationList) : ['No migrations to run.'];
 
   output.log({ title: 'Running the following migrations:', body: migrationListBody });
 
@@ -44,12 +43,9 @@ export async function runMigrations(migrations: Migration[], options: RunMigrati
     }
   }
 
-  // Only set the version in the config file if there were migrations to run.
-  if (migrations.length > 0) {
-    await setRootConfig({ version: CURRENT_APP_VERSION });
+  await setRootConfig({ version: CURRENT_APP_VERSION });
 
-    if (options.commitEachMigration) {
-      await gitCommitNoVerify(`chore: update .config/.cprc.json to version ${CURRENT_APP_VERSION}.`);
-    }
+  if (options.commitEachMigration) {
+    await gitCommitNoVerify(`chore: update .config/.cprc.json to version ${CURRENT_APP_VERSION}.`);
   }
 }

--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -32,17 +32,24 @@ export const update = async (argv: minimist.ParsedArgs) => {
     }
 
     const migrations = getMigrationsToRun(version, CURRENT_APP_VERSION);
+
+    if (migrations.length === 0) {
+      output.log({
+        title: 'No migrations to run, exiting.',
+      });
+
+      process.exit(0);
+    }
+
     // filter out minimist internal properties (_ and $0) before passing to codemod
     const { _, $0, ...codemodOptions } = argv;
     await runMigrations(migrations, {
       commitEachMigration: !!argv.commit,
       codemodOptions,
     });
-    if (migrations.length > 0) {
-      output.success({
-        title: `Successfully updated create-plugin from ${version} to ${CURRENT_APP_VERSION}.`,
-      });
-    }
+    output.success({
+      title: `Successfully updated create-plugin from ${version} to ${CURRENT_APP_VERSION}.`,
+    });
   } catch (error) {
     if (error instanceof Error) {
       output.error({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently if create-plugin update doesn't run any migrations it still updates the version in the cprc.json file. This creates unnecessary noise both locally and if update runs via CI. This PR addresses this by bailing out early if there are no migrations to run.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@7.0.5-canary.2513.22765717595.0
  # or 
  yarn add @grafana/create-plugin@7.0.5-canary.2513.22765717595.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
