### PR TITLE
chore: remove global owners to reduce number of team reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,3 @@
-# These default owners will match all PRs unless a later match takes precedence.
-
-* @grafana/plugins-platform-frontend @grafana/grafana-frontend-platform
-
 /packages/create-plugin/ @grafana/grafana-frontend-platform
 /packages/eslint-plugin-plugins/ @grafana/plugins-platform-frontend
 /packages/plugin-docs-parser/ @grafana/plugins-platform-frontend


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR removes the global code owners from the repo in an attempt to reduce reviewer noise.

Changes to certain files that live in the root of this mono-repo are creating bother where multiple teams are required to review PRs. F.ex a dependency bump that touches plugin-e2e/package.json will also touch package-lock.json in root and ask for reviews from frontend-platform and plugins-platform.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
