### PR TITLE
chore: update create-github-app-token from 0.2.3 to 0.3.0 (#2691)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,7 +546,7 @@ jobs:
 
       - name: Generate token
         id: generate-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        uses: grafana/shared-workflows/actions/create-github-app-token@795f748a236f9de024b7514efc9a208456e7e468 # create-github-app-token/v0.3.0
         with:
           github_app: grafana-plugins-platform-bot
           permission_set: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'release' || 'default' }}

--- a/docusaurus/docs/set-up/set-up-github.md
+++ b/docusaurus/docs/set-up/set-up-github.md
@@ -142,7 +142,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+       uses: grafana/shared-workflows/actions/create-github-app-token@795f748a236f9de024b7514efc9a208456e7e468 # create-github-app-token/v0.3.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}

--- a/docusaurus/docs/set-up/set-up-github.md
+++ b/docusaurus/docs/set-up/set-up-github.md
@@ -142,7 +142,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: generate_token
-       uses: grafana/shared-workflows/actions/create-github-app-token@795f748a236f9de024b7514efc9a208456e7e468 # create-github-app-token/v0.3.0
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
chore: update create-github-app-token from 0.2.3 to 0.3.0 which contains a security fix.

Ref: https://github.com/grafana/shared-workflows/releases/tag/create-github-app-token%2Fv0.3.0