### PR TITLE
ci: replace auto canary releases with pkg.pr.new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [test, generate-plugins]
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci') && github.actor != 'dependabot[bot]'"
+    if: |
+      !contains(github.event.head_commit.message, 'ci skip')
+      && !contains(github.event.head_commit.message, 'skip ci')
+      && github.actor != 'dependabot[bot]'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
     name: Release packages
     env:
       NX_BRANCH: ${{ github.event.number || github.ref_name }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,9 +20,9 @@ jobs:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
           persist-credentials: false
-      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       - name: Setup nodejs
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           package-manager-cache: false

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,7 +4,6 @@ on:
     types: [labeled, synchronize]
 permissions:
   contents: read
-  id-token: write
 concurrency:
   group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,10 @@ on:
     types: [labeled, synchronize]
 permissions:
   contents: read
+  id-token: write
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
   preview:
     if: |
@@ -11,12 +15,22 @@ jobs:
       (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          node-version-file: .nvmrc
+          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: nrwl/nx-set-shas@3e9ad7370203c1e93d109be57f3b72eb0eb511b1 # v4.4.0
+      - name: Setup nodejs
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: '.nvmrc'
           package-manager-cache: false
 
-      - run: npm ci
-      - run: npm run build
-      - run: npx pkg-pr-new publish './packages/*' --compact --commentWithSha --commentWithDev
+      - name: Install dependencies
+        run: npm ci --no-audit
+      - name: Build all packages
+        run: npm run build
+      - name: Publish packages
+        run: npx pkg-pr-new publish './packages/*' --compact --commentWithSha --commentWithDev

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,22 @@
+name: Preview (pkg.pr.new)
+on:
+  pull_request:
+    types: [labeled, synchronize]
+permissions:
+  contents: read
+jobs:
+  preview:
+    if: |
+      (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - run: npm ci
+      - run: npm run build
+      - run: npx pkg-pr-new publish './packages/*' --compact --commentWithSha --commentWithDev

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Build all packages
         run: npm run build
       - name: Publish packages
-        run: npx pkg-pr-new publish './packages/*' --compact --commentWithSha --commentWithDev
+        run: npm exec pkg-pr-new publish -- './packages/*' --compact --commentWithSha --commentWithDev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,10 @@
   - [Contribute Documentation](#contribute-documentation)
   - [Contribute Code](#contribute-code)
 - Manage Something ✅🙆🏼💃👔
-  - [Create a Release](#create-a-release)
-    - [Release Version Calculation](#release-version-calculation)
-    - [Help! The release failed after the packages were published to the NPM registry](#help-the-release-failed-after-the-packages-were-published-to-the-npm-registry)
+- [Preview Your Changes Before Release](#preview-your-changes-before-release)
+- [Create a Release](#create-a-release)
+  - [Release Version Calculation](#release-version-calculation)
+  - [Help! The release failed after the packages were published to the NPM registry](#help-the-release-failed-after-the-packages-were-published-to-the-npm-registry)
 
 ## Introduction
 
@@ -159,6 +160,33 @@ Once you've filed the PR:
 - If the maintainer asks for any changes, edit your changes, push, and ask for another review. Additional tags (such as `needs-tests`) will be added depending on the review.
 - If the maintainer decides to pass on your PR, they will thank you for the contribution and explain why they won't be accepting the changes. That's okay! We still really appreciate you taking the time to do it, and we don't take that lightly. 💚
 - If your PR gets accepted, it will be marked as such, and merged into the `main` branch soon after. Your contribution will be distributed to the masses next time the maintainers [create a release](#create-a-release)
+
+## Preview Your Changes Before Release
+
+Whilst developing new features it possible to publish and install preview builds of every affected package using [pkg.pr.new](https://pkg.pr.new) — a free open-source service that builds and hosts SHA-keyed npm tarballs.
+
+To opt in:
+
+1. Add the `preview` label to your PR.
+2. CI builds every workspace and publishes the affected packages to pkg.pr.new.
+3. The [`pkg-pr-new[bot]`](https://github.com/apps/pkg-pr-new) posts a comment on the PR with one installable URL per affected package.
+
+Consumers install the preview by URL:
+
+```bash
+npm i https://pkg.pr.new/grafana/plugin-tools/@grafana/<package-name>@<commit-sha>
+```
+
+For CLI packages (`create-plugin`, `plugin-docs-cli`, `plugin-meta-extractor`, `plugin-types-bundler`, `react-detect`, `sign-plugin`), you can also run the binary directly without installing:
+
+```bash
+npx https://pkg.pr.new/grafana/plugin-tools/@grafana/<cli-package>@<commit-sha>
+```
+
+> [!IMPORTANT]
+> The URL keys off the commit SHA, not a real semver version. Any `package.json` reference to a pkg.pr.new URL must be swapped back to the published version once the PR is merged and released.
+
+When you push new commits to a PR with the `preview` label, the existing pkg.pr.new comment is updated in place with the new commit sha.
 
 ## Create A Release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,10 @@
   - [Contribute Documentation](#contribute-documentation)
   - [Contribute Code](#contribute-code)
 - Manage Something ✅🙆🏼💃👔
-- [Preview Your Changes Before Release](#preview-your-changes-before-release)
-- [Create a Release](#create-a-release)
-  - [Release Version Calculation](#release-version-calculation)
-  - [Help! The release failed after the packages were published to the NPM registry](#help-the-release-failed-after-the-packages-were-published-to-the-npm-registry)
+  - [Preview Your Changes Before Release](#preview-your-changes-before-release)
+  - [Create a Release](#create-a-release)
+    - [Release Version Calculation](#release-version-calculation)
+    - [Help! The release failed after the packages were published to the NPM registry](#help-the-release-failed-after-the-packages-were-published-to-the-npm-registry)
 
 ## Introduction
 
@@ -163,7 +163,7 @@ Once you've filed the PR:
 
 ## Preview Your Changes Before Release
 
-Whilst developing new features it possible to publish and install preview builds of every affected package using [pkg.pr.new](https://pkg.pr.new) — a free open-source service that builds and hosts SHA-keyed npm tarballs.
+Whilst developing new features it's possible to publish and install preview builds of every affected package using [pkg.pr.new](https://pkg.pr.new) — a free open-source service that builds and hosts SHA-keyed npm tarballs.
 
 To opt in:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ npx https://pkg.pr.new/grafana/plugin-tools/@grafana/<cli-package>@<commit-sha>
 > [!IMPORTANT]
 > The URL keys off the commit SHA, not a real semver version. Any `package.json` reference to a pkg.pr.new URL must be swapped back to the published version once the PR is merged and released.
 
-When you push new commits to a PR with the `preview` label, the existing pkg.pr.new comment is updated in place with the new commit sha.
+When you push new commits to a PR with the `preview` label, the existing pkg.pr.new comment is updated in place with the new commit SHA.
 
 ## Create A Release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "husky": "^9.1.7",
         "lerna": "^9.0.3",
         "lint-staged": "^16.2.7",
+        "pkg-pr-new": "^0.0.75",
         "prettier": "3.8.3",
         "publint": "^0.3.12",
         "rollup": "^4.57.1",
@@ -33501,6 +33502,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-pr-new": {
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/pkg-pr-new/-/pkg-pr-new-0.0.75.tgz",
+      "integrity": "sha512-u9mdErTewKSMsr+ceCt8VcNuNP0ro5AXiPXhUVApuEyqr2Zlvt+DdCFBcm+yGWN8mhOdZJ27meIDbnoZgfzpOw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pkg-pr-new": "bin/cli.js"
       }
     },
     "node_modules/pkijs": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "husky": "^9.1.7",
     "lerna": "^9.0.3",
     "lint-staged": "^16.2.7",
+    "pkg-pr-new": "^0.0.75",
     "prettier": "3.8.3",
     "publint": "^0.3.12",
     "rollup": "^4.57.1",

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "@grafana/create-plugin",
   "version": "7.6.2",
   "repository": {
+    "type": "git",
     "directory": "packages/create-plugin",
     "url": "https://github.com/grafana/plugin-tools"
   },

--- a/packages/eslint-plugin-plugins/package.json
+++ b/packages/eslint-plugin-plugins/package.json
@@ -25,6 +25,7 @@
   ],
   "homepage": "https://www.npmjs.com/package/@grafana/eslint-plugin-plugins",
   "repository": {
+    "type": "git",
     "directory": "packages/eslint-plugin-plugins",
     "url": "git+https://github.com/grafana/plugin-tools.git"
   },

--- a/packages/plugin-docs-cli/package.json
+++ b/packages/plugin-docs-cli/package.json
@@ -11,6 +11,7 @@
     "CHANGELOG.md"
   ],
   "repository": {
+    "type": "git",
     "directory": "packages/plugin-docs-cli",
     "url": "https://github.com/grafana/plugin-tools"
   },

--- a/packages/plugin-docs-parser/package.json
+++ b/packages/plugin-docs-parser/package.json
@@ -12,6 +12,7 @@
     "CHANGELOG.md"
   ],
   "repository": {
+    "type": "git",
     "directory": "packages/plugin-docs-parser",
     "url": "https://github.com/grafana/plugin-tools"
   },

--- a/packages/plugin-e2e/CONTRIBUTING.md
+++ b/packages/plugin-e2e/CONTRIBUTING.md
@@ -115,13 +115,13 @@ Beware that scenarios provided by @grafana/plugin-e2e needs to be work in older 
 
 3. Push the changes in your local PR, create a draft PR in [grafana/plugin-tools](https://github.com/grafana/plugin-tools/) and add the labels `release` and `minor|patch`. CI will run all Playwright tests against a set of different Grafana versions. If not all of them pass, it may be because you've introduced a change that is no longer compatible with older versions of Grafana.
 
-4. Once CI passes, `auto` will publish a canary release to NPM. You can find the version number at the bottom of the PR description.
+4. Add the **`preview`** label to your PR. [pkg.pr.new](https://pkg.pr.new) will post a comment with an installable preview URL for `@grafana/plugin-e2e` (and any other affected packages). See [Preview Your Changes Before Release](../../CONTRIBUTING.md#preview-your-changes-before-release) in the root `CONTRIBUTING.md` for details.
 
 5. Install the pre-release of @grafana/plugin-e2e in [grafana/grafana](https://github.com/grafana/grafana) and run Playwright tests.
 
 ```bash
 # In your local grafana development folder
-yarn add @grafana/plugin-e2e@0.3.0-canary.623.aedff75.0
+yarn add https://pkg.pr.new/grafana/plugin-tools/@grafana/plugin-e2e@<commit-sha>
 yarn e2e:plugin
 ```
 

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -8,6 +8,7 @@
     "./package.json"
   ],
   "repository": {
+    "type": "git",
     "directory": "packages/plugin-e2e",
     "url": "https://github.com/grafana/plugin-tools"
   },

--- a/packages/plugin-meta-extractor/package.json
+++ b/packages/plugin-meta-extractor/package.json
@@ -19,6 +19,7 @@
     "provenance": true
   },
   "repository": {
+    "type": "git",
     "directory": "packages/plugin-meta-extractor",
     "url": "https://github.com/grafana/plugin-tools"
   },

--- a/packages/plugin-types-bundler/package.json
+++ b/packages/plugin-types-bundler/package.json
@@ -30,6 +30,7 @@
     "provenance": true
   },
   "repository": {
+    "type": "git",
     "directory": "packages/plugin-types-bundler",
     "url": "https://github.com/grafana/plugin-tools"
   },

--- a/packages/react-detect/package.json
+++ b/packages/react-detect/package.json
@@ -3,6 +3,7 @@
   "description": "Run various checks to detect if a Grafana plugin is compatible with React.",
   "version": "0.6.4",
   "repository": {
+    "type": "git",
     "directory": "packages/react-detect",
     "url": "https://github.com/grafana/plugin-tools"
   },

--- a/packages/sign-plugin/package.json
+++ b/packages/sign-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "@grafana/sign-plugin",
   "version": "3.2.2",
   "repository": {
+    "type": "git",
     "directory": "packages/sign-plugin",
     "url": "https://github.com/grafana/plugin-tools"
   },

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -10,6 +10,7 @@
     "config"
   ],
   "repository": {
+    "type": "git",
     "directory": "packages/tsconfig",
     "url": "https://github.com/grafana/plugin-tools"
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is the first of three PRs which will remove Auto from the repo and the need for bypassing gh branch rulesets. 

Replaces Auto's PR-time canary publishing with [pkg.pr.new](https://pkg.pr.new), and gates the existing `release` job to push-to-`main` only.

- Adds `.github/workflows/preview.yml` that publishes affected packages to pkg.pr.new when a PR has the `preview` label. The `pkg-pr-new[bot]` will post a comment with installable SHA-keyed URL instructions.
- Gates `ci.yml`'s `release` job with `event_name == 'push' && ref == 'refs/heads/main'`, so `auto shipit` no longer fires on PR events. Auto's main-branch publishing is untouched and continues until PR 2 lands. 
- Adds a `Preview Your Changes Before Release` section to the root `CONTRIBUTING.md` and trims `packages/plugin-e2e/CONTRIBUTING.md` to point to it.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

related: https://github.com/grafana/plugin-tools/issues/2685
related: https://github.com/grafana/grafana-catalog-team/issues/943

**Special notes for your reviewer**:
