### PR TITLE
Create Plugin: Revert @grafana dep pins and re-enable test-updates CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,82 +174,82 @@ jobs:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
         working-directory: ./${{ env.WORKING_DIR }}
-  # Temporarily disable to prevent failures due to NPM package publishing in grafana/grafana. Put back to 5.27.1 once resolved.
-  # test-updates:
-  #   name: Test create-plugin update command
-  #   runs-on: ubuntu-x64
-  #   if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
-  #   needs: [test]
-  #   env:
-  #     WORKING_DIR: 'myorg-nobackend-panel'
-  #   steps:
-  #     - name: Setup nodejs
-  #       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-  #       with:
-  #         node-version: '24'
 
-  #     - name: Scaffold plugin using the earliest create-plugin version mentioned in migrations
-  #       run: npx -y @grafana/create-plugin@5.27.1 --plugin-name='no-backend' --org-name='myorg' --plugin-type='panel'
+  test-updates:
+    name: Test create-plugin update command
+    runs-on: ubuntu-x64
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    needs: [test]
+    env:
+      WORKING_DIR: 'myorg-nobackend-panel'
+    steps:
+      - name: Setup nodejs
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: '24'
 
-  #     - name: Install generated plugin dependencies
-  #       run: npm install --no-audit
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Scaffold plugin using the earliest create-plugin version mentioned in migrations
+        run: npx -y @grafana/create-plugin@5.27.1 --plugin-name='no-backend' --org-name='myorg' --plugin-type='panel'
 
-  #     - name: Download packed artifacts
-  #       uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-  #       with:
-  #         name: packed-artifacts
-  #         path: ./packed-artifacts
+      - name: Install generated plugin dependencies
+        run: npm install --no-audit
+        working-directory: ./${{ env.WORKING_DIR }}
 
-  #     - name: Install npm packages globally
-  #       run: for file in *.tgz; do npm install -g "$file"; done
-  #       working-directory: ./packed-artifacts
+      - name: Download packed artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: packed-artifacts
+          path: ./packed-artifacts
 
-  #     - name: Test create-plugin update command
-  #       run: npx create-plugin update --force
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Install npm packages globally
+        run: for file in *.tgz; do npm install -g "$file"; done
+        working-directory: ./packed-artifacts
 
-  #     - name: Lint plugin frontend
-  #       run: npm run lint
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Test create-plugin update command
+        run: npx create-plugin update --force
+        working-directory: ./${{ env.WORKING_DIR }}
 
-  #     - name: Typecheck plugin frontend
-  #       run: npm run typecheck
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Lint plugin frontend
+        run: npm run lint
+        working-directory: ./${{ env.WORKING_DIR }}
 
-  #     - name: Build plugin frontend
-  #       run: npm run build
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Typecheck plugin frontend
+        run: npm run typecheck
+        working-directory: ./${{ env.WORKING_DIR }}
 
-  #     - name: Test plugin frontend
-  #       run: npm run test:ci
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Build plugin frontend
+        run: npm run build
+        working-directory: ./${{ env.WORKING_DIR }}
 
-  #     - name: Install playwright dependencies
-  #       run: npm exec playwright install --with-deps chromium
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Test plugin frontend
+        run: npm run test:ci
+        working-directory: ./${{ env.WORKING_DIR }}
 
-  #     - name: Start grafana server for e2e tests (10.4.0)
-  #       run: |
-  #         ANONYMOUS_AUTH_ENABLED=false docker compose build --no-cache
-  #         docker compose up -d
-  #       env:
-  #         GRAFANA_VERSION: '10.4.0'
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Install playwright dependencies
+        run: npm exec playwright install --with-deps chromium
+        working-directory: ./${{ env.WORKING_DIR }}
 
-  #     - name: Wait for grafana server (10.4.0)
-  #       uses: grafana/plugin-actions/wait-for-grafana@752a92aaebfcd83121acc27293c93b7013d30deb # wait-for-grafana/v1.0.1
-  #       with:
-  #         url: http://localhost:3000/login
+      - name: Start grafana server for e2e tests (10.4.0)
+        run: |
+          ANONYMOUS_AUTH_ENABLED=false docker compose build --no-cache
+          docker compose up -d
+        env:
+          GRAFANA_VERSION: '10.4.0'
+        working-directory: ./${{ env.WORKING_DIR }}
 
-  #     - name: Run e2e tests (10.4.0)
-  #       id: run-e2e-tests-min-version
-  #       run: npm run e2e
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Wait for grafana server (10.4.0)
+        uses: grafana/plugin-actions/wait-for-grafana@752a92aaebfcd83121acc27293c93b7013d30deb # wait-for-grafana/v1.0.1
+        with:
+          url: http://localhost:3000/login
 
-  #     - name: Stop grafana docker (10.4.0)
-  #       run: docker compose down
-  #       working-directory: ./${{ env.WORKING_DIR }}
+      - name: Run e2e tests (10.4.0)
+        id: run-e2e-tests-min-version
+        run: npm run e2e
+        working-directory: ./${{ env.WORKING_DIR }}
+
+      - name: Stop grafana docker (10.4.0)
+        run: docker compose down
+        working-directory: ./${{ env.WORKING_DIR }}
 
   generate-plugins:
     name: Test plugin scaffolding

--- a/packages/create-plugin/templates/common/.config/docker-compose-base.yaml
+++ b/packages/create-plugin/templates/common/.config/docker-compose-base.yaml
@@ -7,7 +7,7 @@ services:
       context: .
       args:
         grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}} }
-        grafana_version: ${GRAFANA_VERSION:-12.4.0}
+        grafana_version: ${GRAFANA_VERSION:-12.4.3}
         development: ${DEVELOPMENT:-false}
         anonymous_auth_enabled: ${ANONYMOUS_AUTH_ENABLED:-true}
     ports:

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -73,11 +73,11 @@
   },
   "dependencies": {
     "@emotion/css": "11.10.6",
-    "@grafana/data": "12.4.2",
-    "@grafana/i18n": "12.4.2",
-    "@grafana/runtime": "12.4.2",
-    "@grafana/ui": "12.4.2",
-    "@grafana/schema": "12.4.2",{{#if_eq pluginType "scenesapp" }}
+    "@grafana/data": "^12.4.3",
+    "@grafana/i18n": "^12.4.3",
+    "@grafana/runtime": "^12.4.3",
+    "@grafana/ui": "^12.4.3",
+    "@grafana/schema": "^12.4.3",{{#if_eq pluginType "scenesapp" }}
     "@grafana/scenes": "{{ scenesVersion }}",{{/if_eq}}
     "react": "^18.3.0",
     "react-dom": "^18.3.0"{{#if isAppType}},


### PR DESCRIPTION
**What this PR does / why we need it**:
Reverts the temporary workaround introduced in #2577, now that the NPM publishing issue for `@grafana/*` packages in grafana/grafana is resolved. The pinned exact versions (`12.4.2`) are replaced with a caret range (`^12.4.3`) to allow patch updates again, the Docker dev-server default is bumped to `12.4.3` to align, and the `test-updates` CI job is restored.

**Which issue(s) this PR fixes**:
Reverts #2577

**Special notes for your reviewer**: