### PR TITLE
chore(ci): harden permissions in internal playwright workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,6 @@ jobs:
           grafana-version: latest
           grafana-image: grafana-enterprise
           test-outcome: ${{ steps.run-e2e-tests.outcome }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get plugin min version
         id: min-version
@@ -462,7 +461,6 @@ jobs:
           grafana-version: ${{ steps.min-version.outputs.MIN_VERSION }}
           grafana-image: grafana-enterprise
           test-outcome: ${{ steps.run-e2e-tests-min-version.outcome }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check plugin.json
         run: |
@@ -498,7 +496,7 @@ jobs:
         run: exit 1
 
   publish-report:
-    if: ${{ always() && !cancelled() && github.event.pull_request.head.repo.fork != true }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     needs: [generate-plugins]
     runs-on: ubuntu-x64
     permissions:

--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -41,6 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
+    permissions:
+      id-token: write
     name: ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
     runs-on: ubuntu-x64
     steps:

--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -41,9 +41,6 @@ jobs:
       fail-fast: false
       matrix:
         GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
-    permissions:
-      contents: read
-      id-token: write
     name: ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
     runs-on: ubuntu-x64
     steps:
@@ -100,7 +97,6 @@ jobs:
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@fa3356df288e68f5e900ab466e98b0bf9bad3118 # upload-report-artifacts/v1.0.1
         if: ${{ always() && !cancelled() }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           test-outcome: ${{ steps.run-tests.outcome }}
           report-dir: packages/plugin-e2e/playwright-report
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,6 +37,8 @@ jobs:
       fail-fast: false
       matrix:
         GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
+    permissions:
+      id-token: write
     name: ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
     runs-on: ubuntu-x64
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,8 +37,6 @@ jobs:
       fail-fast: false
       matrix:
         GRAFANA_IMAGE: ${{fromJson(needs.resolve-versions.outputs.matrix)}}
-    permissions:
-      id-token: write
     name: ${{ matrix.GRAFANA_IMAGE.name }}@${{ matrix.GRAFANA_IMAGE.VERSION }}
     runs-on: ubuntu-x64
     steps:
@@ -95,12 +93,11 @@ jobs:
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@fa3356df288e68f5e900ab466e98b0bf9bad3118 # upload-report-artifacts/v1.0.1
         if: ${{ always() && !cancelled() }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           test-outcome: ${{ steps.run-tests.outcome }}
           report-dir: packages/plugin-e2e/playwright-report
 
   publish-report:
-    if: ${{ always() && !cancelled() }}
+    if: ${{ always() && !cancelled() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
     needs: [playwright-tests]
     runs-on: ubuntu-x64
     permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:

This narrows the permissions requested by the internal Playwright report publishing workflows to the ones they actually use. It removes the unused `github-token` input from report artifact uploads, keeps `id-token: write` only where the Vault-backed secret step still needs it, and makes the publish jobs skip fork PRs so write permissions are only used on trusted runs.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:
