### PR TITLE
Plugin E2E: Fix toHaveColor matcher for ColorValueEditor

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,7 @@ jobs:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
           skip-grafana-dev-image: false
-          # limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
+          limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
 
   playwright-tests:
     needs: resolve-versions
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,7 @@ jobs:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
           skip-grafana-dev-image: false
-          limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
+          # limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
 
   playwright-tests:
     needs: resolve-versions
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -198,7 +198,15 @@ declare global {
       toHaveChecked(radioGroup: RadioGroup, expected: string, options?: { timeout?: number }): Promise<R>;
 
       /**
-       * Asserts that a color picker has expected color selected
+       * Asserts that a color picker displays the expected color value.
+       *
+       * Grafana normalizes all color values to lowercase hex (e.g. `#ff5733`),
+       * so always pass lowercase hex as the expected value.
+       *
+       * @example
+       * ```ts
+       * await expect(panel.fieldByLabel('Line color').colorPicker()).toHaveColor('#ff5733');
+       * ```
        */
       toHaveColor(colorPicker: ColorPicker, rgbOrHex: string, options?: { timeout?: number }): Promise<R>;
 

--- a/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi } from 'vitest';
 const mockToHaveValue = vi.fn();
 const mockToContainText = vi.fn();
 vi.mock('@playwright/test', () => ({
-  expect: (locator: unknown) => ({
+  expect: () => ({
     toHaveValue: mockToHaveValue,
     toContainText: mockToContainText,
   }),

--- a/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
@@ -104,9 +104,8 @@ describe('toHaveColor', () => {
 
     await toHaveColor(colorPicker, '#ff0000');
 
-    // verify it uses the "button + *" selector to scope to the color value,
-    // not toContainText on the whole field editor which would match label text.
-    // uses wildcard because the element is a <div>, not a <span>
-    expect(mockLocator.locator).toHaveBeenCalledWith('button + *');
+    // verify it targets the span sibling of the button's wrapper div,
+    // not the whole field editor which would match label text
+    expect(mockLocator.locator).toHaveBeenCalledWith('div:has(button) + span');
   });
 });

--- a/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 
 // mock @playwright/test's expect so we can control assertion outcomes
 const mockToHaveValue = vi.fn();
-const mockToContainText = vi.fn();
+const mockToHaveText = vi.fn();
 vi.mock('@playwright/test', () => ({
   expect: () => ({
     toHaveValue: mockToHaveValue,
-    toContainText: mockToContainText,
+    toHaveText: mockToHaveText,
   }),
 }));
 
@@ -18,8 +18,12 @@ function createMockColorPicker(hasTextbox: boolean): ColorPicker {
     count: vi.fn().mockResolvedValue(hasTextbox ? 1 : 0),
   };
 
+  const mockColorValueSpan = {};
+
   const mockLocator = {
     getByRole: vi.fn().mockReturnValue(mockTextbox),
+    // button + span selector targets the color value span next to the swatch button
+    locator: vi.fn().mockReturnValue(mockColorValueSpan),
   };
 
   return {
@@ -30,7 +34,7 @@ function createMockColorPicker(hasTextbox: boolean): ColorPicker {
 describe('toHaveColor', () => {
   beforeEach(() => {
     mockToHaveValue.mockReset();
-    mockToContainText.mockReset();
+    mockToHaveText.mockReset();
   });
 
   it('should use toHaveValue when a textbox is present (ColorPickerInput)', async () => {
@@ -41,17 +45,17 @@ describe('toHaveColor', () => {
 
     expect(result.pass).toBe(true);
     expect(mockToHaveValue).toHaveBeenCalledWith('#ff0000', undefined);
-    expect(mockToContainText).not.toHaveBeenCalled();
+    expect(mockToHaveText).not.toHaveBeenCalled();
   });
 
-  it('should use toContainText when no textbox is present (ColorValueEditor)', async () => {
+  it('should use toHaveText on the color value span when no textbox is present (ColorValueEditor)', async () => {
     const colorPicker = createMockColorPicker(false);
-    mockToContainText.mockResolvedValue(undefined);
+    mockToHaveText.mockResolvedValue(undefined);
 
     const result = await toHaveColor(colorPicker, '#ff0000');
 
     expect(result.pass).toBe(true);
-    expect(mockToContainText).toHaveBeenCalledWith('#ff0000', undefined);
+    expect(mockToHaveText).toHaveBeenCalledWith('#ff0000', undefined);
     expect(mockToHaveValue).not.toHaveBeenCalled();
   });
 
@@ -64,13 +68,13 @@ describe('toHaveColor', () => {
     expect(mockToHaveValue).toHaveBeenCalledWith('rgb(255, 0, 0)', { timeout: 5000 });
   });
 
-  it('should pass timeout options through to toContainText', async () => {
+  it('should pass timeout options through to toHaveText', async () => {
     const colorPicker = createMockColorPicker(false);
-    mockToContainText.mockResolvedValue(undefined);
+    mockToHaveText.mockResolvedValue(undefined);
 
     await toHaveColor(colorPicker, 'rgb(255, 0, 0)', { timeout: 5000 });
 
-    expect(mockToContainText).toHaveBeenCalledWith('rgb(255, 0, 0)', { timeout: 5000 });
+    expect(mockToHaveText).toHaveBeenCalledWith('rgb(255, 0, 0)', { timeout: 5000 });
   });
 
   it('should return pass: false when textbox assertion fails', async () => {
@@ -85,11 +89,23 @@ describe('toHaveColor', () => {
 
   it('should return pass: false when text content assertion fails', async () => {
     const colorPicker = createMockColorPicker(false);
-    mockToContainText.mockRejectedValue(new Error('Expected text "#ff0000" not found'));
+    mockToHaveText.mockRejectedValue(new Error('Expected text "#ff0000" not found'));
 
     const result = await toHaveColor(colorPicker, '#ff0000');
 
     expect(result.pass).toBe(false);
     expect(result.message()).toContain('#ff0000');
+  });
+
+  it('should target the span after the swatch button to avoid matching label text', async () => {
+    const colorPicker = createMockColorPicker(false);
+    mockToHaveText.mockResolvedValue(undefined);
+    const mockLocator = colorPicker.locator();
+
+    await toHaveColor(colorPicker, '#ff0000');
+
+    // verify it uses the "button + span" selector to scope to the color value,
+    // not toContainText on the whole field editor which would match label text
+    expect(mockLocator.locator).toHaveBeenCalledWith('button + span');
   });
 });

--- a/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
@@ -104,8 +104,9 @@ describe('toHaveColor', () => {
 
     await toHaveColor(colorPicker, '#ff0000');
 
-    // verify it uses the "button + span" selector to scope to the color value,
-    // not toContainText on the whole field editor which would match label text
-    expect(mockLocator.locator).toHaveBeenCalledWith('button + span');
+    // verify it uses the "button + *" selector to scope to the color value,
+    // not toContainText on the whole field editor which would match label text.
+    // uses wildcard because the element is a <div>, not a <span>
+    expect(mockLocator.locator).toHaveBeenCalledWith('button + *');
   });
 });

--- a/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// mock @playwright/test's expect so we can control assertion outcomes
+const mockToHaveValue = vi.fn();
+const mockToContainText = vi.fn();
+vi.mock('@playwright/test', () => ({
+  expect: (locator: unknown) => ({
+    toHaveValue: mockToHaveValue,
+    toContainText: mockToContainText,
+  }),
+}));
+
+import { toHaveColor } from './toHaveColor';
+import { ColorPicker } from '../models/components/ColorPicker';
+
+function createMockColorPicker(hasTextbox: boolean): ColorPicker {
+  const mockTextbox = {
+    count: vi.fn().mockResolvedValue(hasTextbox ? 1 : 0),
+  };
+
+  const mockLocator = {
+    getByRole: vi.fn().mockReturnValue(mockTextbox),
+  };
+
+  return {
+    locator: () => mockLocator,
+  } as unknown as ColorPicker;
+}
+
+describe('toHaveColor', () => {
+  beforeEach(() => {
+    mockToHaveValue.mockReset();
+    mockToContainText.mockReset();
+  });
+
+  it('should use toHaveValue when a textbox is present (ColorPickerInput)', async () => {
+    const colorPicker = createMockColorPicker(true);
+    mockToHaveValue.mockResolvedValue(undefined);
+
+    const result = await toHaveColor(colorPicker, '#ff0000');
+
+    expect(result.pass).toBe(true);
+    expect(mockToHaveValue).toHaveBeenCalledWith('#ff0000', undefined);
+    expect(mockToContainText).not.toHaveBeenCalled();
+  });
+
+  it('should use toContainText when no textbox is present (ColorValueEditor)', async () => {
+    const colorPicker = createMockColorPicker(false);
+    mockToContainText.mockResolvedValue(undefined);
+
+    const result = await toHaveColor(colorPicker, '#ff0000');
+
+    expect(result.pass).toBe(true);
+    expect(mockToContainText).toHaveBeenCalledWith('#ff0000', undefined);
+    expect(mockToHaveValue).not.toHaveBeenCalled();
+  });
+
+  it('should pass timeout options through to toHaveValue', async () => {
+    const colorPicker = createMockColorPicker(true);
+    mockToHaveValue.mockResolvedValue(undefined);
+
+    await toHaveColor(colorPicker, 'rgb(255, 0, 0)', { timeout: 5000 });
+
+    expect(mockToHaveValue).toHaveBeenCalledWith('rgb(255, 0, 0)', { timeout: 5000 });
+  });
+
+  it('should pass timeout options through to toContainText', async () => {
+    const colorPicker = createMockColorPicker(false);
+    mockToContainText.mockResolvedValue(undefined);
+
+    await toHaveColor(colorPicker, 'rgb(255, 0, 0)', { timeout: 5000 });
+
+    expect(mockToContainText).toHaveBeenCalledWith('rgb(255, 0, 0)', { timeout: 5000 });
+  });
+
+  it('should return pass: false when textbox assertion fails', async () => {
+    const colorPicker = createMockColorPicker(true);
+    mockToHaveValue.mockRejectedValue(new Error('Expected "#ff0000" but got "#00ff00"'));
+
+    const result = await toHaveColor(colorPicker, '#ff0000');
+
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain('#ff0000');
+  });
+
+  it('should return pass: false when text content assertion fails', async () => {
+    const colorPicker = createMockColorPicker(false);
+    mockToContainText.mockRejectedValue(new Error('Expected text "#ff0000" not found'));
+
+    const result = await toHaveColor(colorPicker, '#ff0000');
+
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain('#ff0000');
+  });
+});

--- a/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 
 // mock @playwright/test's expect so we can control assertion outcomes
-const mockToHaveValue = vi.fn();
-const mockToHaveText = vi.fn();
+const { mockToHaveValue, mockToHaveText } = vi.hoisted(() => {
+  return {
+    mockToHaveValue: vi.fn(),
+    mockToHaveText: vi.fn(),
+  };
+});
 vi.mock('@playwright/test', () => ({
   expect: () => ({
     toHaveValue: mockToHaveValue,

--- a/packages/plugin-e2e/src/matchers/toHaveColor.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.ts
@@ -17,10 +17,10 @@ export async function toHaveColor(
     if (hasTextbox) {
       await expect(textbox).toHaveValue(rgbOrHex, options);
     } else {
-      // target the element adjacent to the swatch button to avoid matching
-      // against field label or description text in the parent container.
-      // uses wildcard (*) because the element is a <div>, not a <span>
-      const colorValue = colorPicker.locator().locator('button + *');
+      // ColorValueEditor wraps the button in a div, with the color value
+      // in a sibling span: div.colorPicker > button + /div > span.colorText
+      // use structural selector to avoid depending on Emotion class names
+      const colorValue = colorPicker.locator().locator('div:has(button) + span');
       await expect(colorValue).toHaveText(rgbOrHex, options);
     }
 

--- a/packages/plugin-e2e/src/matchers/toHaveColor.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.ts
@@ -17,7 +17,10 @@ export async function toHaveColor(
     if (hasTextbox) {
       await expect(textbox).toHaveValue(rgbOrHex, options);
     } else {
-      await expect(colorPicker.locator()).toContainText(rgbOrHex, options);
+      // target the span adjacent to the swatch button to avoid matching
+      // against field label or description text in the parent container
+      const colorValue = colorPicker.locator().locator('button + span');
+      await expect(colorValue).toHaveText(rgbOrHex, options);
     }
 
     return {

--- a/packages/plugin-e2e/src/matchers/toHaveColor.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.ts
@@ -10,16 +10,17 @@ export async function toHaveColor(
 ): Promise<MatcherReturnType> {
   try {
     // ColorPickerInput renders an inline textbox, while ColorValueEditor
-    // renders a swatch button + a span with the color value (no textbox).
+    // renders a swatch button + a div with the color value (no textbox).
     const textbox = colorPicker.locator().getByRole('textbox');
     const hasTextbox = (await textbox.count()) > 0;
 
     if (hasTextbox) {
       await expect(textbox).toHaveValue(rgbOrHex, options);
     } else {
-      // target the span adjacent to the swatch button to avoid matching
-      // against field label or description text in the parent container
-      const colorValue = colorPicker.locator().locator('button + span');
+      // target the element adjacent to the swatch button to avoid matching
+      // against field label or description text in the parent container.
+      // uses wildcard (*) because the element is a <div>, not a <span>
+      const colorValue = colorPicker.locator().locator('button + *');
       await expect(colorValue).toHaveText(rgbOrHex, options);
     }
 

--- a/packages/plugin-e2e/src/matchers/toHaveColor.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.ts
@@ -9,7 +9,16 @@ export async function toHaveColor(
   options?: { timeout?: number }
 ): Promise<MatcherReturnType> {
   try {
-    await expect(colorPicker.locator().getByRole('textbox')).toHaveValue(rgbOrHex, options);
+    // ColorPickerInput renders an inline textbox, while ColorValueEditor
+    // renders a swatch button + a span with the color value (no textbox).
+    const textbox = colorPicker.locator().getByRole('textbox');
+    const hasTextbox = (await textbox.count()) > 0;
+
+    if (hasTextbox) {
+      await expect(textbox).toHaveValue(rgbOrHex, options);
+    } else {
+      await expect(colorPicker.locator()).toContainText(rgbOrHex, options);
+    }
 
     return {
       pass: true,

--- a/packages/plugin-e2e/src/matchers/toHaveColor.ts
+++ b/packages/plugin-e2e/src/matchers/toHaveColor.ts
@@ -18,7 +18,7 @@ export async function toHaveColor(
       await expect(textbox).toHaveValue(rgbOrHex, options);
     } else {
       // ColorValueEditor wraps the button in a div, with the color value
-      // in a sibling span: div.colorPicker > button + /div > span.colorText
+      // in an adjacent sibling span: div:has(button) + span.colorText
       // use structural selector to avoid depending on Emotion class names
       const colorValue = colorPicker.locator().locator('div:has(button) + span');
       await expect(colorValue).toHaveText(rgbOrHex, options);


### PR DESCRIPTION
**What this PR does / why we need it**:

The `toHaveColor` matcher assumed the color picker always renders an inline textbox (`ColorPickerInput`), but `ColorValueEditor` renders a swatch button with a span containing the color value instead. This caused the matcher to fail when used against panels that use `ColorValueEditor`.

The fix checks whether a textbox is present and falls back to matching the color value as text content when it isn't.

Found while adding plugin-e2e API tests in Grafana: https://github.com/grafana/grafana/pull/119822

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-docs-cli@0.0.9-canary.2527.23050393538.0
  npm install @grafana/plugin-e2e@3.4.7-canary.2527.23050393538.0
  # or 
  yarn add @grafana/plugin-docs-cli@0.0.9-canary.2527.23050393538.0
  yarn add @grafana/plugin-e2e@3.4.7-canary.2527.23050393538.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
