### PR TITLE
fix(create-plugin): fix typo in scaffolded agent md templates

### DIFF
--- a/packages/create-plugin/templates/common/AGENTS.md
+++ b/packages/create-plugin/templates/common/AGENTS.md
@@ -1,2 +1,2 @@
 ## Project knowledge
-Thie repository contains a **Grafana plugin**. You must Read @./.config/AGENTS/instructions.md before doing changes.
+This repository contains a **Grafana plugin**. You must Read @./.config/AGENTS/instructions.md before doing changes.

--- a/packages/create-plugin/templates/common/CLAUDE.md
+++ b/packages/create-plugin/templates/common/CLAUDE.md
@@ -1,2 +1,2 @@
 ## Project knowledge
-Thie repository contains a **Grafana plugin**. You must Read @./.config/AGENTS/instructions.md before doing changes.
+This repository contains a **Grafana plugin**. You must Read @./.config/AGENTS/instructions.md before doing changes.

--- a/packages/create-plugin/templates/common/GEMINI.md
+++ b/packages/create-plugin/templates/common/GEMINI.md
@@ -1,3 +1,3 @@
 ## Project knowledge
-Thie repository contains a **Grafana plugin**. You must Read @./.config/AGENTS/instructions.md before doing changes.
+This repository contains a **Grafana plugin**. You must Read @./.config/AGENTS/instructions.md before doing changes.
 


### PR DESCRIPTION
## Summary
- Fix "Thie" → "This" typo in scaffolded CLAUDE.md, AGENTS.md, and GEMINI.md templates