### PR TITLE
fix(plugin-docs-cli): limit doc page nesting to 3 

### DIFF
--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
@@ -250,4 +250,60 @@ describe('checkFilesystem', () => {
 
     expect(findings.find((f) => f.rule === Rule.AllowedFileTypes)).toBeUndefined();
   });
+
+  it('should not report max-nesting-depth for pages at depth 3 or shallower', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'a'));
+    await writeFile(join(tmp, 'a', 'index.md'), '---\ntitle: A\n---\n');
+    await mkdir(join(tmp, 'a', 'b'));
+    await writeFile(join(tmp, 'a', 'b', 'page.md'), '---\ntitle: Page\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    expect(findings.find((f) => f.rule === Rule.MaxNestingDepth)).toBeUndefined();
+  });
+
+  it('should report max-nesting-depth as error in strict mode for pages deeper than 3 levels', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'a', 'b', 'c'), { recursive: true });
+    await writeFile(join(tmp, 'a', 'b', 'c', 'page.md'), '---\ntitle: Deep\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    const finding = findings.find((f) => f.rule === Rule.MaxNestingDepth);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(finding!.file).toContain(join('a', 'b', 'c', 'page.md'));
+    expect(finding!.title).toContain('4 levels');
+  });
+
+  it('should report max-nesting-depth as info in non-strict mode for pages deeper than 3 levels', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'a', 'b', 'c'), { recursive: true });
+    await writeFile(join(tmp, 'a', 'b', 'c', 'page.md'), '---\ntitle: Deep\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: false });
+
+    const finding = findings.find((f) => f.rule === Rule.MaxNestingDepth);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('info');
+  });
+
+  it('should report max-nesting-depth once per offending file', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'a', 'b', 'c'), { recursive: true });
+    await writeFile(join(tmp, 'a', 'b', 'c', 'one.md'), '---\ntitle: One\n---\n');
+    await writeFile(join(tmp, 'a', 'b', 'c', 'two.md'), '---\ntitle: Two\n---\n');
+    await mkdir(join(tmp, 'a', 'b', 'c', 'd'), { recursive: true });
+    await writeFile(join(tmp, 'a', 'b', 'c', 'd', 'three.md'), '---\ntitle: Three\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    const depthFindings = findings.filter((f) => f.rule === Rule.MaxNestingDepth);
+    expect(depthFindings).toHaveLength(3);
+  });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -43,14 +43,13 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
 
   // max-nesting-depth: report .md pages nested deeper than MAX_NESTING_DEPTH from docsPath
   for (const file of mdFiles) {
-    const filePath = join(file.parentPath, file.name);
-    const rel = relative(input.docsPath, filePath);
+    const rel = relative(input.docsPath, join(file.parentPath, file.name));
     const depth = rel.split(sep).length;
     if (depth > MAX_NESTING_DEPTH) {
       diagnostics.push({
         rule: Rule.MaxNestingDepth,
         severity: input.strict ? 'error' : 'info',
-        file: filePath,
+        file: rel,
         title: `Doc page nested too deeply (${depth} levels, max ${MAX_NESTING_DEPTH})`,
         detail: `"${rel}" is ${depth} levels from the docs root. Deeply nested pages are hard to discover in the sidebar nav. Flatten the structure so no page is more than ${MAX_NESTING_DEPTH} levels deep.`,
       });

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -1,10 +1,13 @@
 import { readdir } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
-import { join, extname, sep } from 'node:path';
+import { join, extname, relative, sep } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 
 // slug-safe: lowercase letters, digits and hyphens only
 const SLUG_SAFE_RE = /^[a-z0-9-]+$/;
+
+// max path segments from the docs root (e.g. `a/b/page.md` is 3)
+const MAX_NESTING_DEPTH = 3;
 
 // permitted image formats shared across filesystem and asset rules
 export const ALLOWED_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif']);
@@ -36,6 +39,22 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
       title: 'Symlinks are not allowed',
       detail: `"${link.name}" is a symbolic link. Use actual files instead of symlinks.`,
     });
+  }
+
+  // max-nesting-depth: report .md pages nested deeper than MAX_NESTING_DEPTH from docsPath
+  for (const file of mdFiles) {
+    const filePath = join(file.parentPath, file.name);
+    const rel = relative(input.docsPath, filePath);
+    const depth = rel.split(sep).length;
+    if (depth > MAX_NESTING_DEPTH) {
+      diagnostics.push({
+        rule: Rule.MaxNestingDepth,
+        severity: input.strict ? 'error' : 'info',
+        file: filePath,
+        title: `Doc page nested too deeply (${depth} levels, max ${MAX_NESTING_DEPTH})`,
+        detail: `"${rel}" is ${depth} levels from the docs root. Deeply nested pages are hard to discover in the sidebar nav. Flatten the structure so no page is more than ${MAX_NESTING_DEPTH} levels deep.`,
+      });
+    }
   }
 
   // allowed-file-types: non-.md files must be permitted image formats

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -10,6 +10,7 @@ export const Rule = {
   NoEmptyDir: 'no-empty-directories',
   NoSymlinks: 'no-symlinks',
   AllowedFileTypes: 'allowed-file-types',
+  MaxNestingDepth: 'max-nesting-depth',
   // frontmatter rules
   BlockExists: 'frontmatter-block-exists',
   ValidYaml: 'frontmatter-valid-yaml',


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the FS-7 max nesting depth rule to `@grafana/plugin-docs-cli` with a limit of 3 levels (so `a/b/page.md` is fine but `a/b/c/page.md` is too deep). Reports `info` during `serve` and `error` under `validate --strict`.

We need a hard cap because the SidebarNav component on the marketing website only looks sensible up to a handful of nesting levels - past that the nav gets cramped and pages become hard to discover. Better to stop authors before they ship a structure the rendered nav can't handle than to paper over it in the website.

**Which issue(s) this PR fixes**:

Part of the docs validation epic.

**Special notes for your reviewer**:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install website@5.6.1-canary.2646.26441606068.0
  npm install @grafana/create-plugin@7.6.1-canary.2646.26441606068.0
  npm install @grafana/plugin-docs-cli@0.0.11-canary.2646.26441606068.0
  npm install @grafana/plugin-meta-extractor@0.12.3-canary.2646.26441606068.0
  # or 
  yarn add website@5.6.1-canary.2646.26441606068.0
  yarn add @grafana/create-plugin@7.6.1-canary.2646.26441606068.0
  yarn add @grafana/plugin-docs-cli@0.0.11-canary.2646.26441606068.0
  yarn add @grafana/plugin-meta-extractor@0.12.3-canary.2646.26441606068.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
