### PR TITLE
fix(deps): bump copy-webpack-plugin to 14.0.0

### DIFF
--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@emotion/css": "11.10.6",
-    "@grafana/data": "13.0.2",
+    "@grafana/data": "12.4.2",
     "@grafana/i18n": "12.4.2",
     "@grafana/runtime": "12.4.2",
     "@grafana/ui": "12.4.2",

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -36,7 +36,7 @@
     "@types/ws": "^8.18.1",{{/if}}
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",{{#unless useExperimentalRspack}}
-    "copy-webpack-plugin": "^13.0.0",{{/unless}}
+    "copy-webpack-plugin": "^14.0.0",{{/unless}}
     "css-loader": "^7.1.0",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.0",
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@emotion/css": "11.10.6",
-    "@grafana/data": "12.4.2",
+    "@grafana/data": "13.0.2",
     "@grafana/i18n": "12.4.2",
     "@grafana/runtime": "12.4.2",
     "@grafana/ui": "12.4.2",


### PR DESCRIPTION
Bumping copy-webpack-plugin from ^13.0.0 to ^14.0.0 fixes two transitive vulnerabilities:                                                                  
                                                                                                                                                           
 - serialize-javascript: v13 pulls 6.0.2 (vulnerable to RCE via RegExp.flags and CPU exhaustion DoS). v14 depends on ^7.0.3 which is patched.               
  - fast-uri: resolves to a patched version (3.1.2+) on fresh lockfile generation, fixing path traversal and host confusion vulnerabilities.     
