### PR TITLE
ci: bump plugin-actions/e2e-version to v3.0.1

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -25,12 +25,11 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@c246b748568a80db2a20ab5c65ff01b8b4f342c4 # e2e-version/v1.2.0
+        uses: grafana/plugin-actions/e2e-version@304ed38a05911eda030608b10ff9ca59616e465c # e2e-version/v3.0.1
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
           skip-grafana-dev-image: false
-          skip-grafana-react-19-preview-image: true
           # limit to latest stable + grafana-dev (2 entries total)
           limit: 1
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@73cd57e848b81e75e3c17697e6701c9fa1404bcc # e2e-version/v2.0.0
+        uses: grafana/plugin-actions/e2e-version@304ed38a05911eda030608b10ff9ca59616e465c # e2e-version/v3.0.1
         with:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'


### PR DESCRIPTION
## What

Bumps the SHA-pinned `grafana/plugin-actions/e2e-version` action in this repo's own workflows to `e2e-version/v3.0.1` (`304ed38`):

- `.github/workflows/playwright.yml` — v2.0.0 → **v3.0.1**
- `.github/workflows/playwright-nightly.yml` — v1.2.0 → **v3.0.1**

## Why

Keep the monorepo CI on the latest `e2e-version`.

## Breaking change handled

v3's only breaking change is removing the broken react19 preview image from the test matrix ([#249](https://github.com/grafana/plugin-actions/issues/249)) — which also removed the `skip-grafana-react-19-preview-image` input. `playwright-nightly.yml` previously set that input, so this PR drops the now non-existent input. All other inputs (`version-resolver-type`, `grafana-dependency`, `skip-grafana-dev-image`, `limit`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)