### PR TITLE
Plugin Docs CLI: Always sort root index.md first in manifest

### DIFF
--- a/packages/plugin-docs-cli/src/__fixtures__/no-position-index-docs/guide.md
+++ b/packages/plugin-docs-cli/src/__fixtures__/no-position-index-docs/guide.md
@@ -1,0 +1,9 @@
+---
+title: Guide
+description: User guide
+sidebar_position: 1
+---
+
+# Guide
+
+This guide page has sidebar_position: 1.

--- a/packages/plugin-docs-cli/src/__fixtures__/no-position-index-docs/index.md
+++ b/packages/plugin-docs-cli/src/__fixtures__/no-position-index-docs/index.md
@@ -1,0 +1,8 @@
+---
+title: Overview
+description: Plugin overview page
+---
+
+# Overview
+
+This is the overview page with no sidebar_position set.

--- a/packages/plugin-docs-cli/src/scanner.test.ts
+++ b/packages/plugin-docs-cli/src/scanner.test.ts
@@ -15,6 +15,14 @@ describe('scanDocsFolder', () => {
     expect(result.manifest.pages).toHaveLength(4); // home, guide, advanced, config
   });
 
+  it('should sort root index.md first even when sidebar_position is not set', async () => {
+    const noPositionPath = join(__dirname, '__fixtures__', 'no-position-index-docs');
+    const result = await scanDocsFolder(noPositionPath);
+
+    expect(result.manifest.pages[0].slug).toBe('index');
+    expect(result.manifest.pages[0].file).toBe('index.md');
+  });
+
   it('should sort pages by sidebar_position', async () => {
     const result = await scanDocsFolder(testDocsPath);
 

--- a/packages/plugin-docs-cli/src/scanner.ts
+++ b/packages/plugin-docs-cli/src/scanner.ts
@@ -204,11 +204,12 @@ function treeToPages(node: TreeNode): Page[] {
     }
   }
 
-  // convert children to array and sort by sidebar_position
-  const sortedEntries = childEntries.sort(
-    (a, b) =>
-      (a[1].file?.frontmatter.sidebar_position ?? Infinity) - (b[1].file?.frontmatter.sidebar_position ?? Infinity)
-  );
+  // convert children to array and sort by sidebar_position; root index.md always first
+  const sortedEntries = childEntries.sort((a, b) => {
+    if (a[0] === 'index.md') { return -1; }
+    if (b[0] === 'index.md') { return 1; }
+    return (a[1].file?.frontmatter.sidebar_position ?? Infinity) - (b[1].file?.frontmatter.sidebar_position ?? Infinity);
+  });
 
   for (const [name, child] of sortedEntries) {
     if (child.file) {


### PR DESCRIPTION
**What this PR does / why we need it**:

When a plugin is packaged, `@grafana/plugin-docs-cli` runs a build step that scans the docs folder and generates a `manifest.json` describing the page tree. Pages are sorted by `sidebar_position` frontmatter, with files that don't set it falling back to `Infinity`, sorting them last.

The root `index.md` (the landing page) has no special sort treatment, so plugin authors who omit `sidebar_position` end up with their overview page at the bottom of the nav on grafana.com (as shown in the screenshot below, where the overview is missing from the top of the docs nav). The fix gives `index.md` implicit first-place priority in the sort, without requiring authors to set `sidebar_position` manually.

| Before | After |
|---|---|
| <img width="255" height="469" alt="Screenshot 2026-05-21 at 16 59 56" src="https://github.com/user-attachments/assets/94742bcc-b600-4b00-aa7c-4a779286d249" /> | <img width="287" height="528" alt="Screenshot 2026-05-21 at 16 59 12" src="https://github.com/user-attachments/assets/01a6bf24-102b-4a7e-b921-75c80fd34136" /> |


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.6.1-canary.2636.26226198477.0
  npm install @grafana/create-plugin@7.6.1-canary.2636.26226198477.0
  npm install @grafana/plugin-docs-cli@0.0.11-canary.2636.26226198477.0
  npm install @grafana/plugin-meta-extractor@0.12.3-canary.2636.26226198477.0
  # or 
  yarn add website@5.6.1-canary.2636.26226198477.0
  yarn add @grafana/create-plugin@7.6.1-canary.2636.26226198477.0
  yarn add @grafana/plugin-docs-cli@0.0.11-canary.2636.26226198477.0
  yarn add @grafana/plugin-meta-extractor@0.12.3-canary.2636.26226198477.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
