### PR TITLE
Plugin E2E: Add support for Grafana 13 new dashboard layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5444,9 +5444,9 @@
       "license": "0BSD"
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "13.1.0-24236083202",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24236083202.tgz",
-      "integrity": "sha512-AMkuNNxedKRvkSPbNKXEZk34crfr8B5lvRrn2I3EqOtknKf49GthDm7qyx5JtvdOSjK/g3pvlJtRHbY1Bvf9lg==",
+      "version": "13.1.0-24329840005",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24329840005.tgz",
+      "integrity": "sha512-kKcWFaTjkKunBGLcnbp0DNT05T2x+5eDMIG6AQhNwiN//Pp/9gjQu5I/bkjPc4J9TJjlU9mfni3HrqQ5/cxJHQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.0",
@@ -40742,7 +40742,7 @@
       "version": "3.4.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "13.1.0-24236083202",
+        "@grafana/e2e-selectors": "13.1.0-24329840005",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5444,9 +5444,9 @@
       "license": "0BSD"
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "13.1.0-24329840005",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24329840005.tgz",
-      "integrity": "sha512-kKcWFaTjkKunBGLcnbp0DNT05T2x+5eDMIG6AQhNwiN//Pp/9gjQu5I/bkjPc4J9TJjlU9mfni3HrqQ5/cxJHQ==",
+      "version": "13.1.0-24335230309",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24335230309.tgz",
+      "integrity": "sha512-EHd8S/MHBQFAlSVFvdG45sHu6iXIVSGN9szk8yAbJMnjqo90iKde9iErz2Qh4FCQCSv8M5zL3TUSeqlUDrrXGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "semver": "^7.7.0",
@@ -40742,7 +40742,7 @@
       "version": "3.4.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "13.1.0-24329840005",
+        "@grafana/e2e-selectors": "13.1.0-24335230309",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"

--- a/packages/plugin-e2e/docker-compose.yaml
+++ b/packages/plugin-e2e/docker-compose.yaml
@@ -9,8 +9,7 @@ services:
       - GF_AUTH_ANONYMOUS_ORG_NAME=Main Org.
       - GF_AUTH_ANONYMOUS_ORG_ID=1
       - GF_PANELS_ENABLE_ALPHA=true
-      - GF_FEATURE_TOGGLES_splashScreen=false
-      # TODO we need to handle new layouts in the e2e tests!
+      - GF_FEATURE_TOGGLES_splashScreen=true
       - GF_FEATURE_TOGGLES_dashboardNewLayouts=true
     ports:
       - 3000:3000/tcp

--- a/packages/plugin-e2e/docker-compose.yaml
+++ b/packages/plugin-e2e/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - GF_PANELS_ENABLE_ALPHA=true
       - GF_FEATURE_TOGGLES_splashScreen=false
       # TODO we need to handle new layouts in the e2e tests!
-      - GF_FEATURE_TOGGLES_dashboardNewLayouts=false
+      - GF_FEATURE_TOGGLES_dashboardNewLayouts=true
     ports:
       - 3000:3000/tcp
     volumes:

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -49,7 +49,7 @@
     "dotenv": "^17.2.4"
   },
   "dependencies": {
-    "@grafana/e2e-selectors": "13.1.0-24236083202",
+    "@grafana/e2e-selectors": "13.1.0-24329840005",
     "semver": "^7.5.4",
     "uuid": "^13.0.0",
     "yaml": "^2.3.4"

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -49,7 +49,7 @@
     "dotenv": "^17.2.4"
   },
   "dependencies": {
-    "@grafana/e2e-selectors": "13.1.0-24329840005",
+    "@grafana/e2e-selectors": "13.1.0-24335230309",
     "semver": "^7.5.4",
     "uuid": "^13.0.0",
     "yaml": "^2.3.4"

--- a/packages/plugin-e2e/src/fixtures/page.ts
+++ b/packages/plugin-e2e/src/fixtures/page.ts
@@ -2,6 +2,7 @@ import { Page, TestFixture } from '@playwright/test';
 import { gte } from 'semver';
 
 import { PlaywrightArgs } from '../types';
+import { DEFAULT_OPEN_FEATURE_FLAGS } from '../options';
 import { setupOpenFeatureRoutes } from './openFeature';
 import { overrideGrafanaBootData } from './scripts/overrideGrafanaBootData';
 
@@ -28,7 +29,8 @@ export const page: PageFixture = async (
   use
 ) => {
   const hasFeatureToggles = Object.keys(featureToggles).length > 0;
-  const hasOpenFeature = Object.keys(openFeature.flags).length > 0;
+  const mergedFlags = { ...DEFAULT_OPEN_FEATURE_FLAGS, ...openFeature.flags };
+  const hasOpenFeature = Object.keys(mergedFlags).length > 0;
   const hasUserPreferences = Object.keys(userPreferences).length > 0;
 
   // set up legacy feature toggle overrides via init script
@@ -43,7 +45,7 @@ export const page: PageFixture = async (
   // set up OpenFeature OFREP route interception BEFORE navigation
   // only runs if openFeature flags are provided and Grafana version >= 12.1.0
   if (hasOpenFeature && gte(grafanaVersion, '12.1.0')) {
-    await setupOpenFeatureRoutes(page, openFeature.flags, openFeature.latency ?? 0, selectors);
+    await setupOpenFeatureRoutes(page, mergedFlags, openFeature.latency ?? 0, selectors);
   }
 
   await page.goto('/');

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -6,6 +6,7 @@ import { PanelEditPage } from './PanelEditPage';
 import { TimeRange } from '../components/TimeRange';
 import { Panel } from '../components/Panel';
 import { isLegacyFeatureEnabled } from '../../fixtures/isFeatureToggleEnabled';
+import { resolveGrafanaSelector } from '../utils';
 
 export class DashboardPage extends GrafanaPage {
   dataSourcePicker: any;
@@ -110,7 +111,18 @@ export class DashboardPage extends GrafanaPage {
       }
     }
 
-    if (semver.gte(this.ctx.grafanaVersion, '9.5.0')) {
+    if (semver.gte(this.ctx.grafanaVersion, '13.0.0')) {
+      // await this.ctx.page.waitForTimeout(500); // wait for the sidebar animation to finish
+      await this.ctx.page.waitForSelector(resolveGrafanaSelector(this.ctx.selectors.components.Sidebar.container));
+      const newPanelButton = this.getByGrafanaSelector(components.Sidebar.newPanelButton);
+      if (!(await newPanelButton.isVisible())) {
+        await this.getByGrafanaSelector(pages.Dashboard.Sidebar.addButton).click();
+      }
+      await this.getByGrafanaSelector(components.Sidebar.newPanelButton).click();
+      const sidebarContainer = this.getByGrafanaSelector(components.Sidebar.container);
+      // TODO: add proper selector
+      await sidebarContainer.getByRole('button', { name: 'Configure' }).click();
+    } else if (semver.gte(this.ctx.grafanaVersion, '9.5.0')) {
       let addButton = this.getByGrafanaSelector(
         components.PageToolbar.itemButton(constants.PageToolBar.itemButtonTitle)
       );

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -119,9 +119,6 @@ export class DashboardPage extends GrafanaPage {
         await this.getByGrafanaSelector(pages.Dashboard.Sidebar.addButton).click();
       }
       await this.getByGrafanaSelector(components.Sidebar.newPanelButton).click();
-      const sidebarContainer = this.getByGrafanaSelector(components.Sidebar.container);
-      // TODO: add proper selector
-      // await sidebarContainer.getByRole('button', { name: 'Configure' }).click();
       await this.getByGrafanaSelector(components.Sidebar.configurePanelButton).click();
     } else if (semver.gte(this.ctx.grafanaVersion, '9.5.0')) {
       let addButton = this.getByGrafanaSelector(

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -121,7 +121,8 @@ export class DashboardPage extends GrafanaPage {
       await this.getByGrafanaSelector(components.Sidebar.newPanelButton).click();
       const sidebarContainer = this.getByGrafanaSelector(components.Sidebar.container);
       // TODO: add proper selector
-      await sidebarContainer.getByRole('button', { name: 'Configure' }).click();
+      // await sidebarContainer.getByRole('button', { name: 'Configure' }).click();
+      await this.getByGrafanaSelector(components.Sidebar.configurePanelButton).click();
     } else if (semver.gte(this.ctx.grafanaVersion, '9.5.0')) {
       let addButton = this.getByGrafanaSelector(
         components.PageToolbar.itemButton(constants.PageToolBar.itemButtonTitle)

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -112,7 +112,6 @@ export class DashboardPage extends GrafanaPage {
     }
 
     if (semver.gte(this.ctx.grafanaVersion, '13.0.0')) {
-      // await this.ctx.page.waitForTimeout(500); // wait for the sidebar animation to finish
       await this.ctx.page.waitForSelector(resolveGrafanaSelector(this.ctx.selectors.components.Sidebar.container));
       const newPanelButton = this.getByGrafanaSelector(components.Sidebar.newPanelButton);
       if (!(await newPanelButton.isVisible())) {

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -118,8 +118,7 @@ export class DashboardPage extends GrafanaPage {
         await this.getByGrafanaSelector(pages.Dashboard.Sidebar.addButton).click();
       }
       await this.getByGrafanaSelector(components.Sidebar.newPanelButton).click();
-      const sidebarContainer = this.getByGrafanaSelector(components.Sidebar.container);
-      await sidebarContainer.getByRole('button', { name: 'Configure' }).click();
+      await this.getByGrafanaSelector(components.Sidebar.configurePanelButton).click();
     } else if (semver.gte(this.ctx.grafanaVersion, '9.5.0')) {
       let addButton = this.getByGrafanaSelector(
         components.PageToolbar.itemButton(constants.PageToolBar.itemButtonTitle)

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -118,7 +118,8 @@ export class DashboardPage extends GrafanaPage {
         await this.getByGrafanaSelector(pages.Dashboard.Sidebar.addButton).click();
       }
       await this.getByGrafanaSelector(components.Sidebar.newPanelButton).click();
-      await this.getByGrafanaSelector(components.Sidebar.configurePanelButton).click();
+      const sidebarContainer = this.getByGrafanaSelector(components.Sidebar.container);
+      await sidebarContainer.getByRole('button', { name: 'Configure' }).click();
     } else if (semver.gte(this.ctx.grafanaVersion, '9.5.0')) {
       let addButton = this.getByGrafanaSelector(
         components.PageToolbar.itemButton(constants.PageToolBar.itemButtonTitle)

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -7,11 +7,16 @@ export const DEFAULT_ADMIN_USER: User = {
   password: process.env.GRAFANA_ADMIN_PASSWORD || 'admin',
 };
 
+const DEFAULT_OPEN_FEATURE_FLAGS = {
+  // disable the splash screen by default for all consumers of plugin-e2e
+  splashScreen: false,
+};
+
 export const options: Fixtures<{}, PluginOptions> = {
   userPreferences: [{}, { option: true, scope: 'worker' }],
   featureToggles: [{}, { option: true, scope: 'worker' }],
   openFeature: [
-    { flags: {}, latency: 0 },
+    { flags: DEFAULT_OPEN_FEATURE_FLAGS, latency: 0 },
     { option: true, scope: 'worker' },
   ],
   provisioningRootDir: [path.join(process.cwd(), 'provisioning'), { option: true, scope: 'worker' }],

--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -7,7 +7,7 @@ export const DEFAULT_ADMIN_USER: User = {
   password: process.env.GRAFANA_ADMIN_PASSWORD || 'admin',
 };
 
-const DEFAULT_OPEN_FEATURE_FLAGS = {
+export const DEFAULT_OPEN_FEATURE_FLAGS = {
   // disable the splash screen by default for all consumers of plugin-e2e
   splashScreen: false,
 };
@@ -16,7 +16,7 @@ export const options: Fixtures<{}, PluginOptions> = {
   userPreferences: [{}, { option: true, scope: 'worker' }],
   featureToggles: [{}, { option: true, scope: 'worker' }],
   openFeature: [
-    { flags: DEFAULT_OPEN_FEATURE_FLAGS, latency: 0 },
+    { flags: {}, latency: 0 },
     { option: true, scope: 'worker' },
   ],
   provisioningRootDir: [path.join(process.cwd(), 'provisioning'), { option: true, scope: 'worker' }],


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for the new dashboard layout introduced in Grafana 13, which changed how panels are added via a sidebar instead of the previous toolbar button. The `addPanel` flow now correctly targets the sidebar's new panel and configure panel buttons for Grafana 13+.

Also disables the splash screen feature flag by default for all consumers of `@grafana/plugin-e2e`, so tests aren't blocked by the splash screen overlay in Grafana 13.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/plugin-tools/issues/2571


**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.5.0-canary.2572.24341579767.0
  # or 
  yarn add @grafana/plugin-e2e@3.5.0-canary.2572.24341579767.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
