### PR TITLE
ci: add issue messages to stalebot 

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,11 +16,20 @@ jobs:
           days-before-close: 14
           # Number of days of inactivity before an Issue or Pull Request becomes stale
           days-before-stale: 90
-          exempt-issue-labels: no stalebot
+          exempt-issue-labels: 'no stalebot,bug,pinned,help-wanted,good-first-issue,confirmed'
           exempt-pr-labels: no stalebot
           operations-per-run: 100
           stale-issue-label: stale
           stale-pr-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last 90 days. It will be closed in 14 days if no further
+            activity occurs. If this is still relevant, please leave a comment or remove
+            the stale label. Thank you for your contribution!
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity. If this is still
+            relevant, please reopen it and provide any additional context. Thank you for
+            your contribution!
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had
             activity in the last 90 days. It will be closed in 2 weeks if no further activity occurs. Please


### PR DESCRIPTION
## Summary

- Adds `stale-issue-message` so issues get a comment when marked stale (previously silent)
- Adds `close-issue-message` so issues get a comment when auto-closed (previously silent)
- Expands `exempt-issue-labels` from just `no stalebot` to also cover `bug`, `pinned`, `help-wanted`, `good-first-issue`, and `confirmed`

Fixes the hostile experience reported in #2310 and #2364 where stalebot was closing issues with zero notification.

PR timings (`days-before-stale: 90`, `days-before-close: 14`) and PR messages are unchanged.

## Test plan

- [ ] Confirm workflow YAML is valid (no syntax errors)
- [ ] After merge, verify the next stale run posts a comment on issues it marks stale
- [ ] Verify issues labelled `bug`, `help-wanted`, etc. are no longer touched by the bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)