### PR TITLE
Remove bogus net/http.ResponseWriter.WriteHeader calls from examples

### DIFF
--- a/docusaurus/docs/how-to-guides/app-plugins/add-authentication-for-app-plugins.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/add-authentication-for-app-plugins.md
@@ -231,7 +231,6 @@ func (a *App) handleMyRequest(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
 }
 ```
 
@@ -255,7 +254,6 @@ func (a *App) handleMyRequest(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
 }
 ```
 

--- a/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
+++ b/docusaurus/docs/how-to-guides/app-plugins/add-backend-component.md
@@ -109,7 +109,6 @@ func (a *App) handleMyCustomEndpoint(w http.ResponseWriter, r *http.Request) {
   // handle the request
   // e.g. call a third-party API
   w.Write([]byte("my custom response"))
-  w.WriteHeader(http.StatusOK)
 }
 ```
 

--- a/docusaurus/docs/how-to-guides/data-source-plugins/convert-a-frontend-datasource-to-backend.md
+++ b/docusaurus/docs/how-to-guides/data-source-plugins/convert-a-frontend-datasource-to-backend.md
@@ -391,7 +391,6 @@ func handleTables(w http.ResponseWriter, r *http.Request) {
   // Handle errors (omited)
 
 	w.Write(body)
-	w.WriteHeader(http.StatusOK)
 }
 ```
 

--- a/docusaurus/docs/shared/implement-resource-handler.md
+++ b/docusaurus/docs/shared/implement-resource-handler.md
@@ -52,7 +52,6 @@ func (p *MyPlugin) handleNamespaces(rw http.ResponseWriter, req *http.Request) {
   if err != nil {
     return
   }
-  rw.WriteHeader(http.StatusOK)
 }
 
 func (p *MyPlugin) handleProjects(rw http.ResponseWriter, req *http.Request) {
@@ -61,7 +60,6 @@ func (p *MyPlugin) handleProjects(rw http.ResponseWriter, req *http.Request) {
   if err != nil {
     return
   }
-  rw.WriteHeader(http.StatusOK)
 }
 ```
 
@@ -82,7 +80,6 @@ func (p *MyPlugin) handleSomeRoute(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		return
 	}
-	rw.WriteHeader(http.StatusOK)
 }
 ```
 

--- a/packages/create-plugin/templates/backend-app/pkg/plugin/resources.go
+++ b/packages/create-plugin/templates/backend-app/pkg/plugin/resources.go
@@ -12,7 +12,6 @@ func (a *App) handlePing(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
 }
 
 // handleEcho is an example HTTP POST resource that accepts a JSON with a "message" key and
@@ -34,7 +33,6 @@ func (a *App) handleEcho(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
 }
 
 // registerRoutes takes a *http.ServeMux and registers some HTTP handlers.


### PR DESCRIPTION
As per [Go's documentation](https://pkg.go.dev/net/http#ResponseWriter), the first call to `net/http.ResponseWriter.Write` will trigger an implicit `WriteHeader(http.StatusOK)`, if `WriteHeader` has not already been called explicitly. The HTTP status code and headers must be written prior to content being sent and cannot be changed afterwards.
