### PR TITLE
Plugin Docs: Publish packages to NPM

### DIFF
--- a/packages/plugin-docs-cli/package.json
+++ b/packages/plugin-docs-cli/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@grafana/plugin-docs-cli",
   "version": "0.0.9",
-  "private": true,
   "description": "CLI tool for developing, validating and previewing Grafana plugin documentation locally.",
   "type": "module",
   "bin": "./dist/bin/run.js",

--- a/packages/plugin-docs-parser/package.json
+++ b/packages/plugin-docs-parser/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@grafana/plugin-docs-parser",
   "version": "0.0.3",
-  "private": true,
   "description": "A lightweight library for parsing Grafana plugin documentation from markdown to HAST.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes `"private": true` from `@grafana/plugin-docs-cli` and `@grafana/plugin-docs-parser` so they get picked up by the existing release pipeline and published to NPM.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-docs-cli@0.0.10-canary.2537.23286312909.0
  npm install @grafana/plugin-docs-parser@0.0.4-canary.2537.23286312909.0
  # or 
  yarn add @grafana/plugin-docs-cli@0.0.10-canary.2537.23286312909.0
  yarn add @grafana/plugin-docs-parser@0.0.4-canary.2537.23286312909.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
