### PR TITLE
feat: harden bundle-stats workflow permissions

### DIFF
--- a/docusaurus/docs/set-up/set-up-github.md
+++ b/docusaurus/docs/set-up/set-up-github.md
@@ -169,7 +169,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   actions: read
 
@@ -181,7 +181,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: grafana/plugin-actions/bundle-size@main
+      - uses: grafana/plugin-actions/bundle-size@bundle-size/v1.0.2
 ```
 
 ### Troubleshooting

--- a/packages/create-plugin/src/codemods/migrations/migrations.ts
+++ b/packages/create-plugin/src/codemods/migrations/migrations.ts
@@ -54,7 +54,7 @@ export default [
     name: '008-bundle-stats-permissions',
     version: '7.3.2',
     description:
-      'Harden ./.github/workflows/bundle-stats.yml: contents permission was set to write but only read access is required; restricted to read for least-privilege.',
+      'Harden bundle-stats/bundle-size workflow permissions: contents permission was set to write but only read access is required; restricted to read for least-privilege.',
     scriptPath: import.meta.resolve('./scripts/008-bundle-stats-permissions.js'),
   },
   // Do not use LEGACY_UPDATE_CUTOFF_VERSION for new migrations. It is only used above to force migrations to run

--- a/packages/create-plugin/src/codemods/migrations/migrations.ts
+++ b/packages/create-plugin/src/codemods/migrations/migrations.ts
@@ -50,6 +50,13 @@ export default [
       'Add setupTests.d.ts for @testing-library/jest-dom types and remove @types/testing-library__jest-dom npm package.',
     scriptPath: import.meta.resolve('./scripts/007-remove-testing-library-types.js'),
   },
+  {
+    name: '008-bundle-stats-permissions',
+    version: '7.3.2',
+    description:
+      'Harden ./.github/workflows/bundle-stats.yml: contents permission was set to write but only read access is required; restricted to read for least-privilege.',
+    scriptPath: import.meta.resolve('./scripts/008-bundle-stats-permissions.js'),
+  },
   // Do not use LEGACY_UPDATE_CUTOFF_VERSION for new migrations. It is only used above to force migrations to run
   // for those written before the switch to updates as migrations.
 ] satisfies Migration[];

--- a/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.test.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.test.ts
@@ -4,6 +4,7 @@ import migrate from './008-bundle-stats-permissions.js';
 import { parse } from 'yaml';
 
 const workflowPath = './.github/workflows/bundle-stats.yml';
+const legacyWorkflowPath = './.github/workflows/bundle-size.yml';
 
 describe('008-bundle-stats-permissions', () => {
   it('should not modify anything if workflow file does not exist', async () => {
@@ -159,6 +160,52 @@ jobs:
       'pull-requests': 'write',
       actions: 'read',
     });
+  });
+
+  it('should update permissions.contents in the legacy bundle-size.yml workflow', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      legacyWorkflowPath,
+      `name: Bundle Stats
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`
+    );
+
+    await migrate(context);
+
+    const migrated = parse(context.getFile(legacyWorkflowPath) || '');
+    expect(migrated.permissions.contents).toBe('read');
+  });
+
+  it('should update both workflow filenames if both exist', async () => {
+    const context = new Context('/virtual');
+    const original = `name: Bundle Stats
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`;
+    context.addFile(workflowPath, original);
+    context.addFile(legacyWorkflowPath, original);
+
+    await migrate(context);
+
+    expect(parse(context.getFile(workflowPath) || '').permissions.contents).toBe('read');
+    expect(parse(context.getFile(legacyWorkflowPath) || '').permissions.contents).toBe('read');
   });
 
   it('should be idempotent', async () => {

--- a/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.test.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { Context } from '../../context.js';
+import migrate from './008-bundle-stats-permissions.js';
+import { parse } from 'yaml';
+
+const workflowPath = './.github/workflows/bundle-stats.yml';
+
+describe('008-bundle-stats-permissions', () => {
+  it('should not modify anything if workflow file does not exist', async () => {
+    const context = new Context('/virtual');
+
+    await migrate(context);
+
+    expect(context.listChanges()).toEqual({});
+  });
+
+  it('should not modify anything if workflow file is empty', async () => {
+    const context = new Context('/virtual');
+    context.addFile(workflowPath, '');
+    const initialChanges = context.listChanges();
+
+    await migrate(context);
+
+    expect(context.listChanges()).toEqual(initialChanges);
+  });
+
+  it('should not modify anything if permissions block is missing', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      workflowPath,
+      `name: Bundle Stats
+on: [pull_request]
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`
+    );
+    const initialChanges = context.listChanges();
+
+    await migrate(context);
+
+    expect(context.listChanges()).toEqual(initialChanges);
+  });
+
+  it('should not modify anything if permissions.contents key is missing', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      workflowPath,
+      `name: Bundle Stats
+on: [pull_request]
+permissions:
+  pull-requests: write
+  actions: read
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`
+    );
+    const initialChanges = context.listChanges();
+
+    await migrate(context);
+
+    expect(context.listChanges()).toEqual(initialChanges);
+  });
+
+  it('should not modify anything if permissions.contents is already read', async () => {
+    const context = new Context('/virtual');
+    const original = `name: Bundle Stats
+on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`;
+    context.addFile(workflowPath, original);
+
+    await migrate(context);
+
+    expect(context.getFile(workflowPath)).toBe(original);
+  });
+
+  it('should update permissions.contents from write to read', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      workflowPath,
+      `name: Bundle Stats
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`
+    );
+
+    await migrate(context);
+
+    const migrated = parse(context.getFile(workflowPath) || '');
+    expect(migrated.permissions.contents).toBe('read');
+  });
+
+  it('should preserve other permissions when updating contents', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      workflowPath,
+      `name: Bundle Stats
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`
+    );
+
+    await migrate(context);
+
+    const migrated = parse(context.getFile(workflowPath) || '');
+    expect(migrated.permissions).toEqual({
+      contents: 'read',
+      'pull-requests': 'write',
+      actions: 'read',
+    });
+  });
+
+  it('should be idempotent', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      workflowPath,
+      `name: Bundle Stats
+on: [pull_request]
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`
+    );
+
+    await expect(migrate).toBeIdempotent(context);
+  });
+});

--- a/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.test.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.test.ts
@@ -88,6 +88,27 @@ jobs:
     expect(context.getFile(workflowPath)).toBe(original);
   });
 
+  it('should not modify anything if permissions.contents is none', async () => {
+    const context = new Context('/virtual');
+    const original = `name: Bundle Stats
+on: [pull_request]
+permissions:
+  contents: none
+  pull-requests: write
+  actions: read
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+`;
+    context.addFile(workflowPath, original);
+
+    await migrate(context);
+
+    expect(context.getFile(workflowPath)).toBe(original);
+  });
+
   it('should update permissions.contents from write to read', async () => {
     const context = new Context('/virtual');
     context.addFile(

--- a/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.ts
@@ -16,11 +16,7 @@ export default async function migrate(context: Context) {
 
   const workflowDoc = parseDocument(workflowContent);
 
-  if (!workflowDoc.hasIn(['permissions', 'contents'])) {
-    return context;
-  }
-
-  if (workflowDoc.getIn(['permissions', 'contents']) === 'read') {
+  if (workflowDoc.getIn(['permissions', 'contents']) !== 'write') {
     return context;
   }
 

--- a/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.ts
@@ -1,27 +1,29 @@
 import { type Context } from '../../context.js';
 import { parseDocument, stringify } from 'yaml';
 
+const workflowPaths = ['./.github/workflows/bundle-stats.yml', './.github/workflows/bundle-size.yml'];
+
 export default async function migrate(context: Context) {
-  const workflowPath = './.github/workflows/bundle-stats.yml';
+  for (const workflowPath of workflowPaths) {
+    if (!context.doesFileExist(workflowPath)) {
+      continue;
+    }
 
-  if (!context.doesFileExist(workflowPath)) {
-    return context;
+    const workflowContent = context.getFile(workflowPath);
+
+    if (!workflowContent) {
+      continue;
+    }
+
+    const workflowDoc = parseDocument(workflowContent);
+
+    if (workflowDoc.getIn(['permissions', 'contents']) !== 'write') {
+      continue;
+    }
+
+    workflowDoc.setIn(['permissions', 'contents'], 'read');
+    context.updateFile(workflowPath, stringify(workflowDoc));
   }
-
-  const workflowContent = context.getFile(workflowPath);
-
-  if (!workflowContent) {
-    return context;
-  }
-
-  const workflowDoc = parseDocument(workflowContent);
-
-  if (workflowDoc.getIn(['permissions', 'contents']) !== 'write') {
-    return context;
-  }
-
-  workflowDoc.setIn(['permissions', 'contents'], 'read');
-  context.updateFile(workflowPath, stringify(workflowDoc));
 
   return context;
 }

--- a/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/008-bundle-stats-permissions.ts
@@ -1,0 +1,31 @@
+import { type Context } from '../../context.js';
+import { parseDocument, stringify } from 'yaml';
+
+export default async function migrate(context: Context) {
+  const workflowPath = './.github/workflows/bundle-stats.yml';
+
+  if (!context.doesFileExist(workflowPath)) {
+    return context;
+  }
+
+  const workflowContent = context.getFile(workflowPath);
+
+  if (!workflowContent) {
+    return context;
+  }
+
+  const workflowDoc = parseDocument(workflowContent);
+
+  if (!workflowDoc.hasIn(['permissions', 'contents'])) {
+    return context;
+  }
+
+  if (workflowDoc.getIn(['permissions', 'contents']) === 'read') {
+    return context;
+  }
+
+  workflowDoc.setIn(['permissions', 'contents'], 'read');
+  context.updateFile(workflowPath, stringify(workflowDoc));
+
+  return context;
+}

--- a/packages/create-plugin/templates/github/workflows/bundle-stats.yml
+++ b/packages/create-plugin/templates/github/workflows/bundle-stats.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   actions: read
 


### PR DESCRIPTION
## Summary

- Restricts `permissions.contents` in the scaffolded `bundle-stats.yml` workflow from `write` to `read` (least-privilege).
- Adds migration `008-bundle-stats-permissions` so existing plugin projects pick up the same hardening when they next run `update`.

## Test plan

- [x] `npm run test -w @grafana/create-plugin` — 238/238 pass, including 8 new tests for the migration
- [x] `npm run typecheck -w @grafana/create-plugin`
- [x] `npm run lint -w @grafana/create-plugin`
- [x] Manually run the migration against a plugin generated before f7bd18d0 to confirm `contents: write` → `contents: read` and that other permissions are preserved

Tested a run of the hardened workflow in [trafficlight panel](https://github.com/jackw/heywesty-trafficlight-panel/pull/144#issuecomment-4431284416).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@7.4.0-canary.2627.25780132301.0
  # or 
  yarn add @grafana/create-plugin@7.4.0-canary.2627.25780132301.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
