### PR TITLE
Renovate: Drop duplicate no-changelog labels

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -94,7 +94,6 @@
       "automerge": true,
       "groupName": "auto-merged devDependencies",
       "groupSlug": "dev-dependencies-automerge",
-      "addLabels": ["no-changelog"],
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["devDependencies", "optionalDependencies"],
       "matchPackageNames": [
@@ -109,7 +108,6 @@
       "automerge": true,
       "groupName": "auto-merged patch dependencies",
       "groupSlug": "prod-dependencies-automerge",
-      "addLabels": ["no-changelog"],
       "matchCurrentVersion": "!/^0/",
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
### What changed?
Removed `"addLabels": ["no-changelog"]` from the `auto-merged devDependencies` and `auto-merged patch dependencies` package rules in `.github/renovate.json`. The top-level `labels` 
  array already includes `"no-changelog"`, so these were duplicates.

### Why?
Found while auditing the renovate config — purely a cleanup, no behavior change.