### PR TITLE
feat(create-plugin): make Grafana host port configurable via GRAFANA_PORT in base template

### DIFF
--- a/packages/create-plugin/templates/common/.config/docker-compose-base.yaml
+++ b/packages/create-plugin/templates/common/.config/docker-compose-base.yaml
@@ -11,7 +11,7 @@ services:
         development: ${DEVELOPMENT:-false}
         anonymous_auth_enabled: ${ANONYMOUS_AUTH_ENABLED:-true}
     ports:
-      - 3000:3000/tcp
+      - ${GRAFANA_PORT:-3000}:3000/tcp
 {{#if hasBackend}}
       - 2345:2345/tcp # delve
     security_opt:


### PR DESCRIPTION
Closes #2555

## Summary

- Replace hardcoded `3000:3000/tcp` in `docker-compose-base.yaml` with `${GRAFANA_PORT:-3000}:3000/tcp`

Docker Compose `extends` merges list fields like `ports` rather than replacing them. When a plugin's `docker-compose.yaml` extends the base and also declares `${GRAFANA_PORT:-3000}:3000/tcp`, both entries are applied to the container. With the base hardcoded at `3000:3000/tcp`, setting `GRAFANA_PORT=3001` results in two different bindings being attempted — one of which conflicts if another environment is already on port 3000.

Using the same variable in the base means both entries always resolve identically. Docker deduplicates them, and only one port is bound. Developers can set `GRAFANA_PORT=3001` in one workspace's `.env` to run two environments side by side. The default remains `3000`, so existing `.env` files need no changes.

## Test plan

- [ ] Scaffold a new plugin, set `GRAFANA_PORT=3001` in `.env`, run `docker compose up` — Grafana should bind on port `3001` only
- [ ] Without `GRAFANA_PORT` set, `docker compose up` continues to bind on port `3000` (default behaviour unchanged)
- [ ] Two plugin environments can run concurrently on ports `3000` and `3001` without conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)