### PR TITLE
ci: drop subjectPattern from PR title check

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -25,4 +25,3 @@ jobs:
             style
             revert
           requireScope: false
-          subjectPattern: ^(?![A-Z]).+$


### PR DESCRIPTION
**What this PR does / why we need it**:

The `check-pr-title` workflow's `subjectPattern: ^(?![A-Z]).+$` forbids a leading uppercase letter in the PR title subject. Renovate emits capitalized subjects (e.g. `chore(deps): Update dependency vitest to v4.1.0 [SECURITY]`), so **every Renovate PR fails the check** — including automerged security updates. ([example run](https://github.com/grafana/plugin-tools/actions/runs/27143649711/job/80115324853))

Subject casing has no bearing on release-please's version calculation (it parses the `type`/`scope` prefix only), so the lowercase rule was purely cosmetic. Dropping it unblocks Renovate. The conventional-commit `type` prefix is still enforced via the `types` list.

**Which issue(s) this PR fixes**:

related: https://github.com/grafana/plugin-tools/issues/2685
related: https://github.com/grafana/grafana-catalog-team/issues/943

**Special notes for your reviewer**:

Trade-off: human PR subjects may now start with an uppercase letter. If we later want to re-enforce lowercase for human-authored PRs specifically, that needs an author-aware approach (the action applies `subjectPattern` to all PRs indiscriminately, which is what caused the Renovate breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)