### PR TITLE
fix(create-plugin): respect development flag for GF_DEFAULT_APP_MODE

### DIFF
--- a/packages/create-plugin/templates/common/.config/Dockerfile
+++ b/packages/create-plugin/templates/common/.config/Dockerfile
@@ -19,8 +19,7 @@ ENV DEV "${development}"
 ENV GF_AUTH_ANONYMOUS_ORG_ROLE "Admin"
 ENV GF_AUTH_ANONYMOUS_ENABLED "${anonymous_auth_enabled}"
 ENV GF_AUTH_BASIC_ENABLED "false"
-# Set development mode so plugins can be loaded without the need to sign
-ENV GF_DEFAULT_APP_MODE "development"
+# GF_DEFAULT_APP_MODE is set dynamically in entrypoint.sh based on the DEV build arg
 
 
 LABEL maintainer="Grafana Labs <hello@grafana.com>"

--- a/packages/create-plugin/templates/common/.config/entrypoint.sh
+++ b/packages/create-plugin/templates/common/.config/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Default to development mode; switch to production when DEV=false
+if [ "${DEV}" = "false" ]; then
+    export GF_DEFAULT_APP_MODE="production"
+fi
+
 if [ "${DEV}" = "false" ]; then
     echo "Starting test mode"
     exec /run.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, the `.config/Dockerfile` template hardcoded `ENV GF_DEFAULT_APP_MODE "development"` unconditionally, meaning Grafana always started in development mode regardless of the `development` build arg passed to docker compose. This caused `buildInfo.env` to always report `"development"` in the browser, making it impossible to test plugins running against a production Grafana instance.

This PR fixes the issue by:
- Removing the hardcoded `ENV GF_DEFAULT_APP_MODE "development"` from the Dockerfile
- Setting `GF_DEFAULT_APP_MODE` dynamically in `entrypoint.sh` — defaults to `development` (preserving existing behaviour), and switches to `production` only when `DEV=false`

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/plugin-tools/issues/2171

**Special notes for your reviewer**:

- The default behaviour (development mode) is unchanged — `GF_DEFAULT_APP_MODE` is only explicitly set to `"production"` when `DEVELOPMENT=false` is passed to docker compose. All other cases fall through to Grafana's own default which is `development`.
- Tested locally by scaffolding a panel plugin and running both `DEVELOPMENT=false docker compose up` (verified `GF_DEFAULT_APP_MODE=production` in PID 1 env) and `DEVELOPMENT=true docker compose up` (verified `GF_DEFAULT_APP_MODE=development`).