### PR TITLE
AddPanel: Default dashboardScene feature toggle to true in tests

### DIFF
--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -87,7 +87,12 @@ export class DashboardPage extends GrafanaPage {
   async addPanel(): Promise<PanelEditPage> {
     const { components, pages, constants } = this.ctx.selectors;
 
-    const scenesEnabled = await isLegacyFeatureEnabled(this.ctx.page, 'dashboardScene');
+    // scenes feature toggle deprecated in v13 (no longer possible to disable)
+    let scenesEnabled = true;
+
+    if (semver.lt(this.ctx.grafanaVersion, '13.0.0')) {
+      scenesEnabled = await isLegacyFeatureEnabled(this.ctx.page, 'dashboardScene');
+    }
 
     // In scenes powered dashboards, one needs to click the edit button before adding a new panel in already existing dashboards
     if (scenesEnabled && this.dashboard?.uid) {


### PR DESCRIPTION
In grafana v13 we are deprecating `dashboardScene` feature toggle usage. This means it will no longer appear in `grafanaBootData` and playwright scripts need adjusting. 

This PR defaults dashboardScene checks to true and if version is less than 13.0.0 old check kicks in

Enables https://github.com/grafana/grafana/pull/121781
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.4.12-canary.2563.24085911066.0
  # or 
  yarn add @grafana/plugin-e2e@3.4.12-canary.2563.24085911066.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
