### PR TITLE
fix: correct relative @-import path in plugin skill files

### DIFF
--- a/packages/create-plugin/templates/common/.claude/skills/build-plugin/SKILL.md
+++ b/packages/create-plugin/templates/common/.claude/skills/build-plugin/SKILL.md
@@ -1,1 +1,1 @@
-@../../../../.config/AGENTS/skills/build-plugin.md
+@../../../.config/AGENTS/skills/build-plugin.md

--- a/packages/create-plugin/templates/common/.claude/skills/validate-plugin/SKILL.md
+++ b/packages/create-plugin/templates/common/.claude/skills/validate-plugin/SKILL.md
@@ -1,1 +1,1 @@
-@../../../../.config/AGENTS/skills/validate-plugin.md
+@../../../.config/AGENTS/skills/validate-plugin.md

--- a/packages/create-plugin/templates/common/.codex/skills/build-plugin/SKILL.md
+++ b/packages/create-plugin/templates/common/.codex/skills/build-plugin/SKILL.md
@@ -3,4 +3,4 @@ name: build-plugin
 description: build a Grafana plugin using the standard build process (frontend and backend if applicable)
 ---
 
-@../../../../.config/AGENTS/skills/build-plugin.md
+@../../../.config/AGENTS/skills/build-plugin.md

--- a/packages/create-plugin/templates/common/.codex/skills/validate-plugin/SKILL.md
+++ b/packages/create-plugin/templates/common/.codex/skills/validate-plugin/SKILL.md
@@ -3,4 +3,4 @@ name: validate-plugin
 description: validate a Grafana plugin using the official Grafana plugin validator
 ---
 
-@../../../../.config/AGENTS/skills/validate-plugin.md
+@../../../.config/AGENTS/skills/validate-plugin.md


### PR DESCRIPTION
## Summary

Fixes https://github.com/grafana/plugin-tools/issues/2698

fixed build plugin skill path `../../../../` → `../../../` in all four SKILL.md files:

- `.claude/skills/build-plugin/SKILL.md`
- `.claude/skills/validate-plugin/SKILL.md`
- `.codex/skills/build-plugin/SKILL.md`
- `.codex/skills/validate-plugin/SKILL.md`

