### PR TITLE
ci: replace stale dependabot guards with renovate

### DIFF
--- a/.github/actions/check-labels/index.js
+++ b/.github/actions/check-labels/index.js
@@ -21,7 +21,7 @@ async function run() {
     const hasReleaseLabel = labelNames.includes('release');
     const userName = pull_request?.user.login;
 
-    if (userName === 'renovate[bot]') {
+    if (userName === 'renovate[bot]' || userName === 'renovate-sh-app[bot]') {
       if (isMissingSemverLabel) {
         const files = await getPullRequestFiles({ octokit });
 

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -16,7 +16,6 @@ permissions:
 
 jobs:
   check-labels:
-    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-x64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,14 +475,14 @@ jobs:
         working-directory: ./${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
-        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'renovate[bot]' && github.event.pull_request.head.repo.fork != true }}
+        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'renovate[bot]' && github.actor != 'renovate-sh-app[bot]' && github.event.pull_request.head.repo.fork != true }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
         working-directory: ./${{ matrix.workingDir }}
 
       - name: Frontend Knip Report
-        if: ${{ github.actor != 'renovate[bot]' }}
+        if: ${{ github.actor != 'renovate[bot]' && github.actor != 'renovate-sh-app[bot]' }}
         # Knip uses the scaffolded plugin .gitignore file for ignore paths.
         # github workflows use paths like home/runner/work/plugin-tools/plugin-tools
         # so we need to remove /work otherwise knip returns false positives
@@ -516,7 +516,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, generate-plugins]
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.actor != 'renovate[bot]'"
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.actor != 'renovate[bot]' && github.actor != 'renovate-sh-app[bot]'"
     name: Release packages
     env:
       NX_BRANCH: ${{ github.event.number || github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -475,14 +475,14 @@ jobs:
         working-directory: ./${{ matrix.workingDir }}
 
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
-        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork != true }}
+        if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'renovate[bot]' && github.event.pull_request.head.repo.fork != true }}
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
         working-directory: ./${{ matrix.workingDir }}
 
       - name: Frontend Knip Report
-        if: ${{ github.actor != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'renovate[bot]' }}
         # Knip uses the scaffolded plugin .gitignore file for ignore paths.
         # github workflows use paths like home/runner/work/plugin-tools/plugin-tools
         # so we need to remove /work otherwise knip returns false positives
@@ -516,7 +516,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, generate-plugins]
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.actor != 'dependabot[bot]'"
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.actor != 'renovate[bot]'"
     name: Release packages
     env:
       NX_BRANCH: ${{ github.event.number || github.ref_name }}


### PR DESCRIPTION
### What changed?

Replaced the stale `github.actor != 'dependabot[bot]'` guards in our GitHub workflows with `renovate[bot]` - I think this makes sense as we don't rely on dependabot for things like this now?