### PR TITLE
ci: set payload-templated on slack release notification

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -121,4 +121,8 @@ jobs:
         uses: grafana/shared-workflows/actions/send-slack-message@eb1fbd807f87aea8f40ff08dc9cd02872cad55b3 # send-slack-message/v2.0.5
         with:
           method: chat.postMessage
+          # Set explicitly: the shared action forwards this input unconditionally, so leaving
+          # it unset passes an empty string that overrides slackapi's own "false" default and
+          # throws on getBooleanInput. Our payload is pre-rendered, so no templating is needed.
+          payload-templated: false
           payload: ${{ steps.slack-payload.outputs.payload }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `Notify Slack` step in the release workflow crashed on the first real release ([run](https://github.com/grafana/plugin-tools/actions/runs/27208347972/job/80330248410)) — *after* `@grafana/create-plugin@7.7.1` had already been staged on npm. The release itself succeeded; only the notification failed.

Root cause: the shared `send-slack-message` action declares `payload-templated` as optional with no default, then forwards it to `slackapi/slack-github-action@v3.0.2` unconditionally:

```yaml
payload-templated: ${{ inputs.payload-templated }}   # unset → ""
```

slackapi's action defaults this input to `"false"`, but an explicitly-passed empty string overrides that default, and `core.getBooleanInput("")` throws (`Input does not meet YAML 1.2 "Core Schema" specification`).

Fix: set `payload-templated: false` ourselves. Our payload is fully rendered in the `Build Slack payload` step (every URL/version/string is already literal), so no templating is needed — `false` restores the value slackapi would have used anyway.

**Which issue(s) this PR fixes**:

related: https://github.com/grafana/plugin-tools/issues/2685
related: https://github.com/grafana/grafana-catalog-team/issues/943

**Special notes for your reviewer**:

- Titled `ci:` deliberately — this is a workflow fix, not a package fix, so it must not trigger a release.
- No behaviour change to the message itself — purely unblocks the action from crashing.
- Upstream papercut: the shared action should default this input to `false`; worth a follow-up issue on `grafana/shared-workflows`. Setting it on our side is the immediate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)