### PR TITLE
Plugin E2E: Fix addPanel timeout when dashboardNewLayouts is disabled

### DIFF
--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -181,7 +181,14 @@ export class DashboardPage extends GrafanaPage {
       }
     }
 
-    if (semver.gte(this.ctx.grafanaVersion, '13.0.0')) {
+    // Grafana 13.0+ uses a new sidebar UI when the dashboardNewLayouts toggle is on.
+    // When the toggle is off, Grafana 13 still renders the legacy toolbar UI, so we
+    // fall through to the >= 9.5.0 branch below.
+    const useNewSidebarLayout =
+      semver.gte(this.ctx.grafanaVersion, '13.0.0') &&
+      (await isLegacyFeatureEnabled(this.ctx.page, 'dashboardNewLayouts'));
+
+    if (useNewSidebarLayout) {
       await this.ctx.page.waitForSelector(resolveGrafanaSelector(this.ctx.selectors.components.Sidebar.container));
       const newPanelButton = this.getByGrafanaSelector(components.Sidebar.newPanelButton);
       if (!(await newPanelButton.isVisible())) {

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/addPanel.newLayoutDisabled.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/addPanel.newLayoutDisabled.spec.ts
@@ -1,0 +1,17 @@
+import * as semver from 'semver';
+import { expect, test } from '../../../src';
+
+test.use({ featureToggles: { dashboardNewLayouts: false } });
+
+// the dashboardNewLayouts toggle was introduced in Grafana 13. Below that the toolbar
+// flow is used regardless, so skipping keeps the assertion meaningful.
+test('addPanel opens the panel edit page when dashboardNewLayouts is disabled', async ({
+  dashboardPage,
+  page,
+  grafanaVersion,
+}) => {
+  test.skip(semver.lt(grafanaVersion, '13.0.0'), 'dashboardNewLayouts toggle only applies to Grafana 13+');
+  const panelEditPage = await dashboardPage.addPanel();
+  await expect(panelEditPage.panel.locator).toBeVisible();
+  await expect(page.url()).toContain('editPanel');
+});

--- a/packages/plugin-e2e/tests/as-admin-user/dashboard/addPanel.newLayoutEnabled.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/dashboard/addPanel.newLayoutEnabled.spec.ts
@@ -1,0 +1,17 @@
+import * as semver from 'semver';
+import { expect, test } from '../../../src';
+
+test.use({ featureToggles: { dashboardNewLayouts: true } });
+
+// the dashboardNewLayouts toggle was introduced in Grafana 13. Below that the toolbar
+// flow is used regardless, so skipping keeps the assertion meaningful.
+test('addPanel opens the panel edit page when dashboardNewLayouts is enabled', async ({
+  dashboardPage,
+  page,
+  grafanaVersion,
+}) => {
+  test.skip(semver.lt(grafanaVersion, '13.0.0'), 'dashboardNewLayouts toggle only applies to Grafana 13+');
+  const panelEditPage = await dashboardPage.addPanel();
+  await expect(panelEditPage.panel.locator).toBeVisible();
+  await expect(page.url()).toContain('editPanel');
+});


### PR DESCRIPTION
**What this PR does / why we need it**:

`DashboardPage.addPanel()` unconditionally entered the new Grafana 13 sidebar flow for any Grafana >= 13.0.0, but the Sidebar container only exists when the `dashboardNewLayouts` toggle is on. With the toggle off, every `addPanel()` call timed out for 30s.

The fix detects the toggle via `isLegacyFeatureEnabled` and falls back to the legacy toolbar flow when it is off (same pattern as the `dashboardScene` check above it).

**Which issue(s) this PR fixes**:

Reported via [grafana/grafana#123826](https://github.com/grafana/grafana/pull/123826).

**Special notes for your reviewer**:

Regression from #2572 (shipped in 3.5.0). Plugin-e2e CI didn't catch it because `docker-compose.yaml` sets `dashboardNewLayouts=true`. Verified locally against Grafana 13.0.1 with the toggle off — fails without the fix, passes with it.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.5.4-canary.2612.25370213167.0
  npm install @grafana/create-plugin@7.3.1-canary.2612.25370213167.0
  npm install @grafana/plugin-e2e@3.7.1-canary.2612.25370213167.0
  # or 
  yarn add website@5.5.4-canary.2612.25370213167.0
  yarn add @grafana/create-plugin@7.3.1-canary.2612.25370213167.0
  yarn add @grafana/plugin-e2e@3.7.1-canary.2612.25370213167.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
