### PR TITLE
docs: document i18n plural eslint rules

### DIFF
--- a/docusaurus/docs/shared/plugin-internationalization-shared.md
+++ b/docusaurus/docs/shared/plugin-internationalization-shared.md
@@ -118,6 +118,8 @@ Children stay in place because they carry the JSX structure (for example `<stron
 
 For reference, [grafana/grafana#125312](https://github.com/grafana/grafana/pull/125312) and [grafana/grafana#125316](https://github.com/grafana/grafana/pull/125316) migrated every plural `t()` and `<Trans>` in Grafana itself to this shape.
 
+This convention is enforced by the `@grafana/i18n/t-plural-defaults` and `@grafana/i18n/trans-plural-defaults` ESLint rules. See [Configure ESLint rules for translations](#configure-eslint-rules-for-translations) to enable them.
+
 ## Obtain the translated text
 
 Use the [`i18next-cli`](https://github.com/i18next/i18next-cli#readme) and `i18n-extract` to sweep all input files, extract tagged `i18n` keys, and save the translations.
@@ -225,6 +227,8 @@ export default defineConfig([
     rules: {
       '@grafana/i18n/no-untranslated-strings': ['error', { calleesToIgnore: ['^css$', 'use[A-Z].*'] }],
       '@grafana/i18n/no-translation-top-level': 'error',
+      '@grafana/i18n/t-plural-defaults': 'error',
+      '@grafana/i18n/trans-plural-defaults': 'error',
     },
   },
 ]);


### PR DESCRIPTION
**What is this feature?**

Documents the `@grafana/i18n/t-plural-defaults` and `@grafana/i18n/trans-plural-defaults` ESLint rules in the plugin internationalization guide, and cross-links them from the pluralization section.

**Why do we need this feature?**

So plugin developers enable the rules that enforce the plural-default convention.

**Who is this feature for?**

All developers using `@grafana/i18n` package

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

The rules move from `@grafana/eslint-plugin` into `@grafana/i18n` in grafana/grafana#126332. This should only go live once a `@grafana/i18n` release actually exports both rules.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
