### PR TITLE
CI: Re-enable release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,7 +551,6 @@ jobs:
           app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
           private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
           permission-contents: write
-          permission-issues: write
           permission-pull-requests: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, generate-plugins]
-    if: false # temporarily disabled — release blocked by org branch protection rule
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.actor != 'dependabot[bot]'"
     name: Release packages
     env:
       NX_BRANCH: ${{ github.event.number || github.ref_name }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Reverts #2616. Re-enables the release job now that `grafana-plugins-platform-bot` has been granted a bypass for direct pushes to `main` in the repos that need it.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Also removes `permission-issues: write` from the token request — this was dropped from the app as part of the SDLC scoping exercise and isn't needed by any of the `auto` plugins in use.