### PR TITLE
CI: Enable auto-merge for e2e-selectors bump PRs

### DIFF
--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -78,4 +78,4 @@ jobs:
         if: steps.create-pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: gh pr merge "${{ steps.create-pr.outputs.pull-request-number }}" --auto --squash
+        run: gh pr merge "${{ steps.create-pr.outputs.pull-request-number }}" --auto --squash --yes

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -55,6 +55,7 @@ jobs:
           npm install "@grafana/e2e-selectors@${VERSION}" --workspace=@grafana/plugin-e2e --save-exact
 
       - name: Create Pull Request
+        id: create-pr
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -72,3 +73,9 @@ jobs:
             dependencies
             release
             patch
+
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: gh pr merge "${{ steps.create-pr.outputs.pull-request-number }}" --auto --squash


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Enables auto-merge on the PRs created by the `bump-e2e-selectors` workflow ([this PR](https://github.com/grafana/plugin-tools/pull/2533) for example). These PRs are routine dependency bumps triggered from `grafana/grafana` whenever the `e2e-selectors` package changes and currently require manual approval and merge. With this change, the PR will automatically merge (squash) once all required status checks pass. I _think_ this should work as automerging is already enabled for the repo and also the plugin's platform bot is configured to bypass ruleset for the main branch. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
