### PR TITLE
feat: disable package manager script execution

### DIFF
--- a/docusaurus/docs/get-started.md
+++ b/docusaurus/docs/get-started.md
@@ -8,7 +8,7 @@ keywords:
   - plugin
   - create-plugin
   - getting started
-slug: /  
+slug: /
 ---
 
 import ScaffoldNPM from '@shared/createplugin-scaffold.md';
@@ -46,7 +46,7 @@ If this is your first time creating a plugin, we recommend that you familiarize 
 
 ## Signature classifications of Grafana plugins
 
-Familiarize yourself with the signature classifications of Grafana plugins, such as the distinction between private and public plugins. 
+Familiarize yourself with the signature classifications of Grafana plugins, such as the distinction between private and public plugins.
 
 Note that if you want to publish a plugin associated with a commercial offering to the official Grafana catalog, a paid subscription is typically required. Learn more about [Grafana's plugins policy](https://grafana.com/legal/plugins/).
 
@@ -93,7 +93,11 @@ You'll need to have the following tools set up:
 
 #### Supported package managers
 
-When you first run `@grafana/create-plugin`, choose your package manager: `npm`, `pnpm`, or `yarn`.
+`@grafana/create-plugin` officially supports the following Node package managers:
+
+- `npm` (>=10.0.0)
+- `pnpm` (>=10.0.0)
+- `yarn` (>=4.0.0)
 
 :::note
 The Yarn commands on this website are compatible with Yarn Berry (>=2.0.0). If you are using Yarn 1.x.x we suggest you upgrade to [Yarn Berry](https://yarnpkg.com/migration/guide). Alternatively you can use `yarn create @grafana/plugin` to run commands with Yarn 1.x.x.

--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -135,8 +135,7 @@ function getActionsForTemplateFolder({
 }) {
   let files = glob.sync(`${folderPath}/**`, { dot: true });
 
-  // The npmrc file is only useful for `pnpm` settings. We can remove it for other package managers.
-  if (templateData.packageManagerName !== 'pnpm') {
+  if (templateData.packageManagerName !== 'npm') {
     files = files.filter((file) => path.basename(file) !== 'npmrc');
   }
 

--- a/packages/create-plugin/src/commands/generate.command.ts
+++ b/packages/create-plugin/src/commands/generate.command.ts
@@ -135,7 +135,8 @@ function getActionsForTemplateFolder({
 }) {
   let files = glob.sync(`${folderPath}/**`, { dot: true });
 
-  if (templateData.packageManagerName !== 'npm') {
+  // If the user selected yarn as their package manager, filter out npmrc file from templates since it's only needed for npm/pnpm.
+  if (templateData.packageManagerName === 'yarn') {
     files = files.filter((file) => path.basename(file) !== 'npmrc');
   }
 

--- a/packages/create-plugin/src/utils/utils.packageManager.ts
+++ b/packages/create-plugin/src/utils/utils.packageManager.ts
@@ -24,7 +24,7 @@ export async function configureYarn(cwd: string, packageManagerVersion: string) 
         shell: true,
         cwd,
       });
-      spawnSync('yarn', ['config', 'set', 'executeScripts', 'false'], {
+      spawnSync('yarn', ['config', 'set', 'enableScripts', 'false'], {
         shell: true,
         cwd,
       });

--- a/packages/create-plugin/src/utils/utils.packageManager.ts
+++ b/packages/create-plugin/src/utils/utils.packageManager.ts
@@ -24,9 +24,18 @@ export async function configureYarn(cwd: string, packageManagerVersion: string) 
         shell: true,
         cwd,
       });
-      return 'Configured Yarn Berry to use node_modules (PnP is not supported)';
+      spawnSync('yarn', ['config', 'set', 'executeScripts', 'false'], {
+        shell: true,
+        cwd,
+      });
+      return 'Configured Yarn Berry to use node_modules and disabled script execution during installation.';
     }
-    return '';
+    spawnSync('yarn', ['config', 'set', 'ignore-scripts', 'true'], {
+      shell: true,
+      cwd,
+    });
+
+    return 'Configured Yarn to ignore scripts during installation.';
   } catch (error) {
     throw new Error(
       'There was an error configuring Yarn. Please run `yarn set version stable && yarn config set nodeLinker node-modules` in your plugin directory.'

--- a/packages/create-plugin/src/utils/utils.packageManager.ts
+++ b/packages/create-plugin/src/utils/utils.packageManager.ts
@@ -30,7 +30,12 @@ export async function configureYarn(cwd: string) {
       shell: true,
       cwd,
     });
-    return 'Configured Yarn Berry to use node_modules and disabled script execution during installation.';
+    // TODO: Remove this once grafana/react-data-grid is published to NPM.
+    spawnSync('yarn', ['config', 'set', 'approvedGitRepositories', '--json', `'["https://github.com/grafana/*"]'`], {
+      shell: true,
+      cwd,
+    });
+    return 'Configured Yarn Berry to use node_modules, disabled script execution, and set approved Git repositories.';
   } catch (error) {
     throw new Error(
       'There was an error configuring Yarn. Please run `yarn set version stable && yarn config set nodeLinker node-modules && yarn config set enableScripts false` in your plugin directory.'

--- a/packages/create-plugin/src/utils/utils.packageManager.ts
+++ b/packages/create-plugin/src/utils/utils.packageManager.ts
@@ -9,36 +9,31 @@ const NPM_LOCKFILE = 'package-lock.json';
 const PNPM_LOCKFILE = 'pnpm-lock.yaml';
 const YARN_LOCKFILE = 'yarn.lock';
 const SUPPORTED_PACKAGE_MANAGERS = ['npm', 'yarn', 'pnpm'];
-const DEFAULT_PACKAGE_MANAGER = { packageManagerName: 'yarn', packageManagerVersion: '1.22.22' };
+const DEFAULT_PACKAGE_MANAGER = { packageManagerName: 'npm', packageManagerVersion: '10.9.0' };
 
 export type PackageManager = {
   packageManagerName: string;
   packageManagerVersion: string;
 };
 
-export async function configureYarn(cwd: string, packageManagerVersion: string) {
+export async function configureYarn(cwd: string) {
   try {
-    const isYarnBerry = gte(packageManagerVersion, '2.0.0');
-    if (isYarnBerry) {
-      spawnSync('yarn', ['config', 'set', 'nodeLinker', 'node-modules'], {
-        shell: true,
-        cwd,
-      });
-      spawnSync('yarn', ['config', 'set', 'enableScripts', 'false'], {
-        shell: true,
-        cwd,
-      });
-      return 'Configured Yarn Berry to use node_modules and disabled script execution during installation.';
-    }
-    spawnSync('yarn', ['config', 'set', 'ignore-scripts', 'true'], {
+    spawnSync('yarn', ['set', 'version', 'stable'], {
       shell: true,
       cwd,
     });
-
-    return 'Configured Yarn to ignore scripts during installation.';
+    spawnSync('yarn', ['config', 'set', 'nodeLinker', 'node-modules'], {
+      shell: true,
+      cwd,
+    });
+    spawnSync('yarn', ['config', 'set', 'enableScripts', 'false'], {
+      shell: true,
+      cwd,
+    });
+    return 'Configured Yarn Berry to use node_modules and disabled script execution during installation.';
   } catch (error) {
     throw new Error(
-      'There was an error configuring Yarn. Please run `yarn set version stable && yarn config set nodeLinker node-modules` in your plugin directory.'
+      'There was an error configuring Yarn. Please run `yarn set version stable && yarn config set nodeLinker node-modules && yarn config set enableScripts false` in your plugin directory.'
     );
   }
 }

--- a/packages/create-plugin/templates/common/gitignore
+++ b/packages/create-plugin/templates/common/gitignore
@@ -9,11 +9,13 @@ yarn-error.log*
 node_modules/
 
 # yarn
-.yarn/cache
-.yarn/unplugged
-.yarn/build-state.yml
-.yarn/install-state.gz
 .pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 
 # Runtime data
 pids

--- a/packages/create-plugin/templates/common/npmrc
+++ b/packages/create-plugin/templates/common/npmrc
@@ -1,1 +1,5 @@
+# Disable post install scripts to prevent execution of arbitrary code during package installation.
+# This secures both local development and CI from common supply chain attacks.
+# If you experience problems with legitimate lifecycle scripts rather than
+# disable this please use https://www.npmjs.com/package/@lavamoat/allow-scripts
 ignore-scripts=true

--- a/packages/create-plugin/templates/common/npmrc
+++ b/packages/create-plugin/templates/common/npmrc
@@ -1,12 +1,1 @@
-# This file is required for PNPM
-
-# PNPM 8 changed the default resolution mode to "lowest-direct" which is not how we expect resolutions to work
-resolution-mode="highest"
-
-# Make sure the default patterns are still included (https://pnpm.io/npmrc#public-hoist-pattern)
-public-hoist-pattern[]="*eslint*"
-public-hoist-pattern[]="*prettier*"
-
-# Hoist all types packages to the root for better TS support
-public-hoist-pattern[]="@types/*"
-public-hoist-pattern[]="*terser-webpack-plugin*"
+ignore-scripts=true


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR updates create-plugin so plugins scaffolded with yarn, npm or pnpm will have script execution disabled.

>A common supply chain security issue with npm packages is the capability of malicious or compromised npm packages to execute arbitrary code or OS commands during the package installation process. This has been a common vector and security concern for developers in the JavaScript ecosystem for many years now and has been exploited by attackers to compromise systems.

This contains a breaking change by making NPM the default package manager (which is kinda the case as far as our docs go) and dropping support for yarn 1. Any attempt to scaffold a plugin with yarn will now set the plugin to use the latest version of yarn berry, and configure it accordingly.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

I've yet to test these changes locally but the .npmrc changes should not break PNPM. They were defaults designed for PNPM 8 that are obsolete in newer versions of PNPM (which is now on v11).

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@6.0.0-canary.2630.25804069973.0
  npm install @grafana/create-plugin@8.0.0-canary.2630.25804069973.0
  npm install @grafana/plugin-e2e@4.0.0-canary.2630.25804069973.0
  # or 
  yarn add website@6.0.0-canary.2630.25804069973.0
  yarn add @grafana/create-plugin@8.0.0-canary.2630.25804069973.0
  yarn add @grafana/plugin-e2e@4.0.0-canary.2630.25804069973.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
