### PR TITLE
fix: override moduleResolution in scaffolded ts-node config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           mkdir ./packed-artifacts
           npm version patch --workspace="@grafana/create-plugin" --commit-hooks=false --git-tag-version=false
-          npm pack --workspace="@grafana/create-plugin" --workspace="@grafana/sign-plugin" --workspace="@grafana/plugin-e2e" --pack-destination="./packed-artifacts"
+          npm pack --workspace="@grafana/create-plugin" --workspace="@grafana/sign-plugin" --workspace="@grafana/plugin-e2e" --workspace="@grafana/tsconfig" --pack-destination="./packed-artifacts"
           cp ./.github/knip.json ./packed-artifacts
       - name: Upload artifacts for testing
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -118,6 +118,12 @@ jobs:
 
       - name: Install generated plugin dependencies
         run: npm install --no-audit
+        working-directory: ./${{ env.WORKING_DIR }}
+
+      - name: Install tsconfig
+        run: |
+          TSCONFIG_PACKAGE=$(ls ../packed-artifacts/grafana-tsconfig-*.tgz | xargs basename)
+          npm install ../packed-artifacts/${TSCONFIG_PACKAGE}
         working-directory: ./${{ env.WORKING_DIR }}
 
       - name: Lint plugin frontend
@@ -319,6 +325,12 @@ jobs:
         run: |
           PLUGIN_E2E_PACKAGE=$(ls ../packed-artifacts/grafana-plugin-e2e-*.tgz | xargs basename)
           npm install ../packed-artifacts/${PLUGIN_E2E_PACKAGE}
+        working-directory: ./${{ matrix.workingDir }}
+
+      - name: Install tsconfig
+        run: |
+          TSCONFIG_PACKAGE=$(ls ../packed-artifacts/grafana-tsconfig-*.tgz | xargs basename)
+          npm install ../packed-artifacts/${TSCONFIG_PACKAGE}
         working-directory: ./${{ matrix.workingDir }}
 
       - name: Lint plugin frontend

--- a/packages/create-plugin/templates/backend-app/.golangci.yml
+++ b/packages/create-plugin/templates/backend-app/.golangci.yml
@@ -1,0 +1,5 @@
+version: '2'
+linters:
+  exclusions:
+    paths:
+      - node_modules

--- a/packages/create-plugin/templates/backend/.golangci.yml
+++ b/packages/create-plugin/templates/backend/.golangci.yml
@@ -1,0 +1,5 @@
+version: '2'
+linters:
+  exclusions:
+    paths:
+      - node_modules

--- a/packages/create-plugin/templates/common/.config/tsconfig.json
+++ b/packages/create-plugin/templates/common/.config/tsconfig.json
@@ -16,6 +16,7 @@
   "ts-node": {
     "compilerOptions": {
       "module": "commonjs",
+      "moduleResolution": "node",
       "target": "es5",
       "esModuleInterop": true
     },


### PR DESCRIPTION
## Summary

Fixes a regression introduced by #2595 where scaffolded plugins fail their build with:

```
[webpack-cli] error TS5095: Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later.
```

### Root cause

#2595 changed `packages/tsconfig/base.json` to `moduleResolution: "bundler"`. Scaffolded plugins extend `@grafana/tsconfig` from `.config/tsconfig.json` and add a `ts-node` override block (used by `webpack-cli` to compile `webpack.config.ts`):

```json
"ts-node": {
  "compilerOptions": {
    "module": "commonjs",
    "target": "es5",
    "esModuleInterop": true
  }
}
```

The merged ts-node config becomes `module: "commonjs"` + `moduleResolution: "bundler"` — exactly the combination TS5095 forbids.

### Fix

Override `moduleResolution: "node"` in the `ts-node` block. `transpileOnly: true` is set, so bundler-style resolution is unnecessary for compiling the config file.

### Why this slipped through CI on #2595

Scaffolded tests pull `@grafana/tsconfig` from npm rather than the local workspace, so the base.json change was never exercised by the scaffold matrix on its own PR. It only broke once auto-publish put the new version on the registry, after which every subsequent PR (and `main`) started failing.

This PR also closes that gap: pack `@grafana/tsconfig` alongside the other local tarballs and install it over the registry version inside scaffolded plugins, mirroring the existing pattern for `@grafana/plugin-e2e`. Future changes to `base.json` will be validated end-to-end by all 6 scaffolding matrix variants before merge.

## Test plan

- [x] Scaffold a panel plugin with the patched template, run `npm install && npm run build` — webpack compiles successfully
- [ ] CI passes on this PR (validates fix end-to-end across all scaffolding matrices)
- [ ] CI step "Install tsconfig" appears in scaffold and node-versions jobs and installs the local tarball