### PR TITLE
feat(deps): bump grafana libs to 13.0.2

### DIFF
--- a/packages/create-plugin/templates/common/.config/docker-compose-base.yaml
+++ b/packages/create-plugin/templates/common/.config/docker-compose-base.yaml
@@ -7,7 +7,7 @@ services:
       context: .
       args:
         grafana_image: ${GRAFANA_IMAGE:-{{~grafanaImage~}} }
-        grafana_version: ${GRAFANA_VERSION:-12.4.0}
+        grafana_version: ${GRAFANA_VERSION:-13.0.2}
         development: ${DEVELOPMENT:-false}
         anonymous_auth_enabled: ${ANONYMOUS_AUTH_ENABLED:-true}
     ports:

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -74,11 +74,11 @@
   },
   "dependencies": {
     "@emotion/css": "11.10.6",
-    "@grafana/data": "12.4.2",
-    "@grafana/i18n": "12.4.2",
-    "@grafana/runtime": "12.4.2",
-    "@grafana/ui": "12.4.2",
-    "@grafana/schema": "12.4.2",{{#if_eq pluginType "scenesapp" }}
+    "@grafana/data": "13.0.2",
+    "@grafana/i18n": "13.0.2",
+    "@grafana/runtime": "13.0.2",
+    "@grafana/ui": "13.0.2",
+    "@grafana/schema": "13.0.2",{{#if_eq pluginType "scenesapp" }}
     "@grafana/scenes": "{{ scenesVersion }}",{{/if_eq}}
     "react": "^18.3.0",
     "react-dom": "^18.3.0"{{#if isAppType}},


### PR DESCRIPTION
 Bump @grafana/* dependencies from 12.4.2 to 13.0.2 to align scaffolded plugins with the latest Grafana 13 release.
