### PR TITLE
ci: bump plugin-actions/deploy-report-pages to v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,7 +508,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish report
-        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@376226a5245b6b8bbb95127241c430ef8d6aa643 # deploy-report-pages/v1.0.1
+        uses: grafana/plugin-actions/playwright-gh-pages/deploy-report-pages@5da62466881cdba091672353cf3c72ca348d01b1 # deploy-report-pages/v1.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           retention-days: 7


### PR DESCRIPTION
## What

Bumps the SHA-pinned `grafana/plugin-actions/playwright-gh-pages/deploy-report-pages` action in `ci.yml` to `deploy-report-pages/v1.1.0` (`5da6246`):

- `.github/workflows/ci.yml` — v1.0.1 → **v1.1.0**

## Why

Brings `ci.yml` in line with `playwright.yml` and `playwright-nightly.yml`, which already use `deploy-report-pages/v1.1.0`. Same `github-token` / `retention-days` inputs — no changes required.

> `upload-report-artifacts` is already on its latest tag (v1.0.1) everywhere, so it is not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)