### PR TITLE
chore: change webhook url for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,7 @@ jobs:
           repo_secrets: |
             GITHUB_APP_ID=plugins-platform-bot-app:app_id
             GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
-            SLACK_WEBHOOK_URL=slack_webhook_url:slack_webhook_url
+            SLACK_WEBHOOK_URL=slack_webhook_url:slack_webhook_url_fp
             NX_CLOUD_ACCESS_TOKEN=nx_token:nx_token
           export_env: false
 


### PR DESCRIPTION
**What is this feature?**

Updates the Slack webhook URL secret reference in the release workflow.

**Why do we need this feature?**

So release notifications get posted to the correct Slack channel.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
