### PR TITLE
feat(plugin-docs-cli): Extract TOC headings at build time

### DIFF
--- a/packages/plugin-docs-cli/src/scanner.test.ts
+++ b/packages/plugin-docs-cli/src/scanner.test.ts
@@ -54,13 +54,26 @@ describe('scanDocsFolder', () => {
     expect(pages[2].file).toBe('advanced.md');
   });
 
-  it('should not include headings in page objects', async () => {
+  it('should extract h2/h3 headings into page objects', async () => {
     const result = await scanDocsFolder(testDocsPath);
 
-    const pages = result.manifest.pages;
-    for (const page of pages) {
-      expect(page).not.toHaveProperty('headings');
-    }
+    const configPage = result.manifest.pages.find((p: Page) => p.slug === 'config');
+    const settingsPage = configPage?.children?.find((p: Page) => p.slug === 'config/settings');
+
+    expect(settingsPage?.headings).toEqual([
+      { level: 2, text: 'General Settings', id: 'general-settings' },
+      { level: 3, text: 'Display Name', id: 'display-name' },
+      { level: 2, text: 'Advanced Settings', id: 'advanced-settings' },
+    ]);
+  });
+
+  it('should omit headings on pages without h2/h3 content', async () => {
+    const result = await scanDocsFolder(testDocsPath);
+
+    // home.md has only an h1, no h2/h3 — field should be omitted
+    const homePage = result.manifest.pages.find((p: Page) => p.slug === 'home');
+    expect(homePage).toBeDefined();
+    expect(homePage).not.toHaveProperty('headings');
   });
 
   it('should throw error when no valid markdown files found', async () => {

--- a/packages/plugin-docs-cli/src/scanner.ts
+++ b/packages/plugin-docs-cli/src/scanner.ts
@@ -3,7 +3,13 @@ import { join, relative, parse, sep } from 'node:path';
 import GithubSlugger from 'github-slugger';
 import matter from 'gray-matter';
 import createDebug from 'debug';
-import type { Manifest, Page, MarkdownFiles, Frontmatter } from '@grafana/plugin-docs-parser';
+import {
+  parseMarkdown,
+  type Manifest,
+  type Page,
+  type MarkdownFiles,
+  type Frontmatter,
+} from '@grafana/plugin-docs-parser';
 
 const debug = createDebug('plugin-docs-cli:scanner');
 
@@ -225,6 +231,13 @@ function treeToPages(node: TreeNode): Page[] {
         slug: customSlug || generatedSlug,
         file: child.file.relativePath,
       };
+
+      // extract h2/h3 headings via the canonical parser pipeline so heading
+      // IDs in the manifest match the IDs rendered at serve time
+      const { headings } = parseMarkdown(child.file.content);
+      if (headings.length > 0) {
+        page.headings = headings;
+      }
 
       // if this file has children (folder with same name), add them
       if (child.children.size > 0) {

--- a/packages/plugin-docs-parser/src/types.ts
+++ b/packages/plugin-docs-parser/src/types.ts
@@ -24,6 +24,12 @@ export interface Page {
   file: string;
 
   /**
+   * Optional headings (h2, h3) extracted from the page's markdown body.
+   * Present only on pages backed by a real file; omitted on category nodes.
+   */
+  headings?: Heading[];
+
+  /**
    * Optional nested child pages.
    */
   children?: Page[];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The Next.js website renders a "Table of contents" for every plugin docs page, listing the h2 and h3 headings in the page. Today those headings are extracted on every page render by re-parsing the full markdown body - a cost paid on the hot path for every page view on grafana.com.

This PR moves heading extraction to build time. The `build` command in `@grafana/plugin-docs-cli` now extracts h2/h3 headings from each page and writes them into the generated `manifest.json` under a new optional `headings` field on `Page`. Consumers can then build the TOC straight from the manifest with zero markdown parsing per request.

Extraction reuses `parseMarkdown()` from `@grafana/plugin-docs-parser`, so manifest heading IDs match the IDs the same pipeline produces at render time - anchors line up by construction.


<img width="286" height="527" alt="Screenshot 2026-05-22 at 10 22 27" src="https://github.com/user-attachments/assets/a61d2c4b-e448-4119-b26e-98d1feb28257" />

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.6.1-canary.2644.26276784934.0
  npm install @grafana/create-plugin@7.6.1-canary.2644.26276784934.0
  npm install @grafana/plugin-docs-cli@0.0.11-canary.2644.26276784934.0
  npm install @grafana/plugin-docs-parser@0.0.5-canary.2644.26276784934.0
  npm install @grafana/plugin-meta-extractor@0.12.3-canary.2644.26276784934.0
  # or 
  yarn add website@5.6.1-canary.2644.26276784934.0
  yarn add @grafana/create-plugin@7.6.1-canary.2644.26276784934.0
  yarn add @grafana/plugin-docs-cli@0.0.11-canary.2644.26276784934.0
  yarn add @grafana/plugin-docs-parser@0.0.5-canary.2644.26276784934.0
  yarn add @grafana/plugin-meta-extractor@0.12.3-canary.2644.26276784934.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
