### PR TITLE
fix(website): prevent duplicate startTracking causing rudderQueue error

### DIFF
--- a/docusaurus/website/src/theme/tracking/index.ts
+++ b/docusaurus/website/src/theme/tracking/index.ts
@@ -23,6 +23,7 @@ export const isFaroSetup = (config: FaroConfig) =>
 // Enqueue all rudderstack requests until it is loaded and consent is granted
 let rudderstack: Partial<RudderStack> = {};
 let rudderQueue = [];
+let trackingInitialized = false;
 const rudderMethods = ['page', 'track', 'identify', 'reset'];
 for (const method of rudderMethods) {
   rudderstack[method] = (...args) => {
@@ -49,9 +50,10 @@ export function startTracking(
   faroConfig: FaroConfig,
   shouldTrack: boolean
 ) {
-  if (!shouldTrack) {
+  if (!shouldTrack || trackingInitialized) {
     return;
   }
+  trackingInitialized = true;
 
   if (isRudderstackSetup(rudderStackConfig)) {
     const { writeKey, url, configUrl } = rudderStackConfig;


### PR DESCRIPTION
Guard `startTracking` with a module-level initialized flag so route changes and React strict-mode double-effects do not append a second rudderstack script, whose `onload` would iterate an already-drained (undefined) `rudderQueue` and throw `TypeError: rudderQueue is not iterable`.

@Ukochka — does this look right to you? If so, would you be up for porting the same fix to the other Grafana sub-sites that share this tracking module?