### PR TITLE
CI: Add auto-approve to bump-e2e-selectors workflow

### DIFF
--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -74,8 +74,10 @@ jobs:
             release
             patch
 
-      - name: Enable auto-merge
+      - name: Approve and enable auto-merge
         if: steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: gh pr merge "${{ steps.create-pr.outputs.pull-request-number }}" --auto --squash
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: |
+          gh pr review "$PR_NUMBER" --approve --body "Automated approval for e2e-selectors bump"
+          GH_TOKEN="${{ steps.generate-token.outputs.token }}" gh pr merge "$PR_NUMBER" --auto --squash

--- a/.github/workflows/bump-e2e-selectors.yml
+++ b/.github/workflows/bump-e2e-selectors.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Approve and enable auto-merge
         if: steps.create-pr.outputs.pull-request-number
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
         run: |
           gh pr review "$PR_NUMBER" --approve --body "Automated approval for e2e-selectors bump"


### PR DESCRIPTION
**What this PR does / why we need it**:

The auto-merge step added in #2538 (and fixed in #2540) enabled auto-merge, but GitHub won't merge because the `main` branch ruleset requires an approving review. This adds an approval step using `GITHUB_TOKEN` (`github-actions[bot]`) before enabling auto-merge with the app token. The app token is a bypass actor on the ruleset so it should be able to merge once any approval exists even though `github-actions[bot]` isn't a code owner.

**Which issue(s) this PR fixes**:

Follow-up to #2538 and #2540. Hopefully completes the auto-merge setup for e2e-selectors bump PRs.

**Special notes for your reviewer**:

To verify this works I'd like to:
1. Merge this PR
2. Go to Actions > "Bump @grafana/e2e-selectors" > Run workflow with version `13.0.0-23832190058`
3. Confirm the "Approve and enable auto-merge" step succeeds
4. Confirm the created PR shows "Auto-merge enabled" but does **not** merge before checks finish
5. Confirm it merges automatically after all checks pass
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.5.3-canary.2549.23834987577.0
  # or 
  yarn add website@5.5.3-canary.2549.23834987577.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
