### PR TITLE
Plugin Docs: Complete validation rules and serve integration

### DIFF
--- a/packages/plugin-docs-cli/src/scanner.ts
+++ b/packages/plugin-docs-cli/src/scanner.ts
@@ -131,12 +131,9 @@ async function scanMarkdownFiles(docsPath: string): Promise<ScannedFile[]> {
     const fileContent = await readFile(absolutePath, 'utf-8');
     const parsed = matter(fileContent);
 
-    // validate frontmatter has required fields with correct types
+    // skip files without required frontmatter (validation rules report these)
     const frontmatter = parsed.data as Partial<Frontmatter>;
     if (typeof frontmatter.title !== 'string' || typeof frontmatter.description !== 'string') {
-      console.warn(
-        `Warning: ${relativePath} missing or invalid required frontmatter fields (title: string, description: string)`
-      );
       continue;
     }
 
@@ -221,11 +218,7 @@ function treeToPages(node: TreeNode): Page[] {
       const generatedSlug = isIndex ? generateSlug(parsed.dir) : generateSlug(child.file.relativePath);
       const customSlug = child.file.frontmatter.slug ? normalizeCustomSlug(child.file.frontmatter.slug) : null;
 
-      if (child.file.frontmatter.slug && !customSlug) {
-        console.warn(
-          `Warning: ${child.file.relativePath} contains an invalid frontmatter slug and will use generated slug instead`
-        );
-      }
+      // invalid slugs fall back to generated slug (validation rules report these)
 
       const page: Page = {
         title: child.file.frontmatter.title,

--- a/packages/plugin-docs-cli/src/server/server.ts
+++ b/packages/plugin-docs-cli/src/server/server.ts
@@ -6,6 +6,9 @@ import createDebug from 'debug';
 import { parseMarkdown, type Manifest, type Page, type MarkdownFiles } from '@grafana/plugin-docs-parser';
 import { toHtml } from 'hast-util-to-html';
 import { scanDocsFolder } from '../scanner.js';
+import { validate } from '../validation/engine.js';
+import { formatResult } from '../validation/format.js';
+import { allRules } from '../validation/rules/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -41,12 +44,27 @@ export async function startServer(options: ServerOptions): Promise<Server> {
   app.set('view engine', 'ejs');
   app.set('views', join(__dirname, 'views'));
 
+  // run validation in non-strict mode and log results without blocking
+  const runValidation = async () => {
+    try {
+      const result = await validate({ docsPath, strict: false }, allRules);
+      if (result.diagnostics.length > 0) {
+        console.log(formatResult(result));
+      }
+    } catch (error) {
+      debug('Validation failed: %O', error);
+    }
+  };
+
   // scan filesystem and generate manifest + load files into memory
   debug('Scanning docs folder: %s', docsPath);
   const scanned = await scanDocsFolder(docsPath);
   let manifest: Manifest = scanned.manifest;
   let files: MarkdownFiles = scanned.files;
   debug('Manifest generated with %d pages, %d files loaded', manifest.pages.length, Object.keys(files).length);
+
+  // validate on startup
+  await runValidation();
 
   // setup file watcher for markdown files
   const watcher = watch(join(docsPath, '**/*.md'), {
@@ -65,6 +83,8 @@ export async function startServer(options: ServerOptions): Promise<Server> {
     } catch (error) {
       console.error('Error re-scanning docs folder:', error);
     }
+
+    await runValidation();
   };
 
   watcher.on('change', (p) => rescan('changed', p));

--- a/packages/plugin-docs-cli/src/server/server.ts
+++ b/packages/plugin-docs-cli/src/server/server.ts
@@ -52,7 +52,7 @@ export async function startServer(options: ServerOptions): Promise<Server> {
         console.log(formatResult(result));
       }
     } catch (error) {
-      debug('Validation failed: %O', error);
+      console.error('Validation failed:', error instanceof Error ? error.message : error);
     }
   };
 

--- a/packages/plugin-docs-cli/src/validation/rules/cross-file.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/cross-file.test.ts
@@ -221,5 +221,14 @@ describe('checkCrossFile', () => {
       const findings = await checkCrossFile(input(tmp));
       expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
     });
+
+    it('should resolve duplicate heading slugs with suffix', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      // github-slugger appends -1 for the second occurrence of the same heading
+      await writeFile(join(tmp, 'index.md'), md('## Setup\n\n## Setup\n\n[first](#setup)\n[second](#setup-1)'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+    });
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/cross-file.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/cross-file.test.ts
@@ -160,12 +160,15 @@ describe('checkCrossFile', () => {
       expect(finding!.detail).toContain('#nonexistent');
     });
 
-    it('should skip anchor validation in non-strict mode', async () => {
+    it('should report anchor as warning in non-strict mode', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
       await writeFile(join(tmp, 'index.md'), md('## Hello\n\n[jump](#nonexistent)'));
 
       const findings = await checkCrossFile(input(tmp, false));
-      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+
+      const finding = findings.find((f) => f.rule === Rule.AnchorLinksResolve);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('warning');
     });
 
     it('should not report valid cross-file anchor', async () => {

--- a/packages/plugin-docs-cli/src/validation/rules/cross-file.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/cross-file.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { checkCrossFile } from './cross-file.js';
+import { Rule } from '../types.js';
+
+const input = (docsPath: string, strict = true) => ({ docsPath, strict });
+
+const md = (body = '') => `---\ntitle: Page\ndescription: A page\n---\n${body}`;
+
+describe('checkCrossFile', () => {
+  it('should return empty for nonexistent path', async () => {
+    const findings = await checkCrossFile(input('/nonexistent/path'));
+    expect(findings).toHaveLength(0);
+  });
+
+  it('should return empty for docs with no links', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+    await writeFile(join(tmp, 'index.md'), md('## Hello\n\nSome content.'));
+
+    const findings = await checkCrossFile(input(tmp));
+    expect(findings).toHaveLength(0);
+  });
+
+  // --- internal-links-resolve ---
+
+  describe('internal-links-resolve', () => {
+    it('should not report when linked file exists', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[other](other.md)'));
+      await writeFile(join(tmp, 'other.md'), md('## Other'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksResolve)).toBeUndefined();
+    });
+
+    it('should not report when linked file exists with ./ prefix', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[other](./other.md)'));
+      await writeFile(join(tmp, 'other.md'), md('## Other'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksResolve)).toBeUndefined();
+    });
+
+    it('should report when linked file does not exist', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[missing](missing.md)'));
+
+      const findings = await checkCrossFile(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.InternalLinksResolve);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+      expect(finding!.detail).toContain('missing.md');
+    });
+
+    it('should report as warning in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[missing](missing.md)'));
+
+      const findings = await checkCrossFile(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.InternalLinksResolve);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('warning');
+    });
+
+    it('should resolve links relative to the source file', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('## Home'));
+      await mkdir(join(tmp, 'sub'));
+      await writeFile(join(tmp, 'sub', 'page.md'), md('[sibling](sibling.md)'));
+      await writeFile(join(tmp, 'sub', 'sibling.md'), md('## Sibling'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksResolve)).toBeUndefined();
+    });
+
+    it('should report when sibling link does not resolve', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await mkdir(join(tmp, 'sub'));
+      await writeFile(join(tmp, 'sub', 'page.md'), md('[ghost](ghost.md)'));
+
+      const findings = await checkCrossFile(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.InternalLinksResolve);
+      expect(finding).toBeDefined();
+      expect(finding!.file).toContain('page.md');
+    });
+
+    it('should include line number', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('\n\n[missing](gone.md)\n'));
+
+      const findings = await checkCrossFile(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.InternalLinksResolve);
+      expect(finding).toBeDefined();
+      expect(finding!.line).toBeDefined();
+      expect(finding!.line).toBeGreaterThan(1);
+    });
+
+    it('should skip external URLs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[external](https://example.com)'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksResolve)).toBeUndefined();
+    });
+
+    it('should skip image references', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](missing-image.png)'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksResolve)).toBeUndefined();
+    });
+
+    it('should not report links inside code blocks', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('```\n[missing](gone.md)\n```'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksResolve)).toBeUndefined();
+    });
+
+    it('should handle links to non-md files', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[download](file.zip)'));
+
+      const findings = await checkCrossFile(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.InternalLinksResolve);
+      expect(finding).toBeDefined();
+    });
+  });
+
+  // --- anchor-links-resolve ---
+
+  describe('anchor-links-resolve', () => {
+    it('should not report valid same-file anchor', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('## Getting Started\n\n[jump](#getting-started)'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+    });
+
+    it('should report invalid same-file anchor in strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('## Hello\n\n[jump](#nonexistent)'));
+
+      const findings = await checkCrossFile(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.AnchorLinksResolve);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+      expect(finding!.detail).toContain('#nonexistent');
+    });
+
+    it('should skip anchor validation in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('## Hello\n\n[jump](#nonexistent)'));
+
+      const findings = await checkCrossFile(input(tmp, false));
+      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+    });
+
+    it('should not report valid cross-file anchor', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[jump](other.md#setup)'));
+      await writeFile(join(tmp, 'other.md'), md('## Setup\n\nContent here.'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+    });
+
+    it('should report invalid cross-file anchor', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[jump](other.md#nonexistent)'));
+      await writeFile(join(tmp, 'other.md'), md('## Setup\n\nContent here.'));
+
+      const findings = await checkCrossFile(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.AnchorLinksResolve);
+      expect(finding).toBeDefined();
+      expect(finding!.detail).toContain('#nonexistent');
+      expect(finding!.detail).toContain('other.md');
+    });
+
+    it('should handle h3 headings', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('### Deep Heading\n\n[jump](#deep-heading)'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+    });
+
+    it('should handle headings with inline formatting', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('## **Bold** heading\n\n[jump](#bold-heading)'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+    });
+
+    it('should handle headings with inline code', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('## The `config` file\n\n[jump](#the-config-file)'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+    });
+
+    it('should not check anchors inside code blocks', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'xfile-test-'));
+      await writeFile(join(tmp, 'index.md'), md('```\n[jump](#nonexistent)\n```'));
+
+      const findings = await checkCrossFile(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.AnchorLinksResolve)).toBeUndefined();
+    });
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/cross-file.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/cross-file.ts
@@ -1,0 +1,201 @@
+import { readFile, readdir } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { join, relative, dirname, normalize } from 'node:path';
+import GithubSlugger from 'github-slugger';
+import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+
+// matches markdown links: [text](url)
+const LINK_RE = /\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+// matches external/special URLs to skip
+const SKIP_URL_RE = /^(https?:\/\/|mailto:|tel:|data:|javascript:|vbscript:)/i;
+
+// matches headings in markdown: ## Heading text
+const HEADING_RE = /^(#{2,6})\s+(.+)$/;
+
+/**
+ * Returns a set of 1-based line numbers inside fenced code blocks.
+ */
+function getCodeBlockLines(content: string): Set<number> {
+  const lines = content.split('\n');
+  const codeLines = new Set<number>();
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```/.test(lines[i].trim())) {
+      inCodeBlock = !inCodeBlock;
+      codeLines.add(i + 1);
+      continue;
+    }
+    if (inCodeBlock) {
+      codeLines.add(i + 1);
+    }
+  }
+
+  return codeLines;
+}
+
+/**
+ * Extracts heading anchor IDs from markdown content using github-slugger
+ * (same algorithm as rehype-slug in the parser).
+ */
+function extractHeadingIds(content: string): Set<string> {
+  const ids = new Set<string>();
+  const slugger = new GithubSlugger();
+  const lines = content.split('\n');
+  const codeLines = getCodeBlockLines(content);
+
+  for (let i = 0; i < lines.length; i++) {
+    if (codeLines.has(i + 1)) {
+      continue;
+    }
+    const match = HEADING_RE.exec(lines[i]);
+    if (match) {
+      // strip inline markdown (bold, italic, code, links) from heading text
+      const text = match[2]
+        .replace(/\*\*([^*]+)\*\*/g, '$1') // bold
+        .replace(/\*([^*]+)\*/g, '$1') // italic
+        .replace(/`([^`]+)`/g, '$1') // inline code
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // links
+        .trim();
+      ids.add(slugger.slug(text));
+    }
+  }
+
+  return ids;
+}
+
+/**
+ * Parses links from markdown content, skipping code blocks and image references.
+ * Returns link refs with their line numbers.
+ */
+function extractLinks(content: string, codeLines: Set<number>): Array<{ ref: string; line: number }> {
+  const results: Array<{ ref: string; line: number }> = [];
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    if (codeLines.has(i + 1)) {
+      continue;
+    }
+    const lineRe = new RegExp(LINK_RE.source, LINK_RE.flags);
+    let m: RegExpExecArray | null;
+    while ((m = lineRe.exec(lines[i])) !== null) {
+      // skip image refs (preceded by !)
+      if (m.index > 0 && lines[i][m.index - 1] === '!') {
+        continue;
+      }
+      results.push({ ref: m[2], line: i + 1 });
+    }
+  }
+
+  return results;
+}
+
+export async function checkCrossFile(input: ValidationInput): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = [];
+
+  let entries: Dirent[] = [];
+  try {
+    entries = await readdir(input.docsPath, { recursive: true, withFileTypes: true });
+  } catch {
+    return diagnostics;
+  }
+
+  const allFiles = entries.filter((e) => e.isFile());
+  const mdFiles = allFiles.filter((e) => e.name.endsWith('.md'));
+  const allFilePaths = new Set(allFiles.map((e) => relative(input.docsPath, join(e.parentPath, e.name))));
+
+  // build a map of relative path -> heading IDs for each markdown file
+  const fileHeadings = new Map<string, Set<string>>();
+  const fileContents = new Map<string, string>();
+
+  for (const md of mdFiles) {
+    const absPath = join(md.parentPath, md.name);
+    const relPath = relative(input.docsPath, absPath);
+
+    let content: string;
+    try {
+      content = await readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    fileContents.set(relPath, content);
+    fileHeadings.set(relPath, extractHeadingIds(content));
+  }
+
+  // check links in each markdown file
+  for (const [relPath, content] of fileContents) {
+    const codeLines = getCodeBlockLines(content);
+    const links = extractLinks(content, codeLines);
+
+    for (const { ref, line } of links) {
+      // skip external and special URLs
+      if (SKIP_URL_RE.test(ref)) {
+        continue;
+      }
+
+      // split ref into path and optional anchor: "page.md#section" -> ["page.md", "section"]
+      const [pathPart, anchor] = ref.split('#', 2);
+
+      // anchor-links-resolve: same-file anchor (#section)
+      if (!pathPart) {
+        if (!input.strict) {
+          continue;
+        }
+        if (anchor) {
+          const headings = fileHeadings.get(relPath);
+          if (headings && !headings.has(anchor)) {
+            diagnostics.push({
+              rule: Rule.AnchorLinksResolve,
+              severity: 'error',
+              file: relPath,
+              line,
+              title: 'Anchor link does not resolve',
+              detail: `"#${anchor}" does not match any heading in this file.`,
+            });
+          }
+        }
+        continue;
+      }
+
+      // skip non-file references (absolute paths handled by internal-links-relative)
+      if (pathPart.startsWith('/') || /^\.\.\//.test(pathPart)) {
+        continue;
+      }
+
+      // resolve the path relative to the current file's directory
+      const resolvedPath = normalize(join(dirname(relPath), pathPart));
+
+      // internal-links-resolve: check that the target file exists
+      if (!allFilePaths.has(resolvedPath)) {
+        diagnostics.push({
+          rule: Rule.InternalLinksResolve,
+          severity: input.strict ? 'error' : 'warning',
+          file: relPath,
+          line,
+          title: 'Internal link does not resolve',
+          detail: `"${pathPart}" does not point to an existing file.`,
+        });
+        continue;
+      }
+
+      // anchor-links-resolve: if the link has an anchor, check it resolves in the target file
+      if (anchor && input.strict) {
+        const targetHeadings = fileHeadings.get(resolvedPath);
+        if (targetHeadings && !targetHeadings.has(anchor)) {
+          diagnostics.push({
+            rule: Rule.AnchorLinksResolve,
+            severity: 'error',
+            file: relPath,
+            line,
+            title: 'Anchor link does not resolve',
+            detail: `"#${anchor}" does not match any heading in "${pathPart}".`,
+          });
+        }
+      }
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/plugin-docs-cli/src/validation/rules/cross-file.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/cross-file.ts
@@ -80,7 +80,9 @@ export async function checkCrossFile(input: ValidationInput): Promise<Diagnostic
     return diagnostics;
   }
 
-  const allFiles = entries.filter((e) => e.isFile());
+  const allFiles = entries.filter(
+    (e) => e.isFile() && !e.parentPath.includes('node_modules') && !e.parentPath.includes('dist')
+  );
   const mdFiles = allFiles.filter((e) => e.name.endsWith('.md'));
   const allFilePaths = new Set(allFiles.map((e) => relative(input.docsPath, join(e.parentPath, e.name))));
 
@@ -119,15 +121,12 @@ export async function checkCrossFile(input: ValidationInput): Promise<Diagnostic
 
       // anchor-links-resolve: same-file anchor (#section)
       if (!pathPart) {
-        if (!input.strict) {
-          continue;
-        }
         if (anchor) {
           const headings = fileHeadings.get(relPath);
           if (headings && !headings.has(anchor)) {
             diagnostics.push({
               rule: Rule.AnchorLinksResolve,
-              severity: 'error',
+              severity: input.strict ? 'error' : 'warning',
               file: relPath,
               line,
               title: 'Anchor link does not resolve',
@@ -160,12 +159,12 @@ export async function checkCrossFile(input: ValidationInput): Promise<Diagnostic
       }
 
       // anchor-links-resolve: if the link has an anchor, check it resolves in the target file
-      if (anchor && input.strict) {
+      if (anchor) {
         const targetHeadings = fileHeadings.get(resolvedPath);
         if (targetHeadings && !targetHeadings.has(anchor)) {
           diagnostics.push({
             rule: Rule.AnchorLinksResolve,
-            severity: 'error',
+            severity: input.strict ? 'error' : 'warning',
             file: relPath,
             line,
             title: 'Anchor link does not resolve',

--- a/packages/plugin-docs-cli/src/validation/rules/cross-file.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/cross-file.ts
@@ -3,6 +3,7 @@ import type { Dirent } from 'node:fs';
 import { join, relative, dirname, normalize } from 'node:path';
 import GithubSlugger from 'github-slugger';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+import { getCodeBlockLines } from './utils.js';
 
 // matches markdown links: [text](url)
 const LINK_RE = /\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
@@ -12,28 +13,6 @@ const SKIP_URL_RE = /^(https?:\/\/|mailto:|tel:|data:|javascript:|vbscript:)/i;
 
 // matches headings in markdown: ## Heading text
 const HEADING_RE = /^(#{2,6})\s+(.+)$/;
-
-/**
- * Returns a set of 1-based line numbers inside fenced code blocks.
- */
-function getCodeBlockLines(content: string): Set<number> {
-  const lines = content.split('\n');
-  const codeLines = new Set<number>();
-  let inCodeBlock = false;
-
-  for (let i = 0; i < lines.length; i++) {
-    if (/^```/.test(lines[i].trim())) {
-      inCodeBlock = !inCodeBlock;
-      codeLines.add(i + 1);
-      continue;
-    }
-    if (inCodeBlock) {
-      codeLines.add(i + 1);
-    }
-  }
-
-  return codeLines;
-}
 
 /**
  * Extracts heading anchor IDs from markdown content using github-slugger

--- a/packages/plugin-docs-cli/src/validation/rules/index.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/index.ts
@@ -2,5 +2,6 @@ import type { RuleRunner } from '../types.js';
 import { checkAssets } from './assets.js';
 import { checkFilesystem } from './filesystem.js';
 import { checkFrontmatter } from './frontmatter.js';
+import { checkMarkdown } from './markdown.js';
 
-export const allRules: RuleRunner[] = [checkFilesystem, checkFrontmatter, checkAssets];
+export const allRules: RuleRunner[] = [checkFilesystem, checkFrontmatter, checkAssets, checkMarkdown];

--- a/packages/plugin-docs-cli/src/validation/rules/index.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/index.ts
@@ -1,7 +1,16 @@
 import type { RuleRunner } from '../types.js';
 import { checkAssets } from './assets.js';
+import { checkCrossFile } from './cross-file.js';
 import { checkFilesystem } from './filesystem.js';
 import { checkFrontmatter } from './frontmatter.js';
+import { checkManifest } from './manifest.js';
 import { checkMarkdown } from './markdown.js';
 
-export const allRules: RuleRunner[] = [checkFilesystem, checkFrontmatter, checkAssets, checkMarkdown];
+export const allRules: RuleRunner[] = [
+  checkFilesystem,
+  checkFrontmatter,
+  checkAssets,
+  checkMarkdown,
+  checkCrossFile,
+  checkManifest,
+];

--- a/packages/plugin-docs-cli/src/validation/rules/manifest.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/manifest.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { checkManifest } from './manifest.js';
+import { Rule } from '../types.js';
+
+const input = (docsPath: string, strict = true) => ({ docsPath, strict });
+
+const md = (title: string, body = '') =>
+  `---\ntitle: ${title}\ndescription: A page about ${title.toLowerCase()}\n---\n${body}`;
+
+describe('checkManifest', () => {
+  it('should return empty for nonexistent path', async () => {
+    const findings = await checkManifest(input('/nonexistent/path'));
+    expect(findings).toHaveLength(0);
+  });
+
+  it('should return empty for valid single-file docs', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'manifest-test-'));
+    await writeFile(join(tmp, 'index.md'), md('Home', '## Welcome'));
+
+    const findings = await checkManifest(input(tmp));
+    expect(findings).toHaveLength(0);
+  });
+
+  it('should return empty for valid multi-file docs', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'manifest-test-'));
+    await writeFile(join(tmp, 'index.md'), md('Home'));
+    await writeFile(join(tmp, 'setup.md'), md('Setup'));
+    await mkdir(join(tmp, 'config'));
+    await writeFile(join(tmp, 'config', 'index.md'), md('Configuration'));
+    await writeFile(join(tmp, 'config', 'auth.md'), md('Authentication'));
+
+    const findings = await checkManifest(input(tmp));
+    expect(findings).toHaveLength(0);
+  });
+
+  // --- manifest-valid ---
+
+  describe('manifest-valid', () => {
+    it('should return empty when docs have valid frontmatter', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'manifest-test-'));
+      await writeFile(join(tmp, 'index.md'), md('Home'));
+
+      const findings = await checkManifest(input(tmp));
+
+      const validFindings = findings.filter((f) => f.rule === Rule.ManifestValid);
+      expect(validFindings).toHaveLength(0);
+    });
+
+    it('should return empty for docs without any valid markdown', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'manifest-test-'));
+      // file with no frontmatter - scanner skips it, throws, and checkManifest catches
+      await writeFile(join(tmp, 'bad.md'), 'no frontmatter here');
+
+      const findings = await checkManifest(input(tmp));
+      // scanDocsFolder throws "No valid markdown files found", checkManifest catches it
+      expect(findings).toHaveLength(0);
+    });
+  });
+
+  // --- manifest-refs-exist ---
+
+  describe('manifest-refs-exist', () => {
+    it('should not report when all manifest file refs exist', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'manifest-test-'));
+      await writeFile(join(tmp, 'index.md'), md('Home'));
+      await writeFile(join(tmp, 'other.md'), md('Other'));
+
+      const findings = await checkManifest(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ManifestRefsExist)).toBeUndefined();
+    });
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/manifest.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/manifest.ts
@@ -1,0 +1,129 @@
+import { readdir } from 'node:fs/promises';
+import { relative, join } from 'node:path';
+import type { Dirent } from 'node:fs';
+import type { Page } from '@grafana/plugin-docs-parser';
+import { scanDocsFolder } from '../../scanner.js';
+import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+
+/**
+ * Collects all file references from a manifest page tree.
+ */
+function collectPageFiles(pages: Page[]): Array<{ file: string; slug: string }> {
+  const refs: Array<{ file: string; slug: string }> = [];
+  for (const page of pages) {
+    if (page.file) {
+      refs.push({ file: page.file, slug: page.slug });
+    }
+    if (page.children) {
+      refs.push(...collectPageFiles(page.children));
+    }
+  }
+  return refs;
+}
+
+/**
+ * Validates that a page has required fields and valid structure.
+ */
+function validatePage(page: Page, path: string, diagnostics: Diagnostic[]): void {
+  if (!page.title) {
+    diagnostics.push({
+      rule: Rule.ManifestValid,
+      severity: 'error',
+      title: 'Manifest page missing title',
+      detail: `Page at "${path}" has no title.`,
+    });
+  }
+
+  if (!page.slug && page.slug !== '') {
+    diagnostics.push({
+      rule: Rule.ManifestValid,
+      severity: 'error',
+      title: 'Manifest page missing slug',
+      detail: `Page "${page.title || path}" has no slug.`,
+    });
+  }
+
+  if (page.children) {
+    for (let i = 0; i < page.children.length; i++) {
+      validatePage(page.children[i], `${path}/${page.children[i].slug || i}`, diagnostics);
+    }
+  }
+}
+
+export async function checkManifest(input: ValidationInput): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = [];
+
+  // generate manifest from filesystem
+  let manifest;
+  try {
+    const scanned = await scanDocsFolder(input.docsPath);
+    manifest = scanned.manifest;
+  } catch {
+    // if scanning fails entirely, other rules already cover the issues (no markdown files, etc.)
+    return diagnostics;
+  }
+
+  // manifest-valid: check basic structure
+  if (!manifest.version) {
+    diagnostics.push({
+      rule: Rule.ManifestValid,
+      severity: 'error',
+      title: 'Manifest missing version',
+      detail: 'The generated manifest has no version field.',
+    });
+  }
+
+  if (!manifest.pages || !Array.isArray(manifest.pages)) {
+    diagnostics.push({
+      rule: Rule.ManifestValid,
+      severity: 'error',
+      title: 'Manifest missing pages',
+      detail: 'The generated manifest has no pages array.',
+    });
+    return diagnostics;
+  }
+
+  if (manifest.pages.length === 0) {
+    diagnostics.push({
+      rule: Rule.ManifestValid,
+      severity: 'error',
+      title: 'Manifest has no pages',
+      detail: 'The generated manifest has an empty pages array.',
+    });
+    return diagnostics;
+  }
+
+  // validate each page recursively
+  for (const page of manifest.pages) {
+    validatePage(page, page.slug || '(root)', diagnostics);
+  }
+
+  // manifest-refs-exist: check that all file paths in the manifest point to existing files
+  let entries: Dirent[] = [];
+  try {
+    entries = await readdir(input.docsPath, { recursive: true, withFileTypes: true });
+  } catch {
+    return diagnostics;
+  }
+
+  const allFiles = new Set(
+    entries.filter((e) => e.isFile()).map((e) => relative(input.docsPath, join(e.parentPath, e.name)))
+  );
+
+  const pageFiles = collectPageFiles(manifest.pages);
+  for (const { file, slug } of pageFiles) {
+    if (!file) {
+      continue;
+    }
+    if (!allFiles.has(file)) {
+      diagnostics.push({
+        rule: Rule.ManifestRefsExist,
+        severity: 'error',
+        title: 'Manifest references missing file',
+        detail: `Page "${slug}" references "${file}" which does not exist.`,
+      });
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.test.ts
@@ -1,0 +1,546 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { checkMarkdown } from './markdown.js';
+import { Rule } from '../types.js';
+
+const input = (docsPath: string, strict = true) => ({ docsPath, strict });
+
+// helper: valid frontmatter markdown file content
+const md = (body = '') => `---\ntitle: Page\ndescription: A page\n---\n${body}`;
+
+describe('checkMarkdown', () => {
+  it('should return empty for nonexistent path', async () => {
+    const findings = await checkMarkdown(input('/nonexistent/path'));
+    expect(findings).toHaveLength(0);
+  });
+
+  it('should return empty for valid markdown with no issues', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+    await writeFile(join(tmp, 'index.md'), md('## Hello\n\nSome content.\n'));
+
+    const findings = await checkMarkdown(input(tmp));
+    expect(findings).toHaveLength(0);
+  });
+
+  // --- no-raw-html ---
+
+  describe('no-raw-html', () => {
+    it('should report raw HTML tags', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<div>content</div>'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const htmlFindings = findings.filter((f) => f.rule === Rule.NoRawHtml);
+      expect(htmlFindings.length).toBeGreaterThanOrEqual(1);
+      expect(htmlFindings[0].severity).toBe('error');
+    });
+
+    it('should report as warning in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<div>content</div>'));
+
+      const findings = await checkMarkdown(input(tmp, false));
+
+      const htmlFindings = findings.filter((f) => f.rule === Rule.NoRawHtml);
+      expect(htmlFindings.length).toBeGreaterThanOrEqual(1);
+      expect(htmlFindings[0].severity).toBe('warning');
+    });
+
+    it('should allow <br> tags', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('Line 1<br>Line 2'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoRawHtml)).toBeUndefined();
+    });
+
+    it('should allow <details> and <summary> tags', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<details><summary>Click</summary>\nHidden content\n</details>'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoRawHtml)).toBeUndefined();
+    });
+
+    it('should not report HTML inside fenced code blocks', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('```html\n<div>example</div>\n```'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoRawHtml)).toBeUndefined();
+    });
+
+    it('should report HTML with attributes', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<span class="highlight">text</span>'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const htmlFindings = findings.filter((f) => f.rule === Rule.NoRawHtml);
+      expect(htmlFindings.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should include line number', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('\n\n<div>deep</div>\n'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoRawHtml);
+      expect(finding).toBeDefined();
+      expect(finding!.line).toBeDefined();
+      expect(finding!.line).toBeGreaterThan(1);
+    });
+  });
+
+  // --- no-script-tags ---
+
+  describe('no-script-tags', () => {
+    it('should report <script> tags', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<script>alert("xss")</script>'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const scriptFindings = findings.filter((f) => f.rule === Rule.NoScriptTags);
+      expect(scriptFindings.length).toBeGreaterThanOrEqual(1);
+      expect(scriptFindings[0].severity).toBe('error');
+    });
+
+    it('should report <script> with attributes', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<script src="evil.js"></script>'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const scriptFindings = findings.filter((f) => f.rule === Rule.NoScriptTags);
+      expect(scriptFindings.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should report event handler attributes', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<img src="x" onerror="alert(1)">'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const scriptFindings = findings.filter((f) => f.rule === Rule.NoScriptTags);
+      expect(scriptFindings.length).toBeGreaterThanOrEqual(1);
+      expect(scriptFindings.some((f) => f.title.includes('Event handler'))).toBe(true);
+    });
+
+    it('should not report script tags inside code blocks', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('```html\n<script>safe()</script>\n```'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoScriptTags)).toBeUndefined();
+    });
+
+    it('should report as error even in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<script>alert("xss")</script>'));
+
+      const findings = await checkMarkdown(input(tmp, false));
+
+      const scriptFindings = findings.filter((f) => f.rule === Rule.NoScriptTags);
+      expect(scriptFindings.length).toBeGreaterThanOrEqual(1);
+      expect(scriptFindings[0].severity).toBe('error');
+    });
+  });
+
+  // --- image-refs-relative ---
+
+  describe('image-refs-relative', () => {
+    it('should not report relative image refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](img/screenshot.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ImageRefsRelative)).toBeUndefined();
+    });
+
+    it('should not report ./ prefixed image refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](./img/screenshot.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.ImageRefsRelative)).toBeUndefined();
+    });
+
+    it('should report absolute image paths', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](/images/screenshot.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ImageRefsRelative);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should include line number', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('\n\n![alt](/absolute/path.png)\n'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.ImageRefsRelative);
+      expect(finding).toBeDefined();
+      expect(finding!.line).toBeDefined();
+      expect(finding!.line).toBeGreaterThan(1);
+    });
+  });
+
+  // --- internal-links-relative ---
+
+  describe('internal-links-relative', () => {
+    it('should not report relative internal links', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[other](./other.md)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksRelative)).toBeUndefined();
+    });
+
+    it('should not report relative links without ./', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[other](other.md)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksRelative)).toBeUndefined();
+    });
+
+    it('should report absolute internal links', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[other](/docs/other.md)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.InternalLinksRelative);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report as warning in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[other](/docs/other.md)'));
+
+      const findings = await checkMarkdown(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.InternalLinksRelative);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('warning');
+    });
+
+    it('should not report external links', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[grafana](https://grafana.com)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksRelative)).toBeUndefined();
+    });
+
+    it('should not report anchor links', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[section](#my-section)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksRelative)).toBeUndefined();
+    });
+
+    it('should not report mailto links', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[email](mailto:test@example.com)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.InternalLinksRelative)).toBeUndefined();
+    });
+  });
+
+  // --- no-dangerous-urls ---
+
+  describe('no-dangerous-urls', () => {
+    it('should report javascript: URLs in links', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[click](javascript:alert(1))'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoDangerousUrls);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report data: URLs in links', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[click](data:text/html,<script>alert(1)</script>)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoDangerousUrls);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report javascript: URLs in image refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![xss](javascript:alert(1))'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoDangerousUrls);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report case-insensitive javascript: URLs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[click](JavaScript:void(0))'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoDangerousUrls);
+      expect(finding).toBeDefined();
+    });
+
+    it('should not report safe URLs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[safe](https://example.com)\n[local](./page.md)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoDangerousUrls)).toBeUndefined();
+    });
+
+    it('should not report dangerous URLs inside code blocks', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('```\n[click](javascript:alert(1))\n```'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoDangerousUrls)).toBeUndefined();
+    });
+
+    it('should report as error even in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[click](javascript:alert(1))'));
+
+      const findings = await checkMarkdown(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.NoDangerousUrls);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+  });
+
+  // --- no-path-traversal ---
+
+  describe('no-path-traversal', () => {
+    it('should report ../ in image refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](../other/img/pic.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoPathTraversal);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report ../ in links', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('[other](../parent/page.md)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoPathTraversal);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report nested path traversal', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](img/../../etc/passwd)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoPathTraversal);
+      expect(finding).toBeDefined();
+    });
+
+    it('should not report ./ prefix', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](./img/pic.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoPathTraversal)).toBeUndefined();
+    });
+
+    it('should not report path traversal inside code blocks', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('```\n![alt](../escape.png)\n```'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoPathTraversal)).toBeUndefined();
+    });
+
+    it('should report as error even in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](../escape.png)'));
+
+      const findings = await checkMarkdown(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.NoPathTraversal);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+  });
+
+  // --- no-base64-images ---
+
+  describe('no-base64-images', () => {
+    it('should report base64-encoded images', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![pixel](data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoBase64Images);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report base64-encoded JPEG images', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![photo](data:image/jpeg;base64,/9j/4AAQ)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoBase64Images);
+      expect(finding).toBeDefined();
+    });
+
+    it('should not report normal image refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](img/screenshot.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoBase64Images)).toBeUndefined();
+    });
+
+    it('should not report inside code blocks', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('```\n![pixel](data:image/png;base64,abc)\n```'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoBase64Images)).toBeUndefined();
+    });
+
+    it('should report as error even in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![pixel](data:image/png;base64,abc)'));
+
+      const findings = await checkMarkdown(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.NoBase64Images);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+  });
+
+  // --- no-external-images ---
+
+  describe('no-external-images', () => {
+    it('should report external image URLs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![logo](https://example.com/logo.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoExternalImages);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('error');
+    });
+
+    it('should report http:// image URLs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![logo](http://example.com/logo.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoExternalImages);
+      expect(finding).toBeDefined();
+    });
+
+    it('should report as warning in non-strict mode', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![logo](https://example.com/logo.png)'));
+
+      const findings = await checkMarkdown(input(tmp, false));
+
+      const finding = findings.find((f) => f.rule === Rule.NoExternalImages);
+      expect(finding).toBeDefined();
+      expect(finding!.severity).toBe('warning');
+    });
+
+    it('should not report local image refs', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('![alt](img/screenshot.png)'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoExternalImages)).toBeUndefined();
+    });
+
+    it('should not report external image URLs inside code blocks', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('```\n![logo](https://example.com/logo.png)\n```'));
+
+      const findings = await checkMarkdown(input(tmp));
+      expect(findings.find((f) => f.rule === Rule.NoExternalImages)).toBeUndefined();
+    });
+
+    it('should include line number', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('\n\n![logo](https://example.com/logo.png)\n'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const finding = findings.find((f) => f.rule === Rule.NoExternalImages);
+      expect(finding).toBeDefined();
+      expect(finding!.line).toBeDefined();
+      expect(finding!.line).toBeGreaterThan(1);
+    });
+  });
+
+  // --- cross-cutting concerns ---
+
+  describe('multiple files', () => {
+    it('should check all markdown files', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<div>bad</div>'));
+      await mkdir(join(tmp, 'sub'));
+      await writeFile(join(tmp, 'sub', 'page.md'), md('<span>also bad</span>'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const htmlFindings = findings.filter((f) => f.rule === Rule.NoRawHtml);
+      expect(htmlFindings.length).toBeGreaterThanOrEqual(2);
+      const files = htmlFindings.map((f) => f.file);
+      expect(files).toContain('index.md');
+      expect(files.some((f) => f?.includes('page.md'))).toBe(true);
+    });
+  });
+
+  describe('multiple rules on same content', () => {
+    it('should report both script tag and dangerous URL', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<script>alert(1)</script>\n[click](javascript:void(0))'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      expect(findings.find((f) => f.rule === Rule.NoScriptTags)).toBeDefined();
+      expect(findings.find((f) => f.rule === Rule.NoDangerousUrls)).toBeDefined();
+    });
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.test.ts
@@ -544,3 +544,30 @@ describe('checkMarkdown', () => {
     });
   });
 });
+
+describe('edge cases', () => {
+  it('should not skip regular links when same pattern also appears as image ref on same line', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+    // ![x](../a) is an image ref (path traversal), [x](../a) is a regular link (path traversal)
+    await writeFile(join(tmp, 'index.md'), md('![x](../a.png) [x](../a.md)'));
+
+    const findings = await checkMarkdown(input(tmp));
+
+    const traversal = findings.filter((f) => f.rule === Rule.NoPathTraversal);
+    // should have TWO path traversal diagnostics: one from image ref, one from link
+    expect(traversal).toHaveLength(2);
+  });
+
+  it('should report data:text/html URI in image ref as dangerous URL', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+    await writeFile(join(tmp, 'index.md'), md('![xss](data:text/html,<script>alert(1)</script>)'));
+
+    const findings = await checkMarkdown(input(tmp));
+
+    const finding = findings.find((f) => f.rule === Rule.NoDangerousUrls);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    // should NOT be caught by no-base64-images (that's only for data:image/...;base64,...)
+    expect(findings.find((f) => f.rule === Rule.NoBase64Images)).toBeUndefined();
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.test.ts
@@ -131,6 +131,17 @@ describe('checkMarkdown', () => {
       expect(scriptFindings.some((f) => f.title.includes('Event handler'))).toBe(true);
     });
 
+    it('should report unquoted event handler attributes', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
+      await writeFile(join(tmp, 'index.md'), md('<details ontoggle=alert(1)>x</details>'));
+
+      const findings = await checkMarkdown(input(tmp));
+
+      const scriptFindings = findings.filter((f) => f.rule === Rule.NoScriptTags);
+      expect(scriptFindings.length).toBeGreaterThanOrEqual(1);
+      expect(scriptFindings.some((f) => f.title.includes('Event handler'))).toBe(true);
+    });
+
     it('should not report script tags inside code blocks', async () => {
       const tmp = await mkdtemp(join(tmpdir(), 'md-test-'));
       await writeFile(join(tmp, 'index.md'), md('```html\n<script>safe()</script>\n```'));

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.ts
@@ -13,8 +13,8 @@ const ALLOWED_HTML_TAGS = new Set(['br', 'wbr', 'hr', 'details', 'summary']);
 // matches <script> tags (opening or self-closing)
 const SCRIPT_TAG_RE = /<script\b[^>]*>/gi;
 
-// matches HTML event handler attributes like onclick="...", onerror="..."
-const EVENT_HANDLER_RE = /\bon[a-z]+\s*=\s*["'][^"']*["']/gi;
+// matches HTML event handler attributes like onclick="...", onerror="...", ontoggle=alert(1)
+const EVENT_HANDLER_RE = /\bon[a-z]+\s*=\s*(?:["'][^"']*["']|[^\s>]+)/gi;
 
 // matches markdown image references: ![alt](url)
 const IMAGE_REF_RE = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.ts
@@ -4,7 +4,6 @@ import { join, relative } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 
 // matches HTML tags like <div>, <span class="x">, </p>, <br/>, <img src="..." />
-// excludes markdown-safe self-closing <br> and <!-- comments -->
 const HTML_TAG_RE = /< *\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*\/?>/g;
 
 // tags that are allowed in markdown (commonly used and safe)
@@ -35,19 +34,6 @@ const EXTERNAL_URL_RE = /^https?:\/\//i;
 const PATH_TRAVERSAL_RE = /(?:^|\/)\.\.\//;
 
 /**
- * Finds the 1-based line number of the first occurrence of a string in content.
- */
-function findLine(content: string, needle: string): number | undefined {
-  const lines = content.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].includes(needle)) {
-      return i + 1;
-    }
-  }
-  return undefined;
-}
-
-/**
  * Checks whether a line is inside a fenced code block.
  * Returns a set of 1-based line numbers that are inside code blocks.
  */
@@ -68,22 +54,6 @@ function getCodeBlockLines(content: string): Set<number> {
   }
 
   return codeLines;
-}
-
-/**
- * Finds the 1-based line number of a match, skipping code blocks.
- */
-function findLineOutsideCode(content: string, needle: string, codeLines: Set<number>): number | undefined {
-  const lines = content.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    if (codeLines.has(i + 1)) {
-      continue;
-    }
-    if (lines[i].includes(needle)) {
-      return i + 1;
-    }
-  }
-  return undefined;
 }
 
 /**
@@ -168,10 +138,6 @@ export async function checkMarkdown(input: ValidationInput): Promise<Diagnostic[
       if (tagName === 'script' || ALLOWED_HTML_TAGS.has(tagName)) {
         continue;
       }
-      // skip HTML comments
-      if (match[0].startsWith('<!--')) {
-        continue;
-      }
       diagnostics.push({
         rule: Rule.NoRawHtml,
         severity: input.strict ? 'error' : 'warning',
@@ -252,15 +218,13 @@ export async function checkMarkdown(input: ValidationInput): Promise<Diagnostic[
     }
 
     // process links (non-image)
+    const contentLines = content.split('\n');
     for (const { match, line } of matchOutsideCode(content, LINK_RE, codeLines)) {
       const ref = match[2];
 
-      // skip image links (already handled above) - the LINK_RE also matches ![...](...) prefix
-      // but since LINK_RE is [text](url) and IMAGE_REF_RE is ![alt](url), we need to check
-      // if this match is preceded by ! on the same line
-      const lineContent = content.split('\n')[line - 1];
-      const matchIndex = lineContent.indexOf(match[0]);
-      if (matchIndex > 0 && lineContent[matchIndex - 1] === '!') {
+      // skip image links (already handled above) - LINK_RE also matches the [alt](url) part
+      // of ![alt](url), so check if the char before this match is !
+      if (match.index > 0 && contentLines[line - 1][match.index - 1] === '!') {
         continue;
       }
 

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.ts
@@ -70,7 +70,10 @@ export async function checkMarkdown(input: ValidationInput): Promise<Diagnostic[
     return diagnostics;
   }
 
-  const mdFiles = entries.filter((e) => e.isFile() && e.name.endsWith('.md'));
+  const mdFiles = entries.filter(
+    (e) =>
+      e.isFile() && e.name.endsWith('.md') && !e.parentPath.includes('node_modules') && !e.parentPath.includes('dist')
+  );
 
   for (const md of mdFiles) {
     const absPath = join(md.parentPath, md.name);

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.ts
@@ -2,6 +2,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, relative } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+import { getCodeBlockLines } from './utils.js';
 
 // matches HTML tags like <div>, <span class="x">, </p>, <br/>, <img src="..." />
 const HTML_TAG_RE = /< *\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*\/?>/g;
@@ -32,29 +33,6 @@ const EXTERNAL_URL_RE = /^https?:\/\//i;
 
 // matches path traversal
 const PATH_TRAVERSAL_RE = /(?:^|\/)\.\.\//;
-
-/**
- * Checks whether a line is inside a fenced code block.
- * Returns a set of 1-based line numbers that are inside code blocks.
- */
-function getCodeBlockLines(content: string): Set<number> {
-  const lines = content.split('\n');
-  const codeLines = new Set<number>();
-  let inCodeBlock = false;
-
-  for (let i = 0; i < lines.length; i++) {
-    if (/^```/.test(lines[i].trim())) {
-      inCodeBlock = !inCodeBlock;
-      codeLines.add(i + 1);
-      continue;
-    }
-    if (inCodeBlock) {
-      codeLines.add(i + 1);
-    }
-  }
-
-  return codeLines;
-}
 
 /**
  * Tests a regex against content lines, skipping code blocks.

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.ts
@@ -1,0 +1,323 @@
+import { readFile, readdir } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { join, relative } from 'node:path';
+import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+
+// matches HTML tags like <div>, <span class="x">, </p>, <br/>, <img src="..." />
+// excludes markdown-safe self-closing <br> and <!-- comments -->
+const HTML_TAG_RE = /< *\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*\/?>/g;
+
+// tags that are allowed in markdown (commonly used and safe)
+const ALLOWED_HTML_TAGS = new Set(['br', 'wbr', 'hr', 'details', 'summary']);
+
+// matches <script> tags (opening or self-closing)
+const SCRIPT_TAG_RE = /<script\b[^>]*>/gi;
+
+// matches HTML event handler attributes like onclick="...", onerror="..."
+const EVENT_HANDLER_RE = /\bon[a-z]+\s*=\s*["'][^"']*["']/gi;
+
+// matches markdown image references: ![alt](url)
+const IMAGE_REF_RE = /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+// matches markdown links: [text](url)
+const LINK_RE = /\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+// matches dangerous URI schemes
+const DANGEROUS_URL_RE = /^(javascript|vbscript|data):/i;
+
+// matches base64 image data in image refs
+const BASE64_IMAGE_RE = /^data:image\/[^;]+;base64,/i;
+
+// matches external URLs (http:// or https://)
+const EXTERNAL_URL_RE = /^https?:\/\//i;
+
+// matches path traversal
+const PATH_TRAVERSAL_RE = /(?:^|\/)\.\.\//;
+
+/**
+ * Finds the 1-based line number of the first occurrence of a string in content.
+ */
+function findLine(content: string, needle: string): number | undefined {
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].includes(needle)) {
+      return i + 1;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Checks whether a line is inside a fenced code block.
+ * Returns a set of 1-based line numbers that are inside code blocks.
+ */
+function getCodeBlockLines(content: string): Set<number> {
+  const lines = content.split('\n');
+  const codeLines = new Set<number>();
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```/.test(lines[i].trim())) {
+      inCodeBlock = !inCodeBlock;
+      codeLines.add(i + 1);
+      continue;
+    }
+    if (inCodeBlock) {
+      codeLines.add(i + 1);
+    }
+  }
+
+  return codeLines;
+}
+
+/**
+ * Finds the 1-based line number of a match, skipping code blocks.
+ */
+function findLineOutsideCode(content: string, needle: string, codeLines: Set<number>): number | undefined {
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (codeLines.has(i + 1)) {
+      continue;
+    }
+    if (lines[i].includes(needle)) {
+      return i + 1;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Tests a regex against content lines, skipping code blocks.
+ * Returns all matches with their line numbers.
+ */
+function matchOutsideCode(
+  content: string,
+  re: RegExp,
+  codeLines: Set<number>
+): Array<{ match: RegExpExecArray; line: number }> {
+  const results: Array<{ match: RegExpExecArray; line: number }> = [];
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    if (codeLines.has(i + 1)) {
+      continue;
+    }
+    const lineRe = new RegExp(re.source, re.flags);
+    let m: RegExpExecArray | null;
+    while ((m = lineRe.exec(lines[i])) !== null) {
+      results.push({ match: m, line: i + 1 });
+    }
+  }
+
+  return results;
+}
+
+export async function checkMarkdown(input: ValidationInput): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = [];
+
+  let entries: Dirent[] = [];
+  try {
+    entries = await readdir(input.docsPath, { recursive: true, withFileTypes: true });
+  } catch {
+    return diagnostics;
+  }
+
+  const mdFiles = entries.filter((e) => e.isFile() && e.name.endsWith('.md'));
+
+  for (const md of mdFiles) {
+    const absPath = join(md.parentPath, md.name);
+    const relPath = relative(input.docsPath, absPath);
+
+    let content: string;
+    try {
+      content = await readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const codeLines = getCodeBlockLines(content);
+
+    // no-script-tags: no <script> tags
+    for (const { match, line } of matchOutsideCode(content, SCRIPT_TAG_RE, codeLines)) {
+      diagnostics.push({
+        rule: Rule.NoScriptTags,
+        severity: 'error',
+        file: relPath,
+        line,
+        title: 'Script tag detected',
+        detail: `"${match[0]}" is not allowed. Script tags pose a security risk.`,
+      });
+    }
+
+    // no-script-tags: no event handler attributes (onclick, onerror, etc.)
+    for (const { match, line } of matchOutsideCode(content, EVENT_HANDLER_RE, codeLines)) {
+      diagnostics.push({
+        rule: Rule.NoScriptTags,
+        severity: 'error',
+        file: relPath,
+        line,
+        title: 'Event handler attribute detected',
+        detail: `"${match[0]}" is not allowed. Inline event handlers pose a security risk.`,
+      });
+    }
+
+    // no-raw-html: no raw HTML tags (except allowed ones)
+    for (const { match, line } of matchOutsideCode(content, HTML_TAG_RE, codeLines)) {
+      const tagName = match[1].toLowerCase();
+      // skip if it's a script tag (already handled above) or allowed tag
+      if (tagName === 'script' || ALLOWED_HTML_TAGS.has(tagName)) {
+        continue;
+      }
+      // skip HTML comments
+      if (match[0].startsWith('<!--')) {
+        continue;
+      }
+      diagnostics.push({
+        rule: Rule.NoRawHtml,
+        severity: input.strict ? 'error' : 'warning',
+        file: relPath,
+        line,
+        title: 'Raw HTML tag detected',
+        detail: `<${tagName}> is not allowed. Use markdown syntax instead of raw HTML.`,
+      });
+    }
+
+    // process image references
+    for (const { match, line } of matchOutsideCode(content, IMAGE_REF_RE, codeLines)) {
+      const ref = match[2];
+
+      // no-base64-images: no base64-encoded image data
+      if (BASE64_IMAGE_RE.test(ref)) {
+        diagnostics.push({
+          rule: Rule.NoBase64Images,
+          severity: 'error',
+          file: relPath,
+          line,
+          title: 'Base64-encoded image detected',
+          detail: `Base64-encoded images are not allowed. Save the image as a file in the img/ directory instead.`,
+        });
+        continue;
+      }
+
+      // no-external-images: no external image URLs
+      if (EXTERNAL_URL_RE.test(ref)) {
+        diagnostics.push({
+          rule: Rule.NoExternalImages,
+          severity: input.strict ? 'error' : 'warning',
+          file: relPath,
+          line,
+          title: 'External image URL detected',
+          detail: `"${ref}" is an external URL. Download the image and place it in the img/ directory.`,
+        });
+        continue;
+      }
+
+      // no-dangerous-urls: no javascript: or data: URIs in image refs
+      if (DANGEROUS_URL_RE.test(ref)) {
+        diagnostics.push({
+          rule: Rule.NoDangerousUrls,
+          severity: 'error',
+          file: relPath,
+          line,
+          title: 'Dangerous URI scheme in image reference',
+          detail: `"${ref}" uses a dangerous URI scheme. Only relative file paths are allowed.`,
+        });
+        continue;
+      }
+
+      // no-path-traversal: no ../ in image refs
+      if (PATH_TRAVERSAL_RE.test(ref)) {
+        diagnostics.push({
+          rule: Rule.NoPathTraversal,
+          severity: 'error',
+          file: relPath,
+          line,
+          title: 'Path traversal in image reference',
+          detail: `"${ref}" contains path traversal. Image references must not use "../".`,
+        });
+        continue;
+      }
+
+      // image-refs-relative: image refs must be relative paths (not absolute)
+      if (ref.startsWith('/')) {
+        diagnostics.push({
+          rule: Rule.ImageRefsRelative,
+          severity: 'error',
+          file: relPath,
+          line,
+          title: 'Image reference is not a relative path',
+          detail: `"${ref}" is an absolute path. Use a relative path like "img/filename.png" instead.`,
+        });
+      }
+    }
+
+    // process links (non-image)
+    for (const { match, line } of matchOutsideCode(content, LINK_RE, codeLines)) {
+      const ref = match[2];
+
+      // skip image links (already handled above) - the LINK_RE also matches ![...](...) prefix
+      // but since LINK_RE is [text](url) and IMAGE_REF_RE is ![alt](url), we need to check
+      // if this match is preceded by ! on the same line
+      const lineContent = content.split('\n')[line - 1];
+      const matchIndex = lineContent.indexOf(match[0]);
+      if (matchIndex > 0 && lineContent[matchIndex - 1] === '!') {
+        continue;
+      }
+
+      // skip anchor-only links like #section
+      if (ref.startsWith('#')) {
+        continue;
+      }
+
+      // no-dangerous-urls: no javascript: or data: URIs
+      if (DANGEROUS_URL_RE.test(ref)) {
+        diagnostics.push({
+          rule: Rule.NoDangerousUrls,
+          severity: 'error',
+          file: relPath,
+          line,
+          title: 'Dangerous URI scheme in link',
+          detail: `"${ref}" uses a dangerous URI scheme. Use safe URLs only.`,
+        });
+        continue;
+      }
+
+      // no-path-traversal: no ../ in links
+      if (PATH_TRAVERSAL_RE.test(ref)) {
+        diagnostics.push({
+          rule: Rule.NoPathTraversal,
+          severity: 'error',
+          file: relPath,
+          line,
+          title: 'Path traversal in link',
+          detail: `"${ref}" contains path traversal. Links must not use "../".`,
+        });
+        continue;
+      }
+
+      // skip external URLs for internal-links-relative check
+      if (EXTERNAL_URL_RE.test(ref)) {
+        continue;
+      }
+
+      // skip mailto: and other non-file schemes
+      if (/^[a-z]+:/i.test(ref)) {
+        continue;
+      }
+
+      // internal-links-relative: internal links must be relative .md paths
+      if (ref.startsWith('/')) {
+        diagnostics.push({
+          rule: Rule.InternalLinksRelative,
+          severity: input.strict ? 'error' : 'warning',
+          file: relPath,
+          line,
+          title: 'Internal link is not a relative path',
+          detail: `"${ref}" is an absolute path. Use a relative path like "./page.md" instead.`,
+        });
+      }
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/plugin-docs-cli/src/validation/rules/utils.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.ts
@@ -1,0 +1,21 @@
+/**
+ * Returns a set of 1-based line numbers inside fenced code blocks.
+ */
+export function getCodeBlockLines(content: string): Set<number> {
+  const lines = content.split('\n');
+  const codeLines = new Set<number>();
+  let inCodeBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (/^```/.test(lines[i].trim())) {
+      inCodeBlock = !inCodeBlock;
+      codeLines.add(i + 1);
+      continue;
+    }
+    if (inCodeBlock) {
+      codeLines.add(i + 1);
+    }
+  }
+
+  return codeLines;
+}

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -36,6 +36,12 @@ export const Rule = {
   NoPathTraversal: 'no-path-traversal',
   NoBase64Images: 'no-base64-images',
   NoExternalImages: 'no-external-images',
+  // cross-file rules
+  InternalLinksResolve: 'internal-links-resolve',
+  AnchorLinksResolve: 'anchor-links-resolve',
+  // manifest rules
+  ManifestValid: 'manifest-valid',
+  ManifestRefsExist: 'manifest-refs-exist',
 } as const;
 
 export type Rule = (typeof Rule)[keyof typeof Rule];

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -27,6 +27,15 @@ export const Rule = {
   ImageFileNaming: 'image-file-naming',
   NoOrphanedImages: 'no-orphaned-images',
   MaxDataUriSize: 'max-data-uri-size',
+  // markdown + security rules
+  NoRawHtml: 'no-raw-html',
+  ImageRefsRelative: 'image-refs-relative',
+  InternalLinksRelative: 'internal-links-relative',
+  NoDangerousUrls: 'no-dangerous-urls',
+  NoScriptTags: 'no-script-tags',
+  NoPathTraversal: 'no-path-traversal',
+  NoBase64Images: 'no-base64-images',
+  NoExternalImages: 'no-external-images',
 } as const;
 
 export type Rule = (typeof Rule)[keyof typeof Rule];


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds two new categories of validation rules to the plugin documentation CLI and integrates validation into the `serve` command.

**Markdown + security rules** prevent raw HTML, script tags, dangerous URI schemes (`javascript:`, `data:`), path traversal (`../`), base64 images and external image URLs in documentation files. These catch common security issues and enforce that all content uses safe markdown syntax and relative references.

**Cross-file and manifest rules** verify that internal links like `[text](page.md)` resolve to existing files, that `#section` anchors map to real headings and that the generated manifest has a valid structure with all file paths pointing to real files on disk.

The `serve` command now runs validation in non-strict mode on startup and after every file change, surfacing warnings in the terminal without blocking the dev server. This gives authors immediate feedback as they write documentation.

**To test with real plugin docs**, clone either of these branches and run `npx plugin-docs-cli serve` / `validate`:
- https://github.com/sunker/docstest-datasource/pull/8
- https://github.com/sunker/docstest-datasource/pull/5


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/issues/assigned?issue=grafana%7Cgrafana-catalog-team%7C769

**Special notes for your reviewer**:
