### PR TITLE
Docs: Skip loading en-US translations in loadResources example

### DIFF
--- a/docusaurus/docs/how-to-guides/plugin-internationalization-grafana-11.md
+++ b/docusaurus/docs/how-to-guides/plugin-internationalization-grafana-11.md
@@ -117,7 +117,7 @@ npm install --save-dev @types/semver
 To handle translation resource loading let's add `src/loadResources.ts`
 
 ```ts title="src/loadResources.ts"
-import { LANGUAGES, ResourceLoader, Resources } from '@grafana/i18n';
+import { DEFAULT_LANGUAGE, LANGUAGES, ResourceLoader, Resources } from '@grafana/i18n';
 import pluginJson from 'plugin.json';
 
 const resources = LANGUAGES.reduce<Record<string, () => Promise<{ default: Resources }>>>((acc, lang) => {
@@ -126,6 +126,11 @@ const resources = LANGUAGES.reduce<Record<string, () => Promise<{ default: Resou
 }, {});
 
 export const loadResources: ResourceLoader = async (resolvedLanguage: string) => {
+  // Don't load resources for the default language as they are already embedded in the source code
+  if (resolvedLanguage === DEFAULT_LANGUAGE) {
+    return {};
+  }
+
   try {
     const translation = await resources[resolvedLanguage]();
     return translation.default;


### PR DESCRIPTION
## Summary
- Updates the `loadResources.ts` code sample in the plugin i18n guide to import `DEFAULT_LANGUAGE` from `@grafana/i18n` and add an early return when the resolved language is the default
- This avoids unnecessary dynamic imports of ~500kb of en-US translations that are already embedded in source code via `t()` and `<Trans>`

Related: grafana/logs-drilldown#1839
Related: grafana/grafana#122188

## Test plan
- [x] Code sample compiles and reads correctly in context of the guide