### PR TITLE
Create Plugin: Pin @grafana dependencies to 12.4.2

### DIFF
--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -73,11 +73,11 @@
   },
   "dependencies": {
     "@emotion/css": "11.10.6",
-    "@grafana/data": "^12.4.0",
-    "@grafana/i18n": "^12.4.0",
-    "@grafana/runtime": "^12.4.0",
-    "@grafana/ui": "^12.4.0",
-    "@grafana/schema": "^12.4.0",{{#if_eq pluginType "scenesapp" }}
+    "@grafana/data": "12.4.2",
+    "@grafana/i18n": "12.4.2",
+    "@grafana/runtime": "12.4.2",
+    "@grafana/ui": "12.4.2",
+    "@grafana/schema": "12.4.2",{{#if_eq pluginType "scenesapp" }}
     "@grafana/scenes": "{{ scenesVersion }}",{{/if_eq}}
     "react": "^18.3.0",
     "react-dom": "^18.3.0"{{#if isAppType}},


### PR DESCRIPTION
[Related Slack thread](https://raintank-corp.slack.com/archives/C025WTVRBSN/p1776162568026399)

### Problem
Due to [grafana-ui@12.4.3 not being available](https://www.npmjs.com/package/@grafana/ui/v/12.4.3) while the rest of packages have that version published, `npx @grafana/create-plugin@latest` now scaffolds a broken plugin (other 12.4.3 packages depending a not existing ui package).

### What changed?

Pinned `@grafana/data`, `@grafana/i18n`, `@grafana/runtime`, `@grafana/ui`, and `@grafana/schema` from `^12.4.0` to exact version `12.4.2` in the create-plugin scaffold template.