### PR TITLE
Plugin E2E: stabilize preference and permission test flakes on nightly builds

### DIFF
--- a/packages/plugin-e2e/tests/as-admin-user/preferences/defaults.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/preferences/defaults.spec.ts
@@ -19,8 +19,8 @@ test.describe('default user preferences', () => {
   test('should use dark theme', async ({ page, grafanaVersion }) => {
     test.skip(semver.lt(grafanaVersion, '11.0.0'), 'User preferences are only supported in Grafana 11 and later');
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
     const header = page.getByRole('banner');
-    await expect(header).toHaveCSS('background-color', 'rgb(24, 27, 31)', { timeout: 10_000 });
+    await expect(header).toBeVisible({ timeout: 10_000 });
+    await expect(header).toHaveCSS('background-color', 'rgb(24, 27, 31)');
   });
 });

--- a/packages/plugin-e2e/tests/as-admin-user/preferences/defaults.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/preferences/defaults.spec.ts
@@ -12,13 +12,15 @@ test.describe('default user preferences', () => {
   test('should use English language on profile page', async ({ grafanaVersion, page }) => {
     test.skip(semver.lt(grafanaVersion, '11.0.0'), 'User preferences are only supported in Grafana 11 and later');
     await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible({ timeout: 10_000 });
   });
 
   test('should use dark theme', async ({ page, grafanaVersion }) => {
     test.skip(semver.lt(grafanaVersion, '11.0.0'), 'User preferences are only supported in Grafana 11 and later');
     await page.goto('/');
+    await page.waitForLoadState('networkidle');
     const header = page.getByRole('banner');
-    await expect(header).toHaveCSS('background-color', 'rgb(24, 27, 31)');
+    await expect(header).toHaveCSS('background-color', 'rgb(24, 27, 31)', { timeout: 10_000 });
   });
 });

--- a/packages/plugin-e2e/tests/as-admin-user/preferences/overrideDefaults.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/preferences/overrideDefaults.spec.ts
@@ -23,8 +23,8 @@ test.describe('override user preferences', () => {
   test('should use light theme', async ({ page, grafanaVersion }) => {
     test.skip(semver.lt(grafanaVersion, '11.0.0'), 'User preferences are only supported in Grafana 11 and later');
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
     const header = page.getByRole('banner');
-    await expect(header).toHaveCSS('background-color', 'rgb(255, 255, 255)', { timeout: 10_000 });
+    await expect(header).toBeVisible({ timeout: 10_000 });
+    await expect(header).toHaveCSS('background-color', 'rgb(255, 255, 255)');
   });
 });

--- a/packages/plugin-e2e/tests/as-admin-user/preferences/overrideDefaults.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/preferences/overrideDefaults.spec.ts
@@ -16,13 +16,15 @@ test.describe('override user preferences', () => {
   test('should use Spanish language on profile page', async ({ page, grafanaVersion }) => {
     test.skip(semver.lt(grafanaVersion, '11.0.0'), 'User preferences are only supported in Grafana 11 and later');
     await page.goto('/profile');
-    await expect(page.getByRole('heading', { name: 'Perfil' })).toBeVisible();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('heading', { name: 'Perfil' })).toBeVisible({ timeout: 10_000 });
   });
 
   test('should use light theme', async ({ page, grafanaVersion }) => {
     test.skip(semver.lt(grafanaVersion, '11.0.0'), 'User preferences are only supported in Grafana 11 and later');
     await page.goto('/');
+    await page.waitForLoadState('networkidle');
     const header = page.getByRole('banner');
-    await expect(header).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+    await expect(header).toHaveCSS('background-color', 'rgb(255, 255, 255)', { timeout: 10_000 });
   });
 });

--- a/packages/plugin-e2e/tests/as-viewer-user/overridePermissions.spec.ts
+++ b/packages/plugin-e2e/tests/as-viewer-user/overridePermissions.spec.ts
@@ -5,5 +5,5 @@ test.use({ storageState: 'playwright/.auth/admin.json', user: { user: 'admin', p
 
 test('should not redirect to start page when permissions to navigate to page is exist', async ({ page }) => {
   await page.goto('/datasources', { waitUntil: 'networkidle' });
-  await expect(page).toHaveURL(/\/datasources/, { timeout: 10_000 });
+  await expect(page).toHaveURL(/\/datasources$/, { timeout: 10_000 });
 });

--- a/packages/plugin-e2e/tests/as-viewer-user/overridePermissions.spec.ts
+++ b/packages/plugin-e2e/tests/as-viewer-user/overridePermissions.spec.ts
@@ -5,5 +5,5 @@ test.use({ storageState: 'playwright/.auth/admin.json', user: { user: 'admin', p
 
 test('should not redirect to start page when permissions to navigate to page is exist', async ({ page }) => {
   await page.goto('/datasources', { waitUntil: 'networkidle' });
-  expect(await page.title()).toMatch(/Data sources.*/);
+  await expect(page).toHaveURL(/\/datasources/, { timeout: 10_000 });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

Three E2E tests in `@grafana/plugin-e2e`'s own test suite have been failing intermittently on nightly Grafana builds (`grafana-dev`) and `grafana-enterprise@12.1.10`. The failures were caused by fragile assertions that didn't account for the React app still rendering when assertions ran.

- `overridePermissions.spec.ts`: replaced a `page.title()` string match (`/Data sources.*/`) with a URL assertion (`toHaveURL(/\/datasources/)`). The page title format changed in recent nightly builds but the URL is stable.
- `preferences/defaults.spec.ts` and `preferences/overrideDefaults.spec.ts`: added `page.waitForLoadState('networkidle')` after each `page.goto` call and bumped assertion timeouts to 10s. On slow CI machines and nightly builds the Profile heading and nav banner weren't fully rendered within the previous 5s default.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

No functional changes — only test stability improvements.