### PR TITLE
Plugin Docs Parser: Reduce dependency footprint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14657,6 +14657,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "license": "MIT"
@@ -24143,19 +24150,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-heading-rank": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
-      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-is-body-ok-link": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
@@ -24618,6 +24612,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
       "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -36929,29 +36924,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-slug": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
-      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "github-slugger": "^2.0.0",
-        "hast-util-heading-rank": "^3.0.0",
-        "hast-util-to-string": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-slug/node_modules/github-slugger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
-      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
-      "license": "ISC"
-    },
     "node_modules/relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -43374,11 +43346,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/hast": "^3.0.0",
-        "gray-matter": "^4.0.3",
-        "hast-util-to-string": "^3.0.0",
-        "rehype-raw": "^7.0.0",
+        "js-yaml": "^4.1.1",
         "rehype-sanitize": "^6.0.0",
-        "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.0",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.0.0",
@@ -43387,6 +43356,7 @@
         "vfile": "^6.0.0"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "hast-util-to-html": "^9.0.0"
       },
       "engines": {

--- a/packages/plugin-docs-parser/package.json
+++ b/packages/plugin-docs-parser/package.json
@@ -45,11 +45,8 @@
   },
   "dependencies": {
     "@types/hast": "^3.0.0",
-    "gray-matter": "^4.0.3",
-    "hast-util-to-string": "^3.0.0",
-    "rehype-raw": "^7.0.0",
+    "js-yaml": "^4.1.1",
     "rehype-sanitize": "^6.0.0",
-    "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.0.0",
@@ -58,6 +55,7 @@
     "vfile": "^6.0.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "hast-util-to-html": "^9.0.0"
   }
 }

--- a/packages/plugin-docs-parser/src/parser.test.ts
+++ b/packages/plugin-docs-parser/src/parser.test.ts
@@ -86,7 +86,7 @@ Body text here.`;
     expect(html).toContain('Title');
   });
 
-  it('should preserve safe raw HTML elements like <details>', () => {
+  it('should drop raw HTML elements per the docs spec', () => {
     const markdown = `## FAQ
 
 <details>
@@ -99,8 +99,10 @@ It works by parsing markdown.
     const result = parseMarkdown(markdown);
     const html = toHtml(result.hast);
 
-    expect(html).toContain('<details>');
-    expect(html).toContain('<summary>');
+    // raw HTML is forbidden by the docs spec, so <details>/<summary> get stripped
+    expect(html).not.toContain('<details>');
+    expect(html).not.toContain('<summary>');
+    // text content inside the raw block is preserved as a regular paragraph
     expect(html).toContain('It works by parsing markdown.');
   });
 

--- a/packages/plugin-docs-parser/src/parser.ts
+++ b/packages/plugin-docs-parser/src/parser.ts
@@ -69,7 +69,11 @@ function parseFrontmatter(content: string): { data: Record<string, unknown>; con
   if (!match) {
     return { data: {}, content };
   }
-  const data = (yaml.load(match[1]) ?? {}) as Record<string, unknown>;
+  // yaml.load can return scalars or arrays for malformed frontmatter; coerce
+  // anything that isn't a plain object back to {} so the public type holds.
+  const parsed = yaml.load(match[1]);
+  const data =
+    parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
   return { data, content: match[2] };
 }
 
@@ -96,8 +100,8 @@ export function parseMarkdown(content: string, options?: ParseOptions): ParsedMa
   }
 
   // build the unified pipeline: markdown → mdast → hast.
-  // raw HTML in markdown is forbidden by the docs spec (see DESIGN_DOC.md),
-  // so allowDangerousHtml is off and any inline HTML gets dropped by remark-rehype.
+  // raw HTML in markdown is forbidden by the docs spec, so allowDangerousHtml
+  // is off and any inline HTML gets dropped by remark-rehype.
   const processor = unified().use(remarkParse).use(remarkGfm).use(remarkRehype).use(rehypeStripH1).use(rehypeSlug);
 
   // rewrite asset paths before sanitization so URLs are final

--- a/packages/plugin-docs-parser/src/parser.ts
+++ b/packages/plugin-docs-parser/src/parser.ts
@@ -2,11 +2,10 @@ import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 import remarkRehype from 'remark-rehype';
-import rehypeRaw from 'rehype-raw';
-import rehypeSlug from 'rehype-slug';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
-import matter from 'gray-matter';
+import * as yaml from 'js-yaml';
 import { VFile } from 'vfile';
+import { rehypeSlug } from './plugins/rehype-slug.js';
 import type { Root as HastRoot } from 'hast';
 import { rehypeRewriteAssetPaths } from './plugins/rehype-rewrite-asset-paths.js';
 import { rehypeRewriteDocLinks } from './plugins/rehype-rewrite-doc-links.js';
@@ -63,6 +62,17 @@ export interface ParsedMarkdown {
 // the default schema already allows id (via clobber) and className on code (for language-* classes).
 const sanitizeSchema = { ...defaultSchema, clobberPrefix: '' };
 
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)([\s\S]*)$/;
+
+function parseFrontmatter(content: string): { data: Record<string, unknown>; content: string } {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) {
+    return { data: {}, content };
+  }
+  const data = (yaml.load(match[1]) ?? {}) as Record<string, unknown>;
+  return { data, content: match[2] };
+}
+
 /**
  * Parses markdown content into a HAST tree with extracted frontmatter and headings.
  *
@@ -72,12 +82,12 @@ const sanitizeSchema = { ...defaultSchema, clobberPrefix: '' };
  * @throws {Error} If markdown parsing fails
  */
 export function parseMarkdown(content: string, options?: ParseOptions): ParsedMarkdown {
-  // extract frontmatter using gray-matter
+  // extract frontmatter
   let frontmatter: Record<string, unknown>;
   let markdownContent: string;
 
   try {
-    const result = matter(content);
+    const result = parseFrontmatter(content);
     frontmatter = result.data;
     markdownContent = result.content;
   } catch (error) {
@@ -85,17 +95,10 @@ export function parseMarkdown(content: string, options?: ParseOptions): ParsedMa
     throw new Error(`Failed to extract frontmatter: ${message}`);
   }
 
-  // build the unified pipeline: markdown → mdast → hast
-  const processor = unified()
-    .use(remarkParse)
-    .use(remarkGfm)
-    // allow raw HTML in markdown (e.g. <details>, <img>) to pass through to hast;
-    // rehype-raw parses the raw nodes into proper hast elements so
-    // rehype-sanitize can inspect and strip anything dangerous
-    .use(remarkRehype, { allowDangerousHtml: true })
-    .use(rehypeRaw)
-    .use(rehypeStripH1)
-    .use(rehypeSlug);
+  // build the unified pipeline: markdown → mdast → hast.
+  // raw HTML in markdown is forbidden by the docs spec (see DESIGN_DOC.md),
+  // so allowDangerousHtml is off and any inline HTML gets dropped by remark-rehype.
+  const processor = unified().use(remarkParse).use(remarkGfm).use(remarkRehype).use(rehypeStripH1).use(rehypeSlug);
 
   // rewrite asset paths before sanitization so URLs are final
   if (options?.assetBaseUrl) {

--- a/packages/plugin-docs-parser/src/plugins/rehype-extract-headings.ts
+++ b/packages/plugin-docs-parser/src/plugins/rehype-extract-headings.ts
@@ -1,8 +1,18 @@
 import type { Root, Element } from 'hast';
+import type { Node } from 'unist';
 import type { VFile } from 'vfile';
 import { visit } from 'unist-util-visit';
-import { toString } from 'hast-util-to-string';
 import type { Heading } from '../types.js';
+
+function hastToString(node: Node): string {
+  if ('value' in node) {
+    return node.value as string;
+  }
+  if ('children' in node) {
+    return (node.children as Node[]).map(hastToString).join('');
+  }
+  return '';
+}
 
 declare module 'vfile' {
   interface DataMap {
@@ -31,7 +41,7 @@ export function rehypeExtractHeadings() {
       headings.push({
         level: node.tagName === 'h2' ? 2 : 3,
         id,
-        text: toString(node),
+        text: hastToString(node),
       });
     });
 

--- a/packages/plugin-docs-parser/src/plugins/rehype-slug.test.ts
+++ b/packages/plugin-docs-parser/src/plugins/rehype-slug.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import type { Root, Element, Text, Properties } from 'hast';
+import { rehypeSlug } from './rehype-slug.js';
+
+function el(tag: string, text: string, properties: Properties = {}): Element {
+  const child: Text = { type: 'text', value: text };
+  return { type: 'element', tagName: tag, properties, children: [child] };
+}
+
+function tree(...children: Element[]): Root {
+  return { type: 'root', children };
+}
+
+function getEl(root: Root, index: number): Element {
+  const child = root.children[index];
+  if (child.type !== 'element') {
+    throw new Error(`expected element at index ${index}, got ${child.type}`);
+  }
+  return child;
+}
+
+describe('rehypeSlug', () => {
+  const transform = rehypeSlug();
+
+  it('should add id attributes to headings', () => {
+    const root = tree(el('h2', 'Getting Started'), el('h3', 'Prerequisites'));
+    transform(root);
+
+    expect(getEl(root, 0).properties).toMatchObject({ id: 'getting-started' });
+    expect(getEl(root, 1).properties).toMatchObject({ id: 'prerequisites' });
+  });
+
+  it('should lowercase and strip punctuation when slugifying', () => {
+    const root = tree(el('h2', "What's New?"));
+    transform(root);
+
+    expect(getEl(root, 0).properties).toMatchObject({ id: 'whats-new' });
+  });
+
+  it('should suffix duplicate headings with -1, -2, ...', () => {
+    const root = tree(el('h2', 'Setup'), el('h2', 'Setup'), el('h2', 'Setup'));
+    transform(root);
+
+    expect(getEl(root, 0).properties).toMatchObject({ id: 'setup' });
+    expect(getEl(root, 1).properties).toMatchObject({ id: 'setup-1' });
+    expect(getEl(root, 2).properties).toMatchObject({ id: 'setup-2' });
+  });
+
+  it('should leave pre-existing ids untouched', () => {
+    const root = tree(el('h2', 'Setup', { id: 'custom-anchor' }));
+    transform(root);
+
+    expect(getEl(root, 0).properties).toMatchObject({ id: 'custom-anchor' });
+  });
+
+  it('should not count pre-existing ids toward dedupe', () => {
+    const root = tree(el('h2', 'Setup', { id: 'setup' }), el('h2', 'Setup'));
+    transform(root);
+
+    // the second heading still gets the unsuffixed slug because the visitor
+    // only tracks ids it has assigned itself
+    expect(getEl(root, 1).properties).toMatchObject({ id: 'setup' });
+  });
+
+  it('should skip headings that slugify to empty (emoji or punctuation only)', () => {
+    const root = tree(el('h2', '🎉'), el('h2', '!!!'));
+    transform(root);
+
+    expect(getEl(root, 0).properties).not.toHaveProperty('id');
+    expect(getEl(root, 1).properties).not.toHaveProperty('id');
+  });
+
+  it('should slugify across all h1-h6 levels', () => {
+    const root = tree(el('h1', 'Title'), el('h4', 'Deep'), el('h6', 'Deeper'));
+    transform(root);
+
+    expect(getEl(root, 0).properties).toMatchObject({ id: 'title' });
+    expect(getEl(root, 1).properties).toMatchObject({ id: 'deep' });
+    expect(getEl(root, 2).properties).toMatchObject({ id: 'deeper' });
+  });
+
+  it('should ignore non-heading elements', () => {
+    const root = tree(el('p', 'A paragraph'), el('div', 'A div'));
+    transform(root);
+
+    expect(getEl(root, 0).properties).not.toHaveProperty('id');
+    expect(getEl(root, 1).properties).not.toHaveProperty('id');
+  });
+
+  it('should concatenate text from nested children', () => {
+    const inner: Element = {
+      type: 'element',
+      tagName: 'code',
+      properties: {},
+      children: [{ type: 'text', value: 'parseMarkdown' } as Text],
+    };
+    const heading: Element = {
+      type: 'element',
+      tagName: 'h2',
+      properties: {},
+      children: [{ type: 'text', value: 'The ' } as Text, inner, { type: 'text', value: ' function' } as Text],
+    };
+    const root = tree(heading);
+    transform(root);
+
+    expect(getEl(root, 0).properties).toMatchObject({ id: 'the-parsemarkdown-function' });
+  });
+
+  it('should handle an empty tree', () => {
+    const root = tree();
+    transform(root);
+
+    expect(root.children).toHaveLength(0);
+  });
+});

--- a/packages/plugin-docs-parser/src/plugins/rehype-slug.ts
+++ b/packages/plugin-docs-parser/src/plugins/rehype-slug.ts
@@ -1,0 +1,49 @@
+import type { Root, Element } from 'hast';
+import { visit } from 'unist-util-visit';
+import type { Node } from 'unist';
+
+// headings ranked h1-h6
+const HEADING_TAGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+function nodeToString(node: Node): string {
+  if ('value' in node) {
+    return node.value as string;
+  }
+  if ('children' in node) {
+    return (node.children as Node[]).map(nodeToString).join('');
+  }
+  return '';
+}
+
+// lowercases, strips non-word chars (preserving hyphens), collapses whitespace to hyphens.
+// matches github-slugger behaviour for ASCII content.
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/[\s]+/g, '-');
+}
+
+/**
+ * Rehype plugin that adds `id` attributes to heading elements.
+ * Duplicate headings get a numeric suffix (-1, -2, ...).
+ */
+export function rehypeSlug() {
+  return (tree: Root) => {
+    const seen = new Map<string, number>();
+
+    visit(tree, 'element', (node: Element) => {
+      if (!HEADING_TAGS.has(node.tagName) || node.properties?.id) {
+        return;
+      }
+
+      const base = slugify(nodeToString(node));
+      const count = seen.get(base) ?? 0;
+      seen.set(base, count + 1);
+
+      node.properties = node.properties ?? {};
+      node.properties.id = count === 0 ? base : `${base}-${count}`;
+    });
+  };
+}

--- a/packages/plugin-docs-parser/src/plugins/rehype-slug.ts
+++ b/packages/plugin-docs-parser/src/plugins/rehype-slug.ts
@@ -39,6 +39,11 @@ export function rehypeSlug() {
       }
 
       const base = slugify(nodeToString(node));
+      // skip if the heading produced no usable slug (e.g. emoji or punctuation only)
+      if (!base) {
+        return;
+      }
+
       const count = seen.get(base) ?? 0;
       seen.set(base, count + 1);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`@grafana/plugin-docs-parser` is about to be installed in the marketing-website repo. Keeping its direct and transitive deps to a minimum reduces the supply-chain attack surface and the ongoing maintenance cost of managing CVEs that bubble up through the tree.

This PR inlines three hardly-used deps and replaces one:

- Inline `hast-util-to-string` as a 4-line helper (one call site, in heading extraction)
- Inline `rehype-slug` as a local plugin with the same slug + dedupe behaviour
- Drop `rehype-raw` and `allowDangerousHtml` - raw HTML in plugin docs is forbidden by spec, so the `parse5` subtree was unused
- Replace `gray-matter` with `js-yaml` v4 plus a small frontmatter regex (gray-matter pulled in `js-yaml@3` plus three other subdeps)

Net effect: 9 direct deps (down from 12) and ~75 fewer packages in the production install tree. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/plugin-tools/issues/2649

**Special notes for your reviewer**: