### PR TITLE
fix: reduce false positives in findStringRefs

### DIFF
--- a/packages/react-detect/src/patterns/matcher.test.ts
+++ b/packages/react-detect/src/patterns/matcher.test.ts
@@ -92,6 +92,7 @@ describe('matcher', () => {
   describe('findStringRefs', () => {
     it('should find stringRefs assignments in source code', () => {
       const code = `
+    import React from 'react';
     class MyComponent extends React.Component {
       componentDidMount() {
         this.refs.input.focus();
@@ -111,6 +112,7 @@ describe('matcher', () => {
 
     it('should find bracket notation refs access', () => {
       const code = `
+      import React from 'react';
       class MyComponent extends React.Component {
         componentDidMount() {
           this.refs['input'].focus();
@@ -126,6 +128,35 @@ describe('matcher', () => {
       expect(matches).toHaveLength(1);
       expect(matches[0].pattern).toBe('stringRefs');
       expect(matches[0].matched).toContain('this.refs');
+    });
+
+    it('should not match this.refs in files without a React import', () => {
+      const code = `
+      class ComponentRegistry {
+        getRef() {
+          return this.refs.primary;
+        }
+      }
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findStringRefs(ast, code);
+
+      expect(matches).toHaveLength(0);
+    });
+
+    it('should not match bare this.refs access without property access', () => {
+      const code = `
+      import React from 'react';
+      class MyComponent extends React.Component {
+        getAllRefs() {
+          return this.refs;
+        }
+      }
+    `;
+      const ast = parseFile(code, 'test.js');
+      const matches = findStringRefs(ast, code);
+
+      expect(matches).toHaveLength(0);
     });
   });
 

--- a/packages/react-detect/src/patterns/matcher.ts
+++ b/packages/react-detect/src/patterns/matcher.ts
@@ -102,14 +102,21 @@ export function findJsxRuntimeImports(ast: TSESTree.Program, code: string): Patt
 
 export function findStringRefs(ast: TSESTree.Program, code: string): PatternMatch[] {
   const matches: PatternMatch[] = [];
+  const imports = trackImportsFromPackage(ast, 'react');
+
+  const hasReactImport = imports.defaultImports.size > 0 || imports.namedImports.size > 0;
+  if (!hasReactImport) {
+    return matches;
+  }
 
   walk(ast, (node) => {
     if (
       node &&
       node.type === 'MemberExpression' &&
-      node.object.type === 'ThisExpression' &&
-      node.property.type === 'Identifier' &&
-      node.property.name === 'refs'
+      node.object?.type === 'MemberExpression' &&
+      node.object.object?.type === 'ThisExpression' &&
+      node.object.property?.type === 'Identifier' &&
+      node.object.property.name === 'refs'
     ) {
       matches.push(createPatternMatch(node, 'stringRefs', code));
     }


### PR DESCRIPTION
## Summary

- `findStringRefs` was matching any `this.refs` access regardless of whether it was in a React file or a React class component, causing false positives in non-React classes that happen to have a `refs` property
- Added a React import guard — the check is skipped entirely if the file doesn't import from `react`
- Narrowed the AST match from bare `this.refs` to `this.refs.X` / `this.refs['X']` (specific ref property access), which is the only form that constitutes actual string ref usage

## Test plan

- [x] Existing positive tests updated to include `import React from 'react'` in fixtures
- [x] New negative test: file without React import → 0 matches
- [x] New negative test: bare `this.refs` without property access → 0 matches
- [x] All 91 tests pass (`npm run test -w @grafana/react-detect -- --run`)
- [x] Typecheck clean (`npm run typecheck -w @grafana/react-detect`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.4.11-canary.2551.23842776194.0
  npm install @grafana/react-detect@0.6.2-canary.2551.23842776194.0
  # or 
  yarn add @grafana/plugin-e2e@3.4.11-canary.2551.23842776194.0
  yarn add @grafana/react-detect@0.6.2-canary.2551.23842776194.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
