### PR TITLE
CI: temporarily disable release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, generate-plugins]
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.actor != 'dependabot[bot]'"
+    if: false # temporarily disabled — release blocked by org branch protection rule
     name: Release packages
     env:
       NX_BRANCH: ${{ github.event.number || github.ref_name }}


### PR DESCRIPTION
Temp disable releases until we have figured out a workaround for https://raintank-corp.slack.com/archives/C08Q9QXEA83/p1778062938258049