### PR TITLE
docs: bump plugin-actions versions in set-up-github guide

### DIFF
--- a/docusaurus/docs/set-up/set-up-github.md
+++ b/docusaurus/docs/set-up/set-up-github.md
@@ -111,7 +111,7 @@ jobs:
   createplugin-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v2.0.1
+      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v2.0.2
         with:
           token: ${{ secrets.GH_PAT_TOKEN }}
 ```
@@ -147,7 +147,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
-      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v2.0.1
+      - uses: grafana/plugin-actions/create-plugin-update@create-plugin-update/v2.0.2
         with:
           token: ${{ steps.generate_token.outputs.token }}
 ```
@@ -181,7 +181,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: grafana/plugin-actions/bundle-size@bundle-size/v1.0.2
+      - uses: grafana/plugin-actions/bundle-size@bundle-size/v1.1.0
 ```
 
 ### Troubleshooting


### PR DESCRIPTION
## What

Bumps the actively-pinned `grafana/plugin-actions` references in `docusaurus/docs/set-up/set-up-github.md`:

- `create-plugin-update` — v2.0.1 → **v2.0.2** (2 occurrences)
- `bundle-size` — v1.0.2 → **v1.1.0**

## Why

Keep the documented workflow snippets in sync with the latest `plugin-actions` releases (and with the create-plugin templates).

## Left untouched (intentional)

- `@main` example refs elsewhere in the docs (build-automation, e2e-test-a-plugin/ci, snippets, `build-plugin@main` in this guide).
- The historical migration guide `migration-guides/.../v12.x-v13.x.md` (`e2e-version/v1.2.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)