### PR TITLE
chore: migrate to GATB [skip ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,7 @@ jobs:
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
           github_app: plugins-platform-bot-app
+          permission_set: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'release' || 'default' }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,8 +531,6 @@ jobs:
         with:
           # Secrets placed in the ci/repo/grafana/plugin-tools in vault
           repo_secrets: |
-            GITHUB_APP_ID=plugins-platform-bot-app:app_id
-            GITHUB_APP_PRIVATE_KEY=plugins-platform-bot-app:app_pem
             SLACK_WEBHOOK_URL=slack_webhook_url:slack_webhook_url_fp
             NX_CLOUD_ACCESS_TOKEN=nx_token:nx_token
           export_env: false
@@ -545,12 +543,9 @@ jobs:
 
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_ID }}
-          private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
+          github_app: plugins-platform-bot-app
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
**What is this feature?**

Migrates the `release` job in `.github/workflows/ci.yml` to use the GitHub App Token Broker via `grafana/shared-workflows/actions/create-github-app-token` instead of pulling the `plugins-platform-bot-app` `app_id` and `app_pem` from Vault directly.

**Why do we need this feature?**

So we no longer hand out GitHub App private keys to workflows — the broker mints short-lived, scoped tokens for us.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Permissions (`contents: write`, `pull_requests: write`) are now defined in the `deployment_tools` `config.yaml` for this workflow instead of inline in the token step.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.6.1-canary.2635.26039908281.0
  # or 
  yarn add website@5.6.1-canary.2635.26039908281.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
