### PR TITLE
Plugin E2E: Add dashboard smoke testing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,10 @@ nx-cloud.env
 
 # End to End tests
 playwright-report/
-packages/plugin-e2e/test-results/
+test-results/
 packages/plugin-e2e/playwright/.cache/
 packages/plugin-e2e/playwright/.auth
+packages/plugin-e2e/.playwright-mcp/
 playwright/.cache/
 playwright/.auth
 

--- a/packages/plugin-e2e/provisioning/dashboards/smoke-test.json
+++ b/packages/plugin-e2e/provisioning/dashboards/smoke-test.json
@@ -1,0 +1,201 @@
+{
+  "id": null,
+  "uid": "smoke-test-dashboard",
+  "title": "Smoke Test Dashboard",
+  "tags": [],
+  "timezone": "browser",
+  "schemaVersion": 36,
+  "version": 1,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Top Left",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 2,
+      "title": "Top Right",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 3,
+      "title": "Middle Left",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 4,
+      "title": "Middle Right",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 5,
+      "title": "Lower Left",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 6,
+      "title": "Lower Right",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 9,
+      "title": "Deep Left",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 10,
+      "title": "Deep Right",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 7,
+      "title": "Bottom Left",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 8,
+      "title": "Bottom Right",
+      "type": "timeseries",
+      "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "targets": [
+        {
+          "refId": "A",
+          "queryText": "test",
+          "datasource": { "type": "grafana-test-datasource", "uid": "P6E498B96656A7F9B" }
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }
+      },
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    }
+  ]
+}

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -226,6 +226,8 @@ declare global {
        * Asserts that a dashboard has panel errors. Omit `count` to assert at least one error.
        * Pass `count` to assert exactly that many panels with errors.
        * Use `.not.toHavePanelErrors()` to assert no panel errors.
+       *
+       * @alpha - the API is not yet stable and may change without a major version bump. Use with caution.
        */
       toHavePanelErrors(this: Matchers<unknown, DashboardPage>, count?: number): Promise<R>;
     }

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -58,6 +58,8 @@ import { toHaveChecked } from './matchers/toHaveChecked';
 import { MultiSelect } from './models/components/MultiSelect';
 import { toHaveColor } from './matchers/toHaveColor';
 import { ColorPicker } from './models/components/ColorPicker';
+import { toHavePanelErrors } from './matchers/toHavePanelErrors';
+import { DashboardPage } from './models/pages/DashboardPage';
 
 // models
 export { DataSourcePicker } from './models/components/DataSourcePicker';
@@ -134,6 +136,7 @@ export const expect = baseExpect.extend({
   toHaveChecked,
   toHaveColor,
   toHaveNoA11yViolations,
+  toHavePanelErrors,
 });
 
 export { selectors } from '@playwright/test';
@@ -218,6 +221,13 @@ declare global {
        * You can use this in conjunction with the .toHaveNoA11yViolations matcher to assert that there are no accessibility violations on the page.
        */
       toHaveNoA11yViolations(results: AxeResults, options?: A11yViolationsOptions): Promise<R>;
+
+      /**
+       * Asserts that a dashboard has panel errors. Omit `count` to assert at least one error.
+       * Pass `count` to assert exactly that many panels with errors.
+       * Use `.not.toHavePanelErrors()` to assert no panel errors.
+       */
+      toHavePanelErrors(this: Matchers<unknown, DashboardPage>, count?: number): Promise<R>;
     }
   }
 }

--- a/packages/plugin-e2e/src/matchers/toHavePanelErrors.test.ts
+++ b/packages/plugin-e2e/src/matchers/toHavePanelErrors.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { toHavePanelErrors } from './toHavePanelErrors';
+import { DashboardPage } from '../models/pages/DashboardPage';
+
+function createMockDashboard(errorCount: number): DashboardPage {
+  const mockLocator = {
+    count: vi.fn().mockResolvedValue(errorCount),
+  };
+
+  return {
+    getByGrafanaSelector: vi.fn().mockReturnValue(mockLocator),
+    ctx: {
+      selectors: {
+        components: {
+          Panels: {
+            Panel: {
+              status: vi.fn().mockReturnValue('data-testid Panel status error'),
+            },
+          },
+        },
+      },
+    },
+  } as unknown as DashboardPage;
+}
+
+describe('toHavePanelErrors', () => {
+  it('should pass when at least 1 error exists and no count given', async () => {
+    const dashboard = createMockDashboard(2);
+    const result = await toHavePanelErrors(dashboard);
+    expect(result.pass).toBe(true);
+  });
+
+  it('should fail when 0 errors and no count given', async () => {
+    const dashboard = createMockDashboard(0);
+    const result = await toHavePanelErrors(dashboard);
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain('0');
+  });
+
+  it('should pass when count matches exactly', async () => {
+    const dashboard = createMockDashboard(3);
+    const result = await toHavePanelErrors(dashboard, 3);
+    expect(result.pass).toBe(true);
+  });
+
+  it('should fail when count does not match', async () => {
+    const dashboard = createMockDashboard(2);
+    const result = await toHavePanelErrors(dashboard, 3);
+    expect(result.pass).toBe(false);
+    expect(result.message()).toContain('2');
+    expect(result.message()).toContain('3');
+  });
+
+  it('should pass when count is 0 and no errors exist', async () => {
+    const dashboard = createMockDashboard(0);
+    const result = await toHavePanelErrors(dashboard, 0);
+    expect(result.pass).toBe(true);
+  });
+});

--- a/packages/plugin-e2e/src/matchers/toHavePanelErrors.ts
+++ b/packages/plugin-e2e/src/matchers/toHavePanelErrors.ts
@@ -1,5 +1,8 @@
 import { DashboardPage } from '../models/pages/DashboardPage';
 
+/**
+ * @alpha - the API is not yet stable and may change without a major version bump. Use with caution.
+ */
 export const toHavePanelErrors = async (dashboard: DashboardPage, expectedCount?: number) => {
   const errorLocator = dashboard.getByGrafanaSelector(dashboard.ctx.selectors.components.Panels.Panel.status('error'));
   const count = await errorLocator.count();

--- a/packages/plugin-e2e/src/matchers/toHavePanelErrors.ts
+++ b/packages/plugin-e2e/src/matchers/toHavePanelErrors.ts
@@ -1,0 +1,15 @@
+import { DashboardPage } from '../models/pages/DashboardPage';
+
+export const toHavePanelErrors = async (dashboard: DashboardPage, expectedCount?: number) => {
+  const errorLocator = dashboard.getByGrafanaSelector(dashboard.ctx.selectors.components.Panels.Panel.status('error'));
+  const count = await errorLocator.count();
+  const pass = expectedCount === undefined ? count >= 1 : count === expectedCount;
+
+  return {
+    pass,
+    message: () =>
+      expectedCount === undefined
+        ? `Expected at least 1 panel with errors but found ${count}`
+        : `Expected exactly ${expectedCount} panel error(s) but found ${count}`,
+  };
+};

--- a/packages/plugin-e2e/src/models/components/Panel.ts
+++ b/packages/plugin-e2e/src/models/components/Panel.ts
@@ -67,6 +67,13 @@ export class Panel extends GrafanaPage {
   }
 
   /**
+   * Scrolls the panel into the viewport, triggering its query if not yet started.
+   */
+  async scrollIntoView(): Promise<void> {
+    await this.locator.scrollIntoViewIfNeeded();
+  }
+
+  /**
    * Returns the locator for the panel error (if any)
    */
   getErrorIcon(): Locator {

--- a/packages/plugin-e2e/src/models/components/Panel.ts
+++ b/packages/plugin-e2e/src/models/components/Panel.ts
@@ -83,12 +83,22 @@ export class Panel extends GrafanaPage {
       return;
     }
 
-    // slow path: lazy-rendered panel - scroll grid items until the panel element appears
+    // slow path: lazy-rendered panel - scroll grid items until the panel element appears.
+    // in Grafana 13.x with dashboardNewLayouts, .react-grid-item elements are not in the
+    // DOM immediately after navigation (~1-2s for the grid layout to render), so we wait
+    // for at least one to appear before iterating. the 500ms pause after each container
+    // matches scrollToRevealAllPanels: it gives IntersectionObserver time to fire and the
+    // VizPanel time to mount before we check.
     const containers = this.ctx.page.locator('.react-grid-item');
+    await containers
+      .first()
+      .waitFor({ state: 'attached', timeout: 5_000 })
+      .catch(() => {});
     const count = await containers.count();
     for (let i = 0; i < count; i++) {
       await containers.nth(i).scrollIntoViewIfNeeded();
-      if (await this.locator.isVisible({ timeout: 500 }).catch(() => false)) {
+      await this.ctx.page.waitForTimeout(500);
+      if (await this.locator.isVisible().catch(() => false)) {
         break;
       }
     }

--- a/packages/plugin-e2e/src/models/components/Panel.ts
+++ b/packages/plugin-e2e/src/models/components/Panel.ts
@@ -78,7 +78,7 @@ export class Panel extends GrafanaPage {
   async scrollIntoView(): Promise<void> {
     if (await this.locator.isVisible().catch(() => false)) {
       // element is already in the DOM - Playwright can scroll it into view directly
-      await this.locator.scrollIntoViewIfNeeded();
+      await this.locator.scrollIntoViewIfNeeded({ timeout: 5000 }).catch(() => {});
       return;
     }
     // panel not yet in DOM (Grafana 13.x lazy render) - scroll page viewport-by-viewport
@@ -98,7 +98,7 @@ export class Panel extends GrafanaPage {
       }
     }
     // element has mounted but may be above the current scroll position — bring it precisely into view
-    await this.locator.scrollIntoViewIfNeeded().catch(() => {});
+    await this.locator.scrollIntoViewIfNeeded({ timeout: 5000 }).catch(() => {});
   }
 
   /**

--- a/packages/plugin-e2e/src/models/components/Panel.ts
+++ b/packages/plugin-e2e/src/models/components/Panel.ts
@@ -77,11 +77,12 @@ export class Panel extends GrafanaPage {
    */
   async scrollIntoView(): Promise<void> {
     if (await this.locator.isVisible().catch(() => false)) {
+      // element is already in the DOM - Playwright can scroll it into view directly
+      await this.locator.scrollIntoViewIfNeeded();
       return;
     }
-    // panel not yet visible - scroll page viewport-by-viewport until it appears
-    // (in Grafana 13.x scenes, VizPanel content isn't mounted until the grid container
-    // enters the viewport, so the locator element won't exist in the DOM until then)
+    // panel not yet in DOM (Grafana 13.x lazy render) - scroll page viewport-by-viewport
+    // until the element mounts, then scroll it precisely into view
     const viewportHeight = await this.ctx.page.evaluate(() => window.innerHeight);
     let scrollY = 0;
     while (true) {
@@ -96,6 +97,8 @@ export class Panel extends GrafanaPage {
         break;
       }
     }
+    // element has mounted but may be above the current scroll position — bring it precisely into view
+    await this.locator.scrollIntoViewIfNeeded().catch(() => {});
   }
 
   /**

--- a/packages/plugin-e2e/src/models/components/Panel.ts
+++ b/packages/plugin-e2e/src/models/components/Panel.ts
@@ -71,39 +71,31 @@ export class Panel extends GrafanaPage {
    *
    * In Grafana 13.x+ with scenes, panels are lazy-rendered: the panel element does not
    * exist in the DOM until its grid container enters the viewport. This method scrolls
-   * `.react-grid-item` containers progressively until the panel element appears, then
-   * scrolls the panel element precisely into view. In older Grafana versions the panel
-   * element is always in the DOM, so the loop exits early and delegates to the standard
-   * scroll path.
+   * the page viewport-by-viewport until the panel element appears, then returns. The
+   * 500ms pause per step gives IntersectionObserver time to fire and the VizPanel time
+   * to mount before checking visibility.
    */
   async scrollIntoView(): Promise<void> {
-    // fast path: panel already in DOM (eager render or already in viewport)
-    if (await this.locator.isVisible({ timeout: 500 }).catch(() => false)) {
-      await this.locator.scrollIntoViewIfNeeded();
+    if (await this.locator.isVisible().catch(() => false)) {
       return;
     }
-
-    // slow path: lazy-rendered panel - scroll grid items until the panel element appears.
-    // in Grafana 13.x with dashboardNewLayouts, .react-grid-item elements are not in the
-    // DOM immediately after navigation (~1-2s for the grid layout to render), so we wait
-    // for at least one to appear before iterating. the 500ms pause after each container
-    // matches scrollToRevealAllPanels: it gives IntersectionObserver time to fire and the
-    // VizPanel time to mount before we check.
-    const containers = this.ctx.page.locator('.react-grid-item');
-    await containers
-      .first()
-      .waitFor({ state: 'attached', timeout: 5_000 })
-      .catch(() => {});
-    const count = await containers.count();
-    for (let i = 0; i < count; i++) {
-      await containers.nth(i).scrollIntoViewIfNeeded();
+    // panel not yet visible - scroll page viewport-by-viewport until it appears
+    // (in Grafana 13.x scenes, VizPanel content isn't mounted until the grid container
+    // enters the viewport, so the locator element won't exist in the DOM until then)
+    const viewportHeight = await this.ctx.page.evaluate(() => window.innerHeight);
+    let scrollY = 0;
+    while (true) {
+      const scrollHeight = await this.ctx.page.evaluate(() => document.documentElement.scrollHeight);
+      if (scrollY >= scrollHeight) {
+        break;
+      }
+      scrollY = Math.min(scrollY + viewportHeight, scrollHeight);
+      await this.ctx.page.evaluate((y) => window.scrollTo(0, y), scrollY);
       await this.ctx.page.waitForTimeout(500);
       if (await this.locator.isVisible().catch(() => false)) {
         break;
       }
     }
-
-    await this.locator.scrollIntoViewIfNeeded();
   }
 
   /**

--- a/packages/plugin-e2e/src/models/components/Panel.ts
+++ b/packages/plugin-e2e/src/models/components/Panel.ts
@@ -68,8 +68,31 @@ export class Panel extends GrafanaPage {
 
   /**
    * Scrolls the panel into the viewport, triggering its query if not yet started.
+   *
+   * In Grafana 13.x+ with scenes, panels are lazy-rendered: the panel element does not
+   * exist in the DOM until its grid container enters the viewport. This method scrolls
+   * `.react-grid-item` containers progressively until the panel element appears, then
+   * scrolls the panel element precisely into view. In older Grafana versions the panel
+   * element is always in the DOM, so the loop exits early and delegates to the standard
+   * scroll path.
    */
   async scrollIntoView(): Promise<void> {
+    // fast path: panel already in DOM (eager render or already in viewport)
+    if (await this.locator.isVisible({ timeout: 500 }).catch(() => false)) {
+      await this.locator.scrollIntoViewIfNeeded();
+      return;
+    }
+
+    // slow path: lazy-rendered panel - scroll grid items until the panel element appears
+    const containers = this.ctx.page.locator('.react-grid-item');
+    const count = await containers.count();
+    for (let i = 0; i < count; i++) {
+      await containers.nth(i).scrollIntoViewIfNeeded();
+      if (await this.locator.isVisible({ timeout: 500 }).catch(() => false)) {
+        break;
+      }
+    }
+
     await this.locator.scrollIntoViewIfNeeded();
   }
 

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -55,25 +55,25 @@ export class DashboardPage extends GrafanaPage {
   }
 
   /**
-   * Scrolls each panel container into view so that below-fold panels have their queries triggered.
-   * Targets .react-grid-item containers (present in the DOM before VizPanel renders) rather
-   * than panel title/content elements which only exist after lazy rendering. Playwright's native
-   * scrollIntoViewIfNeeded finds the correct scroll container automatically across Grafana versions.
+   * Scrolls the page viewport-by-viewport to trigger below-fold panel queries.
    *
-   * In Grafana 13.x with dashboardNewLayouts, the grid renders asynchronously after navigation
-   * (~1-2s), so we wait for the first container to appear before iterating.
+   * In Grafana 13.x with scenes, panels are lazy-rendered: VizPanel content isn't mounted
+   * until the grid container enters the viewport. Scrolling by viewport height ensures
+   * IntersectionObserver fires for each row before moving on. The 500ms pause is required
+   * for the observer to fire and lazy panels to initiate their queries.
    */
   private async scrollToRevealAllPanels(): Promise<void> {
-    const containers = this.ctx.page.locator('.react-grid-item');
-    await containers
-      .first()
-      .waitFor({ state: 'attached', timeout: 5_000 })
-      .catch(() => {});
-    const count = await containers.count();
+    const viewportHeight = await this.ctx.page.evaluate(() => window.innerHeight);
+    let scrollY = 0;
 
-    for (let i = 0; i < count; i++) {
-      await containers.nth(i).scrollIntoViewIfNeeded();
-      // allow IntersectionObserver to fire and lazy-rendered panels to mount and start queries
+    while (true) {
+      const scrollHeight = await this.ctx.page.evaluate(() => document.documentElement.scrollHeight);
+      if (scrollY >= scrollHeight) {
+        break;
+      }
+      scrollY = Math.min(scrollY + viewportHeight, scrollHeight);
+      await this.ctx.page.evaluate((y) => window.scrollTo(0, y), scrollY);
+      // 500ms allows IntersectionObserver to fire and lazy-rendered panels to mount and start queries
       await this.ctx.page.waitForTimeout(500);
     }
   }

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -84,6 +84,8 @@ export class DashboardPage extends GrafanaPage {
    * By default only waits for queries already triggered (panels in the viewport at navigation
    * time or explicitly scrolled into view). Pass `scrollAll: true` to first scroll the full
    * dashboard so that below-fold panels are also triggered before waiting.
+   *
+   * @alpha - the API is not yet stable and may change without a major version bump. Use with caution.
    */
   async waitForPanelsQueriesToComplete({
     timeout = 30_000,

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -55,26 +55,17 @@ export class DashboardPage extends GrafanaPage {
   }
 
   /**
-   * Scrolls the full dashboard height so that below-fold panels have their queries triggered.
-   * Uses document.documentElement.scrollTop because Chrome propagates body's overflow:auto to
-   * the document root — body.scrollTop is effectively read-only in this configuration.
+   * Scrolls each panel container into view so that below-fold panels have their queries triggered.
+   * Targets .react-grid-item containers (always in the DOM, even before VizPanel renders) rather
+   * than panel title/content elements which only exist after lazy rendering. Playwright's native
+   * scrollIntoViewIfNeeded finds the correct scroll container automatically across Grafana versions.
    */
   private async scrollToRevealAllPanels(): Promise<void> {
-    const viewportHeight = await this.ctx.page.evaluate(() => window.innerHeight);
+    const containers = this.ctx.page.locator('.react-grid-item');
+    const count = await containers.count();
 
-    for (let i = 0; i < 20; i++) {
-      const { scrollTop, scrollHeight } = await this.ctx.page.evaluate(() => ({
-        scrollTop: document.documentElement.scrollTop,
-        scrollHeight: document.documentElement.scrollHeight,
-      }));
-      const maxScrollTop = Math.max(0, scrollHeight - viewportHeight);
-      if (scrollTop >= maxScrollTop) {
-        break;
-      }
-      const nextScrollTop = Math.min(scrollTop + viewportHeight, maxScrollTop);
-      await this.ctx.page.evaluate((y) => {
-        document.documentElement.scrollTop = y;
-      }, nextScrollTop);
+    for (let i = 0; i < count; i++) {
+      await containers.nth(i).scrollIntoViewIfNeeded();
       // allow IntersectionObserver to fire and lazy-rendered panels to mount and start queries
       await this.ctx.page.waitForTimeout(500);
     }

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -56,12 +56,19 @@ export class DashboardPage extends GrafanaPage {
 
   /**
    * Scrolls each panel container into view so that below-fold panels have their queries triggered.
-   * Targets .react-grid-item containers (always in the DOM, even before VizPanel renders) rather
+   * Targets .react-grid-item containers (present in the DOM before VizPanel renders) rather
    * than panel title/content elements which only exist after lazy rendering. Playwright's native
    * scrollIntoViewIfNeeded finds the correct scroll container automatically across Grafana versions.
+   *
+   * In Grafana 13.x with dashboardNewLayouts, the grid renders asynchronously after navigation
+   * (~1-2s), so we wait for the first container to appear before iterating.
    */
   private async scrollToRevealAllPanels(): Promise<void> {
     const containers = this.ctx.page.locator('.react-grid-item');
+    await containers
+      .first()
+      .waitFor({ state: 'attached', timeout: 5_000 })
+      .catch(() => {});
     const count = await containers.count();
 
     for (let i = 0; i < count; i++) {

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -1,4 +1,5 @@
 import * as semver from 'semver';
+import { expect } from '@playwright/test';
 import { DashboardPageArgs, NavigateOptions, PluginTestCtx } from '../../types';
 import { DataSourcePicker } from '../components/DataSourcePicker';
 import { GrafanaPage } from './GrafanaPage';
@@ -11,6 +12,8 @@ import { resolveGrafanaSelector } from '../utils';
 export class DashboardPage extends GrafanaPage {
   dataSourcePicker: any;
   timeRange: TimeRange;
+  private pendingQueryCount = 0;
+  private hasSeenQuery = false;
 
   constructor(
     readonly ctx: PluginTestCtx,
@@ -25,6 +28,19 @@ export class DashboardPage extends GrafanaPage {
    * Navigates to the dashboard page. If a dashboard uid was not provided, it's assumed that it's a new dashboard.
    */
   async goto(options: NavigateOptions = {}) {
+    // arm listeners before navigation to capture responses from panels that load instantly
+    this.ctx.page.on('request', (req) => {
+      if (req.url().includes(this.ctx.selectors.apis.DataSource.query)) {
+        this.pendingQueryCount++;
+        this.hasSeenQuery = true;
+      }
+    });
+    this.ctx.page.on('response', (res) => {
+      if (res.url().includes(this.ctx.selectors.apis.DataSource.query)) {
+        this.pendingQueryCount = Math.max(0, this.pendingQueryCount - 1);
+      }
+    });
+
     let url = this.dashboard?.uid
       ? this.ctx.selectors.pages.Dashboard.url(this.dashboard.uid)
       : this.ctx.selectors.pages.AddDashboard.url;
@@ -36,6 +52,60 @@ export class DashboardPage extends GrafanaPage {
     }
 
     return super.navigate(url, options);
+  }
+
+  /**
+   * Scrolls the full dashboard height so that below-fold panels have their queries triggered.
+   * Uses document.documentElement.scrollTop because Chrome propagates body's overflow:auto to
+   * the document root — body.scrollTop is effectively read-only in this configuration.
+   */
+  private async scrollToRevealAllPanels(): Promise<void> {
+    const viewportHeight = await this.ctx.page.evaluate(() => window.innerHeight);
+
+    for (let i = 0; i < 20; i++) {
+      const { scrollTop, scrollHeight } = await this.ctx.page.evaluate(() => ({
+        scrollTop: document.documentElement.scrollTop,
+        scrollHeight: document.documentElement.scrollHeight,
+      }));
+      const maxScrollTop = Math.max(0, scrollHeight - viewportHeight);
+      if (scrollTop >= maxScrollTop) {
+        break;
+      }
+      const nextScrollTop = Math.min(scrollTop + viewportHeight, maxScrollTop);
+      await this.ctx.page.evaluate((y) => {
+        document.documentElement.scrollTop = y;
+      }, nextScrollTop);
+      // allow IntersectionObserver to fire and lazy-rendered panels to mount and start queries
+      await this.ctx.page.waitForTimeout(500);
+    }
+  }
+
+  /**
+   * Waits until all initiated panel queries have received responses.
+   *
+   * By default only waits for queries already triggered (panels in the viewport at navigation
+   * time or explicitly scrolled into view). Pass `scrollAll: true` to first scroll the full
+   * dashboard so that below-fold panels are also triggered before waiting.
+   */
+  async waitForPanelsQueriesToComplete({
+    timeout = 30_000,
+    scrollAll = false,
+  }: { timeout?: number; scrollAll?: boolean } = {}): Promise<void> {
+    // brief grace period for the first query to initiate on slow CI machines
+    await expect
+      .poll(() => this.hasSeenQuery, { timeout: 2_000 })
+      .toBe(true)
+      .catch(() => {}); // dashboards with no data source panels are valid
+
+    // wait for the initially-visible panels to settle before scrolling; Grafana resets
+    // the scroll position during initial layout, so scrolling too early has no effect
+    await expect.poll(() => this.pendingQueryCount === 0, { timeout }).toBe(true);
+
+    if (scrollAll) {
+      await this.scrollToRevealAllPanels();
+      // wait for newly-revealed below-fold panel queries to complete
+      await expect.poll(() => this.pendingQueryCount === 0, { timeout }).toBe(true);
+    }
   }
 
   /**

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
@@ -32,23 +32,14 @@ test.describe('dashboard smoke tests', () => {
     // scrollAll scrolls the full page so bottom row queries are also captured
     await dashboard.waitForPanelsQueriesToComplete({ scrollAll: true });
     await expect(dashboard).not.toHavePanelErrors();
-
-    // explicitly scroll to the bottom panel — some Grafana versions reset the scroll
-    // position after queries complete, potentially unmounting it from the DOM
-    await bottomLeft.scrollIntoView();
-    await expect(bottomLeft.locator).toBeVisible();
   });
 
   test('manually scrolling a below-fold panel into view triggers its query', async ({ gotoDashboardPage }) => {
     const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
 
-    // "Lower Right" (y=16) is below the fold at 1280x720; in Grafana 13.x scenes the
-    // panel element is lazy-rendered, so Panel.scrollIntoView() must find the grid
-    // container first before the title element exists in the DOM
+    // "Lower Right" (y=16) is below the fold at 1280x720
     const lowerRight = dashboard.getPanelByTitle('Lower Right');
     await lowerRight.scrollIntoView();
-    await expect(lowerRight.locator).toBeInViewport();
-
     await dashboard.waitForPanelsQueriesToComplete();
     await expect(dashboard).not.toHavePanelErrors();
   });

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
@@ -25,7 +25,7 @@ test.describe('dashboard smoke tests', () => {
     const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
 
     // without scrollAll the bottom row panels are not in viewport and their
-    // queries have not fired yet — verify they have no data rendered
+    // queries have not fired yet — verify they are not yet visible
     const bottomLeft = dashboard.getPanelByTitle('Bottom Left');
     await expect(bottomLeft.locator).not.toBeInViewport();
 
@@ -33,8 +33,10 @@ test.describe('dashboard smoke tests', () => {
     await dashboard.waitForPanelsQueriesToComplete({ scrollAll: true });
     await expect(dashboard).not.toHavePanelErrors();
 
-    // after scrollAll the bottom panels have been scrolled into view
-    await expect(bottomLeft.locator).toBeInViewport();
+    // after scrollAll the bottom panel should have been scrolled into view and rendered
+    // (use toBeVisible rather than toBeInViewport — some Grafana versions reset the
+    // scroll position after queries complete, making viewport assertions unreliable)
+    await expect(bottomLeft.locator).toBeVisible();
   });
 
   test('manually scrolling a below-fold panel into view triggers its query', async ({ gotoDashboardPage }) => {

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
@@ -40,8 +40,9 @@ test.describe('dashboard smoke tests', () => {
   test('manually scrolling a below-fold panel into view triggers its query', async ({ gotoDashboardPage }) => {
     const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
 
-    // "Lower Right" (y=16) is always in the DOM but below the fold at 1280x720 —
-    // use it here because y=40 panels are lazy-rendered and not yet in the DOM
+    // "Lower Right" (y=16) is below the fold at 1280x720; in Grafana 13.x scenes the
+    // panel element is lazy-rendered, so Panel.scrollIntoView() must find the grid
+    // container first before the title element exists in the DOM
     const lowerRight = dashboard.getPanelByTitle('Lower Right');
     await lowerRight.scrollIntoView();
     await expect(lowerRight.locator).toBeInViewport();

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
@@ -1,4 +1,3 @@
-import * as semver from 'semver';
 import { expect, test } from '../../../src';
 
 test.describe.configure({ mode: 'parallel' });
@@ -22,14 +21,7 @@ test.describe('dashboard smoke tests', () => {
     await expect(dashboard).not.toHavePanelErrors();
   });
 
-  test('scrollAll reaches below-fold panels — bottom row receives query responses', async ({
-    gotoDashboardPage,
-    grafanaVersion,
-  }) => {
-    // the scroll mechanism relies on document.documentElement.scrollTop which behaves
-    // differently in pre-scenes Grafana — skip the viewport assertions on older versions
-    test.skip(semver.lt(grafanaVersion, '9.5.0'), 'viewport-based scroll not supported in this Grafana version');
-
+  test('scrollAll reaches below-fold panels — bottom row receives query responses', async ({ gotoDashboardPage }) => {
     const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
 
     // without scrollAll the bottom row panels are not in viewport and their

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
@@ -1,3 +1,4 @@
+import * as semver from 'semver';
 import { expect, test } from '../../../src';
 
 test.describe.configure({ mode: 'parallel' });
@@ -21,7 +22,14 @@ test.describe('dashboard smoke tests', () => {
     await expect(dashboard).not.toHavePanelErrors();
   });
 
-  test('scrollAll reaches below-fold panels — bottom row receives query responses', async ({ gotoDashboardPage }) => {
+  test('scrollAll reaches below-fold panels — bottom row receives query responses', async ({
+    gotoDashboardPage,
+    grafanaVersion,
+  }) => {
+    // the scroll mechanism relies on document.documentElement.scrollTop which behaves
+    // differently in pre-scenes Grafana — skip the viewport assertions on older versions
+    test.skip(semver.lt(grafanaVersion, '9.5.0'), 'viewport-based scroll not supported in this Grafana version');
+
     const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
 
     // without scrollAll the bottom row panels are not in viewport and their

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
@@ -33,9 +33,9 @@ test.describe('dashboard smoke tests', () => {
     await dashboard.waitForPanelsQueriesToComplete({ scrollAll: true });
     await expect(dashboard).not.toHavePanelErrors();
 
-    // after scrollAll the bottom panel should have been scrolled into view and rendered
-    // (use toBeVisible rather than toBeInViewport — some Grafana versions reset the
-    // scroll position after queries complete, making viewport assertions unreliable)
+    // explicitly scroll to the bottom panel — some Grafana versions reset the scroll
+    // position after queries complete, potentially unmounting it from the DOM
+    await bottomLeft.scrollIntoView();
     await expect(bottomLeft.locator).toBeVisible();
   });
 

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/dashboardSmoke.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '../../../src';
+
+test.describe.configure({ mode: 'parallel' });
+
+// smoke-test-dashboard has 10 panels in 5 rows:
+// row 1 (y=0):  "Top Left",    "Top Right"    — in viewport at all tested resolutions
+// row 2 (y=8):  "Middle Left", "Middle Right" — partially in viewport at 1280x720
+// row 3 (y=16): "Lower Left",  "Lower Right"  — below fold at 1280x720
+// row 4 (y=24): "Deep Left",   "Deep Right"   — below fold at 1280x720
+// row 5 (y=40): "Bottom Left", "Bottom Right" — below fold at all tested resolutions (including 1920x1080)
+test.describe('dashboard smoke tests', () => {
+  test('all visible panels complete without errors', async ({ gotoDashboardPage }) => {
+    const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
+    await dashboard.waitForPanelsQueriesToComplete();
+    await expect(dashboard).not.toHavePanelErrors();
+  });
+
+  test('scrollAll triggers below-fold panels and all complete without errors', async ({ gotoDashboardPage }) => {
+    const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
+    await dashboard.waitForPanelsQueriesToComplete({ scrollAll: true });
+    await expect(dashboard).not.toHavePanelErrors();
+  });
+
+  test('scrollAll reaches below-fold panels — bottom row receives query responses', async ({ gotoDashboardPage }) => {
+    const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
+
+    // without scrollAll the bottom row panels are not in viewport and their
+    // queries have not fired yet — verify they have no data rendered
+    const bottomLeft = dashboard.getPanelByTitle('Bottom Left');
+    await expect(bottomLeft.locator).not.toBeInViewport();
+
+    // scrollAll scrolls the full page so bottom row queries are also captured
+    await dashboard.waitForPanelsQueriesToComplete({ scrollAll: true });
+    await expect(dashboard).not.toHavePanelErrors();
+
+    // after scrollAll the bottom panels have been scrolled into view
+    await expect(bottomLeft.locator).toBeInViewport();
+  });
+
+  test('manually scrolling a below-fold panel into view triggers its query', async ({ gotoDashboardPage }) => {
+    const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
+
+    // "Lower Right" (y=16) is always in the DOM but below the fold at 1280x720 —
+    // use it here because y=40 panels are lazy-rendered and not yet in the DOM
+    const lowerRight = dashboard.getPanelByTitle('Lower Right');
+    await lowerRight.scrollIntoView();
+    await expect(lowerRight.locator).toBeInViewport();
+
+    await dashboard.waitForPanelsQueriesToComplete();
+    await expect(dashboard).not.toHavePanelErrors();
+  });
+
+  test('toHavePanelErrors detects the correct number of panel errors', async ({ gotoDashboardPage }) => {
+    // the smoke-test-dashboard uses a healthy data source — zero errors expected
+    const dashboard = await gotoDashboardPage({ uid: 'smoke-test-dashboard' });
+    await dashboard.waitForPanelsQueriesToComplete({ scrollAll: true });
+
+    await expect(dashboard).not.toHavePanelErrors();
+    await expect(dashboard).toHavePanelErrors(0);
+  });
+});


### PR DESCRIPTION
**What this PR does / why we need it**:

`@grafana/plugin-e2e` had no way to assert that a dashboard's panels complete their queries or are free of errors. This PR adds a minimal smoke testing API that works for any dashboard — loaded by UID, created dynamically in a test, or provisioned alongside a plugin:

```ts
test('dashboard loads without errors', async ({ gotoDashboardPage }) => {
  const dashboard = await gotoDashboardPage({ uid: 'my-dashboard' });
  await dashboard.waitForPanelsQueriesToComplete({ scrollAll: true });
  await expect(dashboard).not.toHavePanelErrors();
});
```

Three additions to the public API:

- `DashboardPage.waitForPanelsQueriesToComplete({ scrollAll?, timeout? })` — waits until all initiated `/api/ds/query` requests have received responses. With `scrollAll: true` it first scrolls the full dashboard so that below-fold panels are triggered before waiting.
- `Panel.scrollIntoView()` — scrolls a specific panel into the viewport, triggering its query if not yet started.
- `expect(dashboard).toHavePanelErrors(count?)` — asserts the number of panels showing an error state. Omit `count` for "at least one", pass `0` or use `.not.toHavePanelErrors()` for zero errors.

**Which issue(s) this PR fixes**:

Fixes #2587

**Special notes for your reviewer**:

The network recorder (`pendingQueryCount` / `hasSeenQuery`) is armed in `goto()` before navigation so that fast-loading panels whose responses arrive before any assertion are still captured.

Grafana resets the scroll position during initial layout, so `waitForPanelsQueriesToComplete` always settles the initially-visible queries first before triggering the optional scroll pass — scrolling too early has no effect.

The `scrollAll` implementation uses `document.documentElement.scrollTop` directly. Chrome propagates `body`'s `overflow:auto` to the document root, making `body.scrollTop` read-only in this configuration; and `window.scrollTo` triggers CSS smooth scrolling which is asynchronous and unreliable in tests.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@7.2.0-canary.2586.24882884910.0
  npm install @grafana/plugin-e2e@3.6.0-canary.2586.24882884910.0
  # or 
  yarn add @grafana/create-plugin@7.2.0-canary.2586.24882884910.0
  yarn add @grafana/plugin-e2e@3.6.0-canary.2586.24882884910.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
