### PR TITLE
Create Plugin: Bump @grafana/plugin-e2e to 3.5.1

### DIFF
--- a/.claude/skills/bump-plugin-e2e/SKILL.md
+++ b/.claude/skills/bump-plugin-e2e/SKILL.md
@@ -23,26 +23,39 @@ Save the output - this is `<NEW_VERSION>`.
 
 Read [packages/create-plugin/templates/common/\_package.json](packages/create-plugin/templates/common/_package.json) and note the current `@grafana/plugin-e2e` semver range (line ~20).
 
-If the current range already matches `^<NEW_VERSION>`, stop - nothing to do.
+Note the semver range prefix (e.g. `^`, `~`, or exact). If the version number already matches `<NEW_VERSION>`, stop - nothing to do.
 
 ### 3. Update \_package.json
 
-Edit the file, replacing the existing `@grafana/plugin-e2e` version range with `^<NEW_VERSION>`.
+Replace only the version number, preserving the existing range prefix exactly.
 
-Example change:
+Example (prefix was `^`, keep it `^`):
 
 ```json
 - "@grafana/plugin-e2e": "^3.5.0",
 + "@grafana/plugin-e2e": "^3.6.0",
 ```
 
-### 4. Create a branch and commit
+### 4. Create a worktree, commit and push
+
+Use a git worktree so the current workspace is never disturbed.
 
 ```bash
-git checkout -b bump/plugin-e2e-<NEW_VERSION>
-git add packages/create-plugin/templates/common/_package.json
-git commit -m "Create Plugin: bump @grafana/plugin-e2e to ^<NEW_VERSION>"
-git push -u origin bump/plugin-e2e-<NEW_VERSION>
+WORKTREE=/tmp/plugin-tools-e2e-bump
+BRANCH=bump/plugin-e2e-<NEW_VERSION>
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+git worktree add "$WORKTREE" -b "$BRANCH" main
+```
+
+Edit the `_package.json` inside the worktree (same relative path: `packages/create-plugin/templates/common/_package.json`), then commit and push:
+
+```bash
+git -C "$WORKTREE" add packages/create-plugin/templates/common/_package.json
+git -C "$WORKTREE" commit -m "Create Plugin: bump @grafana/plugin-e2e to ^<NEW_VERSION>"
+git -C "$WORKTREE" push -u origin "$BRANCH"
+
+git worktree remove "$WORKTREE"
 ```
 
 ### 5. Open a draft PR

--- a/.claude/skills/bump-plugin-e2e/SKILL.md
+++ b/.claude/skills/bump-plugin-e2e/SKILL.md
@@ -42,7 +42,7 @@ Use a git worktree so the current workspace is never disturbed.
 
 ```bash
 WORKTREE=/tmp/plugin-tools-e2e-bump
-BRANCH=bump/plugin-e2e-<NEW_VERSION>
+BRANCH=create-plugin/bump-plugin-e2e-<NEW_VERSION>
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 git worktree add "$WORKTREE" -b "$BRANCH" main

--- a/.claude/skills/bump-plugin-e2e/SKILL.md
+++ b/.claude/skills/bump-plugin-e2e/SKILL.md
@@ -41,7 +41,7 @@ Example (prefix was `^`, keep it `^`):
 Use a git worktree so the current workspace is never disturbed.
 
 ```bash
-WORKTREE=$(mktemp -d)
+WORKTREE="/tmp/plugin-tools-e2e-bump-$$"
 BRANCH=create-plugin/bump-plugin-e2e-<NEW_VERSION>
 
 git worktree add "$WORKTREE" -b "$BRANCH" main

--- a/.claude/skills/bump-plugin-e2e/SKILL.md
+++ b/.claude/skills/bump-plugin-e2e/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: bump-plugin-e2e
+description: Use when bumping the @grafana/plugin-e2e version in the create-plugin template. Fetches the latest npm version, updates _package.json, commits, and opens a draft PR.
+---
+
+# Bump @grafana/plugin-e2e in create-plugin template
+
+## Overview
+
+Updates the `@grafana/plugin-e2e` devDependency in the create-plugin common template to the latest published npm version, then commits and opens a draft PR.
+
+## Steps
+
+### 1. Get the latest version
+
+```bash
+npm view @grafana/plugin-e2e version
+```
+
+Save the output - this is `<NEW_VERSION>`.
+
+### 2. Check the current version
+
+Read [packages/create-plugin/templates/common/\_package.json](packages/create-plugin/templates/common/_package.json) and note the current `@grafana/plugin-e2e` semver range (line ~20).
+
+If the current range already matches `^<NEW_VERSION>`, stop - nothing to do.
+
+### 3. Update \_package.json
+
+Edit the file, replacing the existing `@grafana/plugin-e2e` version range with `^<NEW_VERSION>`.
+
+Example change:
+
+```json
+- "@grafana/plugin-e2e": "^3.5.0",
++ "@grafana/plugin-e2e": "^3.6.0",
+```
+
+### 4. Create a branch and commit
+
+```bash
+git checkout -b bump/plugin-e2e-<NEW_VERSION>
+git add packages/create-plugin/templates/common/_package.json
+git commit -m "Create Plugin: bump @grafana/plugin-e2e to ^<NEW_VERSION>"
+git push -u origin bump/plugin-e2e-<NEW_VERSION>
+```
+
+### 5. Open a draft PR
+
+Use the repo PR template structure. Title format: `Create Plugin: Bump @grafana/plugin-e2e to <NEW_VERSION>`
+
+```bash
+gh pr create --draft \
+  --title "Create Plugin: Bump @grafana/plugin-e2e to <NEW_VERSION>" \
+  --label "patch" \
+  --label "release" \
+  --body "$(cat <<'EOF'
+**What this PR does / why we need it**:
+
+Bumps `@grafana/plugin-e2e` to `^<NEW_VERSION>` in the create-plugin common template.
+
+**Which issue(s) this PR fixes**:
+
+Fixes #
+
+**Special notes for your reviewer**:
+
+Automated version bump. Check the [@grafana/plugin-e2e changelog](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/CHANGELOG.md) for notable changes.
+EOF
+)"
+```
+
+Return the PR URL to the user.

--- a/.claude/skills/bump-plugin-e2e/SKILL.md
+++ b/.claude/skills/bump-plugin-e2e/SKILL.md
@@ -83,4 +83,4 @@ EOF
 )"
 ```
 
-Return the PR URL to the user.
+Post the PR URL to the user as a clickable markdown link, e.g. `[grafana/plugin-tools#123](https://github.com/grafana/plugin-tools/pull/123)`.

--- a/.claude/skills/bump-plugin-e2e/SKILL.md
+++ b/.claude/skills/bump-plugin-e2e/SKILL.md
@@ -41,9 +41,8 @@ Example (prefix was `^`, keep it `^`):
 Use a git worktree so the current workspace is never disturbed.
 
 ```bash
-WORKTREE=/tmp/plugin-tools-e2e-bump
+WORKTREE=$(mktemp -d)
 BRANCH=create-plugin/bump-plugin-e2e-<NEW_VERSION>
-REPO_ROOT=$(git rev-parse --show-toplevel)
 
 git worktree add "$WORKTREE" -b "$BRANCH" main
 ```

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
-    "@grafana/plugin-e2e": "^3.5.0",
+    "@grafana/plugin-e2e": "^3.5.1",
     "@grafana/tsconfig": "^2.0.1",
     "@playwright/test": "^1.57.0",{{#if useExperimentalRspack}}
     "@rspack/core": "^1.6.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps \`@grafana/plugin-e2e\` to \`^3.5.1\` in the create-plugin common template.

Also adds a \`.claude/skills/bump-plugin-e2e\` skill to this repo so future bumps can be done by running \`/bump-plugin-e2e\` in Claude Code.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Automated version bump. Check the [@grafana/plugin-e2e changelog](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/CHANGELOG.md) for notable changes since 3.5.0.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@7.1.7-canary.2580.24515547257.0
  # or 
  yarn add @grafana/create-plugin@7.1.7-canary.2580.24515547257.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
