### PR TITLE
CI: Fix auto-merge step in bump-e2e-selectors workflow

### DIFF
--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -78,4 +78,4 @@ jobs:
         if: steps.create-pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: gh pr merge "${{ steps.create-pr.outputs.pull-request-number }}" --auto --squash --yes
+        run: gh pr merge "${{ steps.create-pr.outputs.pull-request-number }}" --auto --squash


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables auto-merge on the PRs created by the `bump-e2e-selectors` workflow ([this PR](https://github.com/grafana/plugin-tools/pull/2533) for example). These PRs are routine dependency bumps triggered from `grafana/grafana` whenever the `e2e-selectors` package changes and currently require manual approval and merge. With this change, the PR will automatically merge (squash) once all required status checks pass. I _think_ this should work as automerging is already enabled for the repo and also the plugin's platform bot is configured to bypass ruleset for the main branch

**Which issue(s) this PR fixes**:

Fixes the failed auto-merge step introduced in #2538 (`--yes` is not a valid flag for `gh pr merge`).

**Special notes for your reviewer**:

Once merged, re-trigger the `bump-e2e-selectors` workflow to verify auto-merge works on [PR #2539](https://github.com/grafana/plugin-tools/pull/2539), or close that PR and let the next bump create a fresh one.