### PR TITLE
fix: replace find-up dependency with native @libs/find-up helper

### DIFF
--- a/libs/find-up/README.md
+++ b/libs/find-up/README.md
@@ -1,0 +1,18 @@
+# Libs/Find-Up
+
+A utility library that finds a file by walking up parent directories. A minimal, native replacement for the [`find-up`](https://www.npmjs.com/package/find-up) npm package covering the synchronous, files-only use cases in this repository.
+
+## Usage
+
+```ts
+import { findUpSync } from '@libs/find-up';
+
+// Find the closest package.json starting from the current working directory.
+const packageJsonPath = findUpSync('package.json');
+
+// Find the closest of several files starting from a given directory.
+// All names are checked in each directory before moving up to the parent.
+const lockfilePath = findUpSync(['yarn.lock', 'pnpm-lock.yaml', 'package-lock.json'], { cwd: '/some/dir' });
+```
+
+Returns the absolute path of the first match, or `undefined` if no match was found before reaching the filesystem root.

--- a/libs/find-up/package.json
+++ b/libs/find-up/package.json
@@ -1,16 +1,14 @@
 {
-  "name": "@libs/version",
-  "version": "1.0.2",
+  "name": "@libs/find-up",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
-  "dependencies": {
-    "@libs/find-up": "^1.0.0"
-  },
   "scripts": {
     "typecheck": "tsc --noEmit",
     "lint": "eslint ./src",
-    "lint:fix": "eslint --fix ./src"
+    "lint:fix": "eslint --fix ./src",
+    "test": "vitest"
   }
 }

--- a/libs/find-up/src/index.test.ts
+++ b/libs/find-up/src/index.test.ts
@@ -68,6 +68,14 @@ describe('findUpSync', () => {
     expect(findUpSync('file-that-does-not-exist.json', { cwd: rootDir })).toBeUndefined();
   });
 
+  it('should ignore directories that match the name and only return files', () => {
+    const rootDir = createFixtureTree(['package.json', 'a/.gitkeep']);
+    // A directory named like the candidate must be skipped, mirroring find-up's type: 'file' default.
+    mkdirSync(path.join(rootDir, 'a', 'package.json'));
+
+    expect(findUpSync('package.json', { cwd: path.join(rootDir, 'a') })).toBe(path.join(rootDir, 'package.json'));
+  });
+
   it('should default to the current working directory', () => {
     const rootDir = createFixtureTree(['package.json', 'a/.gitkeep']);
     vi.spyOn(process, 'cwd').mockReturnValue(path.join(rootDir, 'a'));

--- a/libs/find-up/src/index.test.ts
+++ b/libs/find-up/src/index.test.ts
@@ -1,0 +1,77 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { vi } from 'vitest';
+import { findUpSync } from './index.js';
+
+describe('findUpSync', () => {
+  const tempDirs: string[] = [];
+
+  function createFixtureTree(files: string[]): string {
+    const rootDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'find-up-test-')));
+    tempDirs.push(rootDir);
+    for (const file of files) {
+      const filePath = path.join(rootDir, file);
+      mkdirSync(path.dirname(filePath), { recursive: true });
+      writeFileSync(filePath, '');
+    }
+    return rootDir;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    tempDirs.forEach((dir) => rmSync(dir, { recursive: true, force: true }));
+  });
+
+  it('should find a file in the starting directory', () => {
+    const rootDir = createFixtureTree(['package.json']);
+
+    expect(findUpSync('package.json', { cwd: rootDir })).toBe(path.join(rootDir, 'package.json'));
+  });
+
+  it('should find a file in a parent directory', () => {
+    const rootDir = createFixtureTree(['package.json', 'a/b/c/.gitkeep']);
+
+    expect(findUpSync('package.json', { cwd: path.join(rootDir, 'a/b/c') })).toBe(path.join(rootDir, 'package.json'));
+  });
+
+  it('should return the closest match when the file exists in multiple parent directories', () => {
+    const rootDir = createFixtureTree(['package.json', 'a/package.json', 'a/b/.gitkeep']);
+
+    expect(findUpSync('package.json', { cwd: path.join(rootDir, 'a/b') })).toBe(
+      path.join(rootDir, 'a', 'package.json')
+    );
+  });
+
+  it('should check all names in a directory before moving up to the parent', () => {
+    const rootDir = createFixtureTree(['yarn.lock', 'a/package-lock.json']);
+
+    expect(findUpSync(['yarn.lock', 'pnpm-lock.yaml', 'package-lock.json'], { cwd: path.join(rootDir, 'a') })).toBe(
+      path.join(rootDir, 'a', 'package-lock.json')
+    );
+  });
+
+  it('should respect the order of names within the same directory', () => {
+    const rootDir = createFixtureTree(['yarn.lock', 'package-lock.json']);
+
+    expect(findUpSync(['yarn.lock', 'pnpm-lock.yaml', 'package-lock.json'], { cwd: rootDir })).toBe(
+      path.join(rootDir, 'yarn.lock')
+    );
+  });
+
+  it('should return undefined when no match is found', () => {
+    const rootDir = createFixtureTree(['.gitkeep']);
+
+    expect(findUpSync('file-that-does-not-exist.json', { cwd: rootDir })).toBeUndefined();
+  });
+
+  it('should default to the current working directory', () => {
+    const rootDir = createFixtureTree(['package.json', 'a/.gitkeep']);
+    vi.spyOn(process, 'cwd').mockReturnValue(path.join(rootDir, 'a'));
+
+    expect(findUpSync('package.json')).toBe(path.join(rootDir, 'package.json'));
+  });
+});

--- a/libs/find-up/src/index.ts
+++ b/libs/find-up/src/index.ts
@@ -1,0 +1,25 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+interface FindUpSyncOptions {
+  cwd?: string;
+}
+
+export function findUpSync(name: string | string[], options: FindUpSyncOptions = {}): string | undefined {
+  const names = Array.isArray(name) ? name : [name];
+  let currentDir = path.resolve(options.cwd ?? process.cwd());
+  let previousDir: string | undefined;
+
+  while (currentDir !== previousDir) {
+    for (const candidateName of names) {
+      const candidatePath = path.join(currentDir, candidateName);
+      if (existsSync(candidatePath)) {
+        return candidatePath;
+      }
+    }
+    previousDir = currentDir;
+    currentDir = path.dirname(currentDir);
+  }
+
+  return undefined;
+}

--- a/libs/find-up/src/index.ts
+++ b/libs/find-up/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { statSync } from 'node:fs';
 import path from 'node:path';
 
 interface FindUpSyncOptions {
@@ -13,7 +13,9 @@ export function findUpSync(name: string | string[], options: FindUpSyncOptions =
   while (currentDir !== previousDir) {
     for (const candidateName of names) {
       const candidatePath = path.join(currentDir, candidateName);
-      if (existsSync(candidatePath)) {
+      // Match files only, mirroring find-up/locate-path (type: 'file' by default).
+      const stat = statSync(candidatePath, { throwIfNoEntry: false });
+      if (stat?.isFile()) {
         return candidatePath;
       }
     }

--- a/libs/find-up/tsconfig.json
+++ b/libs/find-up/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/libs/find-up/vitest.config.ts
+++ b/libs/find-up/vitest.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path';
+import { defineProject, mergeConfig } from 'vitest/config';
+import configShared from '../../vitest.config.base.js';
+
+export default mergeConfig(
+  configShared,
+  defineProject({
+    test: {
+      root: resolve(__dirname),
+    },
+  })
+);

--- a/libs/version/src/index.ts
+++ b/libs/version/src/index.ts
@@ -1,4 +1,4 @@
-import { findUpSync } from 'find-up';
+import { findUpSync } from '@libs/find-up';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,10 @@
         "url": "https://dotenvx.com"
       }
     },
+    "libs/find-up": {
+      "name": "@libs/find-up",
+      "version": "1.0.0"
+    },
     "libs/output": {
       "name": "@libs/output",
       "version": "1.0.3"
@@ -112,8 +116,8 @@
     "libs/version": {
       "name": "@libs/version",
       "version": "1.0.2",
-      "peerDependencies": {
-        "find-up": "^7.0.0"
+      "dependencies": {
+        "@libs/find-up": "^1.0.0"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -9324,6 +9328,10 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
+    },
+    "node_modules/@libs/find-up": {
+      "resolved": "libs/find-up",
+      "link": true
     },
     "node_modules/@libs/output": {
       "resolved": "libs/output",
@@ -19650,40 +19658,6 @@
       },
       "engines": {
         "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
-      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^7.2.0",
-        "path-exists": "^5.0.0",
-        "unicorn-magic": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-up/node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -34182,19 +34156,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unicorn-magic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/unified": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
@@ -36676,7 +36637,6 @@
         "change-case": "5.4.4",
         "debug": "4.4.3",
         "enquirer": "2.4.1",
-        "find-up": "8.0.0",
         "glob": "13.0.6",
         "handlebars": "4.7.9",
         "jsonc-parser": "3.3.1",
@@ -36692,6 +36652,7 @@
         "create-plugin": "dist/bin/run.js"
       },
       "devDependencies": {
+        "@libs/find-up": "1.0.0",
         "@libs/output": "1.0.3",
         "@libs/version": "1.0.2",
         "@types/glob": "9.0.0",
@@ -36703,22 +36664,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "packages/create-plugin/node_modules/find-up": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-8.0.0.tgz",
-      "integrity": "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^8.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/create-plugin/node_modules/glob": {
@@ -36750,21 +36695,6 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
-    "packages/create-plugin/node_modules/locate-path": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-8.0.0.tgz",
-      "integrity": "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/create-plugin/node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -36778,18 +36708,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/create-plugin/node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/eslint-plugin-plugins": {
@@ -37008,7 +36926,6 @@
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "find-up": "8.0.0",
         "minimist": "1.2.8",
         "proxy-agent": "8.0.1"
       },
@@ -37016,55 +36933,13 @@
         "sign-plugin": "dist/bin/run.js"
       },
       "devDependencies": {
+        "@libs/find-up": "^1.0.0",
         "@libs/output": "^1.0.3",
         "@libs/version": "^1.0.2",
         "@types/minimist": "^1.2.5"
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "packages/sign-plugin/node_modules/find-up": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-8.0.0.tgz",
-      "integrity": "sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^8.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/sign-plugin/node_modules/locate-path": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-8.0.0.tgz",
-      "integrity": "sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/sign-plugin/node_modules/unicorn-magic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/tsconfig": {

--- a/packages/create-plugin/package.json
+++ b/packages/create-plugin/package.json
@@ -31,7 +31,6 @@
     "change-case": "5.4.4",
     "debug": "4.4.3",
     "enquirer": "2.4.1",
-    "find-up": "8.0.0",
     "glob": "13.0.6",
     "handlebars": "4.7.9",
     "jsonc-parser": "3.3.1",
@@ -44,6 +43,7 @@
     "yaml": "2.9.0"
   },
   "devDependencies": {
+    "@libs/find-up": "1.0.0",
     "@libs/output": "1.0.3",
     "@libs/version": "1.0.2",
     "@types/glob": "9.0.0",

--- a/packages/create-plugin/src/utils/utils.packageManager.ts
+++ b/packages/create-plugin/src/utils/utils.packageManager.ts
@@ -1,7 +1,7 @@
 import { gte, lt } from 'semver';
 
 import { basename } from 'node:path';
-import { findUpSync } from 'find-up';
+import { findUpSync } from '@libs/find-up';
 import { getPackageJson } from './utils.packagejson.js';
 import { spawnSync } from 'node:child_process';
 

--- a/packages/sign-plugin/package.json
+++ b/packages/sign-plugin/package.json
@@ -26,11 +26,11 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "find-up": "8.0.0",
     "minimist": "1.2.8",
     "proxy-agent": "8.0.1"
   },
   "devDependencies": {
+    "@libs/find-up": "^1.0.0",
     "@libs/output": "^1.0.3",
     "@libs/version": "^1.0.2",
     "@types/minimist": "^1.2.5"


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the `find-up` runtime dependency from `@grafana/create-plugin` and `@grafana/sign-plugin` (introduced in #1597) by replacing it with a ~20 line native helper in a new private `@libs/find-up` workspace.

`find-up` was only used for two synchronous, files-only lookups:

- `@libs/version` — walking up from the bundled module to find the consuming package's `package.json` (this is why both CLIs carried `find-up` in `dependencies`: the lib is bundled into their dist while imports of published packages stay external).
- `create-plugin`'s `utils.packageManager.ts` — finding the closest lockfile to detect the package manager.

The native helper preserves the two find-up semantics that matter for these call sites: all candidate names are checked in each directory before moving up (lockfile precedence), and the walk stops at the filesystem root. It is covered by 7 unit tests.

With this change both CLIs bundle the helper directly, so `find-up` and its transitive dependencies (`locate-path`, `p-locate`, `yocto-queue`, `unicorn-magic`) disappear from the published packages' install footprint. The remaining `find-up` entries in `package-lock.json` are unrelated transitive dependencies of the docusaurus website tooling.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

- Verified in the built output: `dist` no longer contains any `import ... from 'find-up'`; `@libs/version` and `utils.packageManager` now import the bundled helper via relative paths.
- `libs/version` previously declared `find-up` as a `^7.0.0` peerDependency while consumers shipped `8.0.0` — that drift goes away too.
- The `fix:` prefix means release-please will cut patch releases for both CLIs, which seems right for a change to the published artifacts.