### PR TITLE
Plugin E2E: Select MultiSelect options sequentially

### DIFF
--- a/packages/plugin-e2e/src/models/components/MultiSelect.ts
+++ b/packages/plugin-e2e/src/models/components/MultiSelect.ts
@@ -12,10 +12,10 @@ export class MultiSelect extends ComponentBase {
   async selectOptions(values: string[], options?: SelectOptionsType): Promise<string[]> {
     const menu = await openSelect(this, options);
 
-    return Promise.all(
-      values.map((value) => {
-        return selectByValueOrLabel(value, menu, this.ctx, options);
-      })
-    );
+    const selected: string[] = [];
+    for (const value of values) {
+      selected.push(await selectByValueOrLabel(value, menu, this.ctx, options));
+    }
+    return selected;
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces `Promise.all(values.map(...))` with a sequential `for...of` loop in `MultiSelect.selectOptions`. Playwright interactions on the same UI element are not safe to run concurrently — racing clicks against the same open menu can cause flaky tests because the DOM mutates after each selection. The sequential approach ensures each option is fully selected before the next begins.

**Which issue(s) this PR fixes**:

Fixes a potential source of flaky tests flagged in https://github.com/grafana/plugin-tools/pull/2621#discussion_r3207105944

**Special notes for your reviewer**:

The behavior is unchanged — same options are selected in the same order, just awaited one at a time instead of concurrently.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/plugin-e2e@3.7.2-canary.2626.25732312320.0
  npm install @grafana/sign-plugin@3.2.2-canary.2626.25732312320.0
  # or 
  yarn add @grafana/plugin-e2e@3.7.2-canary.2626.25732312320.0
  yarn add @grafana/sign-plugin@3.2.2-canary.2626.25732312320.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
