### PR TITLE
fix: prevent write errors in codemods for new updated files

### DIFF
--- a/packages/create-plugin/src/codemods/context.test.ts
+++ b/packages/create-plugin/src/codemods/context.test.ts
@@ -62,16 +62,22 @@ describe('Context', () => {
 
   describe('updateFile', () => {
     it('should update a file in the context', () => {
-      const context = new Context();
-      context.addFile('file.txt', 'content');
-      context.updateFile('file.txt', 'new content');
-      expect(context.listChanges()).toEqual({ 'file.txt': { content: 'new content', changeType: 'update' } });
+      const context = new Context(`${__dirname}/migrations/fixtures`);
+      context.updateFile('foo/bar.ts', 'new content');
+      expect(context.listChanges()).toEqual({ 'foo/bar.ts': { content: 'new content', changeType: 'update' } });
     });
 
     it('should not update a file if it does not exist', () => {
       const context = new Context();
 
       expect(() => context.updateFile('file.txt', 'new content')).toThrowError('File file.txt does not exist');
+    });
+
+    it('should not replace an update with an add if the file was added in the current context', () => {
+      const context = new Context();
+      context.addFile('file.txt', 'content');
+      context.updateFile('file.txt', 'new content');
+      expect(context.listChanges()).toEqual({ 'file.txt': { content: 'new content', changeType: 'add' } });
     });
   });
 

--- a/packages/create-plugin/src/codemods/context.test.ts
+++ b/packages/create-plugin/src/codemods/context.test.ts
@@ -73,7 +73,7 @@ describe('Context', () => {
       expect(() => context.updateFile('file.txt', 'new content')).toThrowError('File file.txt does not exist');
     });
 
-    it('should not replace an update with an add if the file was added in the current context', () => {
+    it("should preserve the 'add' changeType when updating a file that was added in the current context", () => {
       const context = new Context();
       context.addFile('file.txt', 'content');
       context.updateFile('file.txt', 'new content');

--- a/packages/create-plugin/src/codemods/context.ts
+++ b/packages/create-plugin/src/codemods/context.ts
@@ -58,7 +58,9 @@ export class Context {
     }
 
     if (originalContent !== content) {
-      this.files[path] = { content, changeType: 'update' };
+      // new files should be written as 'add' to ensure their directories are created.
+      const isNewFile = this.files[path]?.changeType === 'add';
+      this.files[path] = { content, changeType: isNewFile ? 'add' : 'update' };
     } else {
       codemodsDebug(`Context.updateFile() - no updates for ${filePath}`);
     }

--- a/packages/create-plugin/src/codemods/context.ts
+++ b/packages/create-plugin/src/codemods/context.ts
@@ -33,7 +33,7 @@ export class Context {
     const path = this.normalisePath(filePath);
 
     // Delete a file that was added to the current context
-    if (this.files[path] && this.files[path].changeType === 'add') {
+    if (this.files[path]?.changeType === 'add') {
       delete this.files[path];
       return;
     }
@@ -42,7 +42,7 @@ export class Context {
       this.files[path] = { ...this.files[path], changeType: 'delete' };
     }
     // Delete a file that was updated in the current context
-    else if (this.files[path] && this.files[path].changeType === 'update') {
+    else if (this.files[path]?.changeType === 'update') {
       throw new Error(`File ${path} was marked as updated already`);
     } else {
       throw new Error(`File ${path} does not exist`);
@@ -92,7 +92,7 @@ export class Context {
     const path = this.normalisePath(filePath);
 
     // Deleted in this context
-    if (this.files[path] && this.files[path].changeType === 'delete') {
+    if (this.files[path]?.changeType === 'delete') {
       return undefined;
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

If a codemod adds a file then later updates the same file the changeType is changed from `add` to `update`. This can cause codemods to fail when writing to disk due to `flushChanges` expecting the containing directory to exist for `update` files as they _should_ already exist on disk.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.5.2-canary.2525.22911401478.0
  npm install @grafana/create-plugin@7.0.7-canary.2525.22911401478.0
  npm install @grafana/eslint-plugin-plugins@0.6.4-canary.2525.22911401478.0
  npm install @grafana/plugin-docs-cli@0.0.8-canary.2525.22911401478.0
  # or 
  yarn add website@5.5.2-canary.2525.22911401478.0
  yarn add @grafana/create-plugin@7.0.7-canary.2525.22911401478.0
  yarn add @grafana/eslint-plugin-plugins@0.6.4-canary.2525.22911401478.0
  yarn add @grafana/plugin-docs-cli@0.0.8-canary.2525.22911401478.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
