### PR TITLE
feat: replace insecure sign script

### DIFF
--- a/docusaurus/docs/publish-a-plugin/sign-a-plugin.md
+++ b/docusaurus/docs/publish-a-plugin/sign-a-plugin.md
@@ -13,7 +13,7 @@ keywords:
 
 # Sign a plugin
 
-Grafana Labs signs all Grafana Labs-authored plugins, including Enterprise plugins, so that Grafana can verify their authenticity with signature verification. By default, Grafana requires all plugins to be signed before it loads them. 
+Grafana Labs signs all Grafana Labs-authored plugins, including Enterprise plugins, so that Grafana can verify their authenticity with signature verification. By default, Grafana requires all plugins to be signed before it loads them.
 
 Refer to [Plugin signatures](https://grafana.com/docs/grafana/latest/administration/plugin-management/plugin-sign/) for more details.
 
@@ -52,7 +52,7 @@ To verify ownership of your plugin, generate an Access Policy token that you use
 
 Plugins can have different [signature levels](https://grafana.com/legal/plugins/#what-are-the-different-classifications-of-plugins) depending on their author, related technology, and intended use.
 
-A plugin can be either _public_ or _private_: 
+A plugin can be either _public_ or _private_:
 
 - **Public plugins:** Grafana signs these as Community or Commercial. Grafana distributes them within the [Grafana plugin catalog](https://grafana.com/plugins) and makes them available for others to install.
 - **Private plugins:** These are only available for use within your organization.
@@ -74,7 +74,7 @@ The Grafana team needs to review public plugins before you can sign them.
 1. Sign the plugin. The Grafana sign-plugin tool creates a [MANIFEST.txt](#add-a-plugin-manifest-for-verification) file in the `dist` directory of your plugin:
 
    ```shell npm2yarn
-   npx @grafana/sign-plugin@latest
+   npm run sign
    ```
 
 ## Sign a private plugin
@@ -88,7 +88,7 @@ The Grafana team needs to review public plugins before you can sign them.
 1. Sign the plugin. The Grafana sign-plugin tool creates a [MANIFEST.txt](#add-a-plugin-manifest-for-verification) file in the `dist` directory of your plugin. After the `rootUrls` flag, enter a comma-separated list of URLs for the Grafana instances where you intend to install the plugin:
 
    ```shell npm2yarn
-   npx @grafana/sign-plugin@latest --rootUrls https://example.com/grafana
+   npm run sign -- --rootUrls https://example.com/grafana
    ```
 
 ## Add a plugin manifest for verification

--- a/packages/create-plugin/src/codemods/migrations/migrations.ts
+++ b/packages/create-plugin/src/codemods/migrations/migrations.ts
@@ -71,6 +71,13 @@ export default [
       'Fix ts-node compatibility with the latest @grafana/tsconfig: outdated module/moduleResolution/target overrides break TypeScript 5/6 builds, replaced with nodenext/nodenext/es2022.',
     scriptPath: import.meta.resolve('./scripts/010-ts-node-nodenext.js'),
   },
+  {
+    name: '011-secure-sign-script',
+    version: '7.6.2',
+    description:
+      'Security: replace insecure inline `npx --yes @grafana/sign-plugin@latest` sign script with a locked @grafana/sign-plugin devDependency to prevent arbitrary code execution from a compromised @latest publish.',
+    scriptPath: import.meta.resolve('./scripts/011-secure-sign-script.js'),
+  },
   // Do not use LEGACY_UPDATE_CUTOFF_VERSION for new migrations. It is only used above to force migrations to run
   // for those written before the switch to updates as migrations.
 ] satisfies Migration[];

--- a/packages/create-plugin/src/codemods/migrations/migrations.ts
+++ b/packages/create-plugin/src/codemods/migrations/migrations.ts
@@ -73,7 +73,7 @@ export default [
   },
   {
     name: '011-secure-sign-script',
-    version: '7.6.2',
+    version: '7.6.3',
     description:
       'Security: replace insecure inline `npx --yes @grafana/sign-plugin@latest` sign script with a locked @grafana/sign-plugin devDependency to prevent arbitrary code execution from a compromised @latest publish.',
     scriptPath: import.meta.resolve('./scripts/011-secure-sign-script.js'),

--- a/packages/create-plugin/src/codemods/migrations/scripts/011-secure-sign-script.test.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/011-secure-sign-script.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import migrate from './011-secure-sign-script.js';
+import { Context } from '../../context.js';
+
+describe('011-secure-sign-script', () => {
+  it('should replace insecure sign script and add @grafana/sign-plugin devDependency', () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        scripts: {
+          sign: 'npx --yes @grafana/sign-plugin@latest',
+        },
+        devDependencies: {
+          '@grafana/tsconfig': '^2.0.1',
+        },
+      })
+    );
+
+    const result = migrate(context);
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+
+    expect(packageJson.scripts.sign).toBe('sign-plugin');
+    expect(packageJson.devDependencies['@grafana/sign-plugin']).toBe('^3.2.2');
+    expect(packageJson.devDependencies['@grafana/tsconfig']).toBe('^2.0.1');
+  });
+
+  it('should preserve trailing CLI flags when rewriting the sign script', () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        scripts: {
+          sign: 'npx --yes @grafana/sign-plugin@latest --rootUrls https://example.com/grafana',
+        },
+        devDependencies: {},
+      })
+    );
+
+    const result = migrate(context);
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+
+    expect(packageJson.scripts.sign).toBe('sign-plugin --rootUrls https://example.com/grafana');
+    expect(packageJson.devDependencies['@grafana/sign-plugin']).toBe('^3.2.2');
+  });
+
+  it('should match the -y short flag as well as --yes', () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        scripts: {
+          sign: 'npx -y @grafana/sign-plugin@latest',
+        },
+        devDependencies: {},
+      })
+    );
+
+    const result = migrate(context);
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+
+    expect(packageJson.scripts.sign).toBe('sign-plugin');
+  });
+
+  it('should leave a customised sign script alone but still add the devDependency', () => {
+    const context = new Context('/virtual');
+    const customSign = './scripts/my-custom-sign.sh';
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        scripts: {
+          sign: customSign,
+        },
+        devDependencies: {},
+      })
+    );
+
+    const result = migrate(context);
+    const packageJson = JSON.parse(result.getFile('package.json') || '{}');
+
+    expect(packageJson.scripts.sign).toBe(customSign);
+    expect(packageJson.devDependencies['@grafana/sign-plugin']).toBe('^3.2.2');
+  });
+
+  it('should be a no-op when already migrated', () => {
+    const context = new Context('/virtual');
+    const original = JSON.stringify({
+      scripts: {
+        sign: 'sign-plugin',
+      },
+      devDependencies: {
+        '@grafana/sign-plugin': '^3.2.2',
+      },
+    });
+    context.addFile('package.json', original);
+
+    const result = migrate(context);
+
+    expect(result.getFile('package.json')).toBe(original);
+  });
+
+  it('should be a no-op when package.json does not exist', () => {
+    const context = new Context('/virtual');
+
+    const result = migrate(context);
+
+    expect(result.hasChanges()).toBe(false);
+  });
+
+  it('should be idempotent', async () => {
+    const context = new Context('/virtual');
+    context.addFile(
+      'package.json',
+      JSON.stringify({
+        scripts: {
+          sign: 'npx --yes @grafana/sign-plugin@latest',
+        },
+        devDependencies: {},
+      })
+    );
+
+    await expect(migrate).toBeIdempotent(context);
+  });
+});

--- a/packages/create-plugin/src/codemods/migrations/scripts/011-secure-sign-script.ts
+++ b/packages/create-plugin/src/codemods/migrations/scripts/011-secure-sign-script.ts
@@ -1,0 +1,26 @@
+import type { Context } from '../../context.js';
+import { addDependenciesToPackageJson } from '../../utils.js';
+
+const SIGN_PLUGIN_VERSION = '^3.2.2';
+const NEW_SIGN_SCRIPT = 'sign-plugin';
+const INSECURE_SIGN_PATTERN = /^npx\s+(?:--yes|-y)\s+@grafana\/sign-plugin(?:@\S+)?(\s.*)?$/;
+
+export default function migrate(context: Context) {
+  if (!context.doesFileExist('package.json')) {
+    return context;
+  }
+
+  const packageJson = JSON.parse(context.getFile('package.json') || '{}');
+  const currentSign: string | undefined = packageJson.scripts?.sign;
+  const match = currentSign?.match(INSECURE_SIGN_PATTERN);
+
+  if (match) {
+    const trailingArgs = match[1] ?? '';
+    packageJson.scripts.sign = `${NEW_SIGN_SCRIPT}${trailingArgs}`;
+    context.updateFile('package.json', JSON.stringify(packageJson, null, 2));
+  }
+
+  addDependenciesToPackageJson(context, {}, { '@grafana/sign-plugin': SIGN_PLUGIN_VERSION });
+
+  return context;
+}

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -11,13 +11,14 @@
     "lint:fix": "{{ packageManagerName }} run lint{{#if isNPM}} --{{/if}} --fix && prettier --write --list-different .",
     "e2e": "playwright test",
     "server": "docker compose up --build",
-    "sign": "npx --yes @grafana/sign-plugin@latest"
+    "sign": "sign-plugin"
   },
   "author": "{{ sentenceCase orgName }}",
   "license": "Apache-2.0",
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
     "@grafana/plugin-e2e": "^3.6.1",
+    "@grafana/sign-plugin": "^3.2.2",
     "@grafana/tsconfig": "^2.0.1",
     "@playwright/test": "^1.57.0",{{#if useExperimentalRspack}}
     "@rspack/core": "^1.6.0",


### PR DESCRIPTION
## Summary

- Adds migration `011-secure-sign-script` that rewrites the insecure `"sign": "npx --yes @grafana/sign-plugin@latest"` script in existing plugins to `"sign": "sign-plugin"` and pins `@grafana/sign-plugin` as a `devDependency`. `--yes @latest` auto-installs whatever is currently published as `latest`, so a compromised publish could execute arbitrary code in CI / on developer machines; the lockfile-pinned devDep removes that surface.
- Updates the scaffold template `templates/common/_package.json` so newly-created plugins ship in the secure state by default.
- Updates `docusaurus/docs/publish-a-plugin/sign-a-plugin.md` to recommend `npm run sign` (and `npm run sign -- --rootUrls ...` for private plugins) over the ad-hoc `npx @grafana/sign-plugin@latest` invocation.

The migration is gated on the original insecure pattern, so any user customisation of the `sign` script (extra flags or a different command) is preserved — only the canonical insecure form is rewritten.

## Test plan

- [x] `npm run lint -w @grafana/create-plugin` — clean
- [x] `npm run typecheck -w @grafana/create-plugin` — clean
- [x] `npm run test -w @grafana/create-plugin -- --run` — 262 passed (incl. 7 new tests covering happy path, trailing-flag preservation, `-y` short flag, custom-script preservation, already-migrated no-op, missing-package.json no-op, idempotency)
- [ ] Reviewer: skim the docs change for tone alignment with the rest of the writers-toolkit guidance
- [ ] Reviewer: confirm the migration `version: '7.6.2'` is the next patch from the current `7.6.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @grafana/create-plugin@7.7.0-canary.2656.26454058960.0
  # or 
  yarn add @grafana/create-plugin@7.7.0-canary.2656.26454058960.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
