### PR TITLE
ci: use scoped package names for release-please tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,15 +22,27 @@
     { "type": "ci", "section": "CI", "hidden": true }
   ],
   "packages": {
-    "packages/create-plugin": { "package-name": "@grafana/create-plugin" },
-    "packages/eslint-plugin-plugins": { "package-name": "@grafana/eslint-plugin-plugins" },
-    "packages/plugin-docs-cli": { "package-name": "@grafana/plugin-docs-cli" },
-    "packages/plugin-docs-parser": { "package-name": "@grafana/plugin-docs-parser" },
-    "packages/plugin-e2e": { "package-name": "@grafana/plugin-e2e" },
-    "packages/plugin-meta-extractor": { "package-name": "@grafana/plugin-meta-extractor" },
-    "packages/plugin-types-bundler": { "package-name": "@grafana/plugin-types-bundler" },
-    "packages/react-detect": { "package-name": "@grafana/react-detect" },
-    "packages/sign-plugin": { "package-name": "@grafana/sign-plugin" },
-    "packages/tsconfig": { "package-name": "@grafana/tsconfig" }
+    "packages/create-plugin": { "package-name": "@grafana/create-plugin", "component": "@grafana/create-plugin" },
+    "packages/eslint-plugin-plugins": {
+      "package-name": "@grafana/eslint-plugin-plugins",
+      "component": "@grafana/eslint-plugin-plugins"
+    },
+    "packages/plugin-docs-cli": { "package-name": "@grafana/plugin-docs-cli", "component": "@grafana/plugin-docs-cli" },
+    "packages/plugin-docs-parser": {
+      "package-name": "@grafana/plugin-docs-parser",
+      "component": "@grafana/plugin-docs-parser"
+    },
+    "packages/plugin-e2e": { "package-name": "@grafana/plugin-e2e", "component": "@grafana/plugin-e2e" },
+    "packages/plugin-meta-extractor": {
+      "package-name": "@grafana/plugin-meta-extractor",
+      "component": "@grafana/plugin-meta-extractor"
+    },
+    "packages/plugin-types-bundler": {
+      "package-name": "@grafana/plugin-types-bundler",
+      "component": "@grafana/plugin-types-bundler"
+    },
+    "packages/react-detect": { "package-name": "@grafana/react-detect", "component": "@grafana/react-detect" },
+    "packages/sign-plugin": { "package-name": "@grafana/sign-plugin", "component": "@grafana/sign-plugin" },
+    "packages/tsconfig": { "package-name": "@grafana/tsconfig", "component": "@grafana/tsconfig" }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The first release-please run after the migration ([#2689](https://github.com/grafana/plugin-tools/pull/2689)) opened release PR [#2699](https://github.com/grafana/plugin-tools/pull/2699) with two problems:

1. **Broken tag continuity.** release-please's `node` strategy strips the npm scope when deriving the git tag component (`@grafana/create-plugin` → `create-plugin`), so it proposed tags like `create-plugin@7.8.0` instead of the historical `@grafana/create-plugin@7.8.0` format used by every existing tag.
2. **Bloated changelogs.** Because the expected tag (`create-plugin@7.7.0`) doesn't exist — the real tag is `@grafana/create-plugin@7.7.0` — release-please couldn't locate the prior release and scanned from the start of history, listing hundreds of already-released commits.

Setting an explicit `component` (the full scoped name) per package bypasses the scope-stripping normalization. Confirmed against `release-please/src/strategies/base.ts:136` — `options.component` is used verbatim; normalization only runs on the derived fallback.

Result: tags return to `@grafana/<pkg>@<version>`, and release-please finds the existing prior tags → scans only new commits → clean changelogs.

**Which issue(s) this PR fixes**:

related: https://github.com/grafana/plugin-tools/issues/2685
related: https://github.com/grafana/grafana-catalog-team/issues/943

**Special notes for your reviewer**:

- `package-name` is kept (npm identity, drives the `node-workspace` dependency-graph matching); `component` is the new addition (git tag identity). They default from the same source but `component`'s default normalization strips the scope — hence the explicit override.
- **Verify-before-publish:** once this merges, the Release workflow re-runs and updates the open release PR #2699 in place. Confirm its compare links read `@grafana/<pkg>@<old>...@grafana/<pkg>@<new>` and the changelogs are short before merging #2699 to trigger the real staged publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)