### PR TITLE
Plugin E2E: Bump e2e-version action to v1.2.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@698612a13f3253e7dcd5b3c66823acc73321a5ed # e2e-version/v1.1.2
+        uses: grafana/plugin-actions/e2e-version@c246b748568a80db2a20ab5c65ff01b8b4f342c4 # e2e-version/v1.2.0
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'


### PR DESCRIPTION
**What this PR does / why we need it**

Bumps the `grafana/plugin-actions/e2e-version` action from v1.1.2 to v1.2.0 in the Playwright CI workflow. This version includes the React 19 dev preview image by default, so E2E tests will run against it without additional configuration.
