### PR TITLE
CI: Skip vault secrets and publish-report for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       NX_BRANCH: ${{ github.event.number || github.ref_name }}
     steps:
       - id: get-secrets
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
         with:
           # Secrets placed in the ci/repo/grafana/plugin-tools in vault
@@ -89,6 +90,7 @@ jobs:
       WORKING_DIR: 'myorg-nobackend-panel'
     steps:
       - id: get-secrets
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
         with:
           # Secrets placed in the ci/repo/grafana/plugin-tools in vault
@@ -161,6 +163,7 @@ jobs:
         working-directory: ./${{ env.WORKING_DIR }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
@@ -274,6 +277,7 @@ jobs:
             hasBackend: false
     steps:
       - id: get-secrets
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
         with:
           # Secrets placed in the ci/repo/grafana/plugin-tools in vault
@@ -282,6 +286,7 @@ jobs:
           export_env: false
 
       - name: Get secrets for DockerHub login
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
         with:
           common_secrets: |
@@ -367,6 +372,7 @@ jobs:
         working-directory: ./${{ matrix.workingDir }}
 
       - name: Log in to Docker Hub
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
@@ -460,7 +466,7 @@ jobs:
         working-directory: ./${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
-        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.event.pull_request.head.repo.fork != true }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
@@ -481,7 +487,7 @@ jobs:
         run: exit 1
 
   publish-report:
-    if: ${{ always() && !cancelled() }}
+    if: ${{ always() && !cancelled() && github.event.pull_request.head.repo.fork != true }}
     needs: [generate-plugins]
     runs-on: ubuntu-x64
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
         working-directory: ./${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
-        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.event.pull_request.head.repo.fork != true }}
+        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork != true }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private


### PR DESCRIPTION
**What this PR does / why we need it**:

Gates vault secret steps, sign-plugin, Docker Hub login and the `publish-report` job with a fork check so external contributors get green CI.

**Which issue(s) this PR fixes**:

Fixes the CI failures on #2498.

**Special notes for your reviewer**: N/A