### PR TITLE
Create Plugin: Add validate-docs workflow to scaffolded plugins

### DIFF
--- a/packages/create-plugin/templates/github/workflows/validate-docs.yml
+++ b/packages/create-plugin/templates/github/workflows/validate-docs.yml
@@ -1,0 +1,43 @@
+{{!-- /* This comment is removed after scaffolding */ --}}
+name: Validate documentation
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'docs/**'
+      - 'src/plugin.json'
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - 'docs/**'
+      - 'src/plugin.json'
+
+jobs:
+  validate:
+    name: Validate plugin docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Validate plugin documentation
+        run: |
+          DOCS_PATH=$(jq -r '.docsPath // empty' src/plugin.json)
+          if [ -z "$DOCS_PATH" ]; then
+            echo "docsPath not set in src/plugin.json, skipping"
+            exit 0
+          fi
+          npx --yes @grafana/plugin-docs-cli validate --strict


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `validate-docs.yml` GitHub Actions workflow to the `create-plugin` scaffolding. The workflow runs `@grafana/plugin-docs-cli validate --strict` on PRs and pushes that touch `docs/**` or `src/plugin.json`, giving plugin authors early feedback on documentation errors before they reach the release pipeline.

The workflow is a no-op for plugins that don't have `docsPath` set in `plugin.json`, so all newly scaffolded plugins can safely include it without any impact on existing workflows. The `paths:` trigger ensures it only runs when docs actually change.

**Which issue(s) this PR fixes**:

No issue — part of the multi-page plugin docs initiative.

**Special notes for your reviewer**:

Pair with grafana/plugin-actions#219, which adds the docs build step to the release pipeline.

Assumption: `docsPath` is conventionally `docs`. Plugins using a different folder name would need to update the `paths:` filter in the workflow file.