### PR TITLE
Plugin E2E: Fix flaky alerting, TLS, and permissions tests on slow CI

### DIFF
--- a/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
@@ -2,9 +2,12 @@ import * as semver from 'semver';
 import { AlertRuleArgs, NavigateOptions, PluginTestCtx, RequestOptions } from '../../types';
 import { GrafanaPage } from './GrafanaPage';
 import { AlertRuleQuery } from '../components/AlertRuleQuery';
-import { expect } from '@playwright/test';
+import { expect, Locator } from '@playwright/test';
 import { isLegacyFeatureEnabled } from '../../fixtures/isFeatureToggleEnabled';
 const QUERY_AND_EXPRESSION_STEP_ID = '2';
+// Alert pages render slowly on busy CI runners; give the rendering 15s headroom
+// before falling back to default 5s expect timeouts for downstream interactions.
+const ALERT_PAGE_READY_TIMEOUT = 15_000;
 
 export class AlertRuleEditPage extends GrafanaPage {
   constructor(
@@ -48,13 +51,13 @@ export class AlertRuleEditPage extends GrafanaPage {
     );
 
     if (alertingQueryAndExpressionsStepMode) {
-      await expect(this.advancedModeSwitch).toBeVisible();
-      await expect(this.advancedModeSwitch).toHaveCount(1);
+      await expect(this.advancedModeSwitch).toBeVisible({ timeout: ALERT_PAGE_READY_TIMEOUT });
+      await expect(this.advancedModeSwitch).toHaveCount(1, { timeout: ALERT_PAGE_READY_TIMEOUT });
       return true;
     }
 
-    await expect(this.advancedModeSwitch).not.toBeVisible();
-    await expect(this.advancedModeSwitch).toHaveCount(0);
+    await expect(this.advancedModeSwitch).not.toBeVisible({ timeout: ALERT_PAGE_READY_TIMEOUT });
+    await expect(this.advancedModeSwitch).toHaveCount(0, { timeout: ALERT_PAGE_READY_TIMEOUT });
     return false;
   }
 
@@ -93,18 +96,20 @@ export class AlertRuleEditPage extends GrafanaPage {
   async getQueryRow(refId = 'A'): Promise<AlertRuleQuery> {
     const advancedModeSupported = await this.isAdvancedModeSupported();
 
+    let locator: Locator;
     if (advancedModeSupported && !(await this.advancedModeSwitch.isChecked()) && refId === 'A') {
       // return the default query row
-      return new AlertRuleQuery(
-        this.ctx,
-        this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRows.rows)
-      );
+      locator = this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRows.rows);
+    } else {
+      // return query by refId
+      locator = this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRows.rows).filter({
+        has: this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRow.title(refId)),
+      });
     }
 
-    // return query by refId
-    const locator = this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRows.rows).filter({
-      has: this.getByGrafanaSelector(this.ctx.selectors.components.QueryEditorRow.title(refId)),
-    });
+    // Wait for the row to be mounted so subsequent interactions (e.g. setting the
+    // datasource) don't race against the alert page still rendering under slow CI.
+    await locator.first().waitFor({ state: 'visible', timeout: ALERT_PAGE_READY_TIMEOUT });
 
     return new AlertRuleQuery(this.ctx, locator);
   }
@@ -188,7 +193,7 @@ export class AlertRuleEditPage extends GrafanaPage {
       evaluateButton = this.ctx.page.getByRole('button', { name: 'Preview', exact: true });
     }
 
-    await expect(evaluateButton).toBeVisible();
+    await expect(evaluateButton).toBeVisible({ timeout: ALERT_PAGE_READY_TIMEOUT });
 
     const evalReq = this.ctx.page
       .waitForRequest((req) => req.url().includes(this.ctx.selectors.apis.Alerting.eval), {

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/feature-toggles/queryEditor.tlsEnabled.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/feature-toggles/queryEditor.tlsEnabled.spec.ts
@@ -33,5 +33,5 @@ test('should display TLS enabled field when tlsEnabled feature toggle is set to 
     : semver.lt(grafanaVersion, '11.5.0')
       ? row.getByLabel('TLS Enabled')
       : row.getByRole('switch', { name: /TLS Enabled/i });
-  await expect(locator).toBeVisible();
+  await expect(locator).toBeVisible({ timeout: 15_000 });
 });

--- a/packages/plugin-e2e/tests/as-viewer-user/permissions.spec.ts
+++ b/packages/plugin-e2e/tests/as-viewer-user/permissions.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from '../../src';
 
 test('should redirect to start page when permissions to navigate to page is missing', async ({ page }) => {
   await page.goto('/');
-  await page.goto('/datasources', { waitUntil: 'networkidle' });
-  expect(new URL(page.url()).pathname).not.toContain('datasources');
+  await page.goto('/datasources');
+  // viewer lacks /datasources permission; wait for Grafana to redirect away rather
+  // than relying on `networkidle`, which is flaky under slow CI.
+  await expect(page).not.toHaveURL(/\/datasources/, { timeout: 15_000 });
 });


### PR DESCRIPTION
## What this PR does / why we need it

Fixes flaky E2E test failures observed on `grafana-enterprise@12.1.10` in CI. The self-hosted CI runners are roughly **8x slower** than local development machines (the full test suite takes ~12 minutes in CI vs ~1.5 minutes locally). Under that load, several tests hit the default 5-second `expect` timeout before the page had finished rendering.

These failures never reproduce locally because pages render well within 5 seconds on a fast machine. They only surface in CI where the runners are under heavier load.

### Changes

**`AlertRuleEditPage.ts`** (alerting-scoped only — no global timeout changes):
- Bump `isAdvancedModeSupported()` assertions from 5s to 15s
- `getQueryRow()` now waits for the query editor row to be visible (15s) before returning, so `DataSourcePicker.set()` doesn't race against a still-rendering page
- Bump `evaluate()` preview-button assertion from 5s to 15s

**`queryEditor.tlsEnabled.spec.ts`**: Bump `toBeVisible` from 5s to 15s

**`permissions.spec.ts`**: Replace `waitUntil: 'networkidle'` (inherently flaky under load) with `expect(page).not.toHaveURL(/\/datasources/)` which auto-retries until the redirect completes

### How we verified

We created test harnesses that emulate slow CI conditions using Chrome DevTools Protocol throttling (50x CPU slowdown + 600ms network latency). Under that throttle:

- **Before fix**: tests fail with `expect(locator).toBeVisible() — Timeout: 5000ms` — the exact same error pattern seen in CI
- **After fix**: all tests pass consistently (verified 3 runs under throttle, plus 3 runs without throttle to confirm no regressions)

## Test plan
- [x] All 19 affected tests pass locally without throttle on Grafana 12.1.10
- [x] All slow-sim tests (alerting, TLS, permissions) pass under extreme throttle (50x CPU, 600ms latency)
- [x] No changes to global config — timeouts are scoped to the alerting page model and two individual test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)