### PR TITLE
test(plugin-e2e): fix appConfig settings test for Grafana 13.1.0

### DIFF
--- a/packages/plugin-e2e/tests/as-admin-user/app/app-config/appConfig.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/app/app-config/appConfig.spec.ts
@@ -7,15 +7,24 @@ test('should navigate to app config page for provided plugin id when created', a
 
 test('should wait for plugin config settings API to respond', async ({ gotoAppConfigPage, page }) => {
   const configPage = await gotoAppConfigPage({ pluginId: 'redis-app' });
-  await page.route(
-    '/api/plugins/redis-app/settings',
-    async (route) => {
+  // only intercept the settings save (POST) so we don't mutate server state. the GET that
+  // fetches plugin meta - and renders the enable/disable button - must reach the real backend,
+  // otherwise the button never renders. since Grafana 13.1.0 the meta GET fires after navigation
+  // completes, so a method-agnostic mock would swallow it and leave the button missing.
+  await page.route('/api/plugins/redis-app/settings', async (route) => {
+    if (route.request().method() === 'POST') {
       await route.fulfill({ status: 200 });
-    },
-    { times: 1 }
-  );
+    } else {
+      await route.fallback();
+    }
+  });
+
+  // wait for the enable/disable button to render (meta GET resolved) before listening for the
+  // save response, so we capture the POST triggered by the click and not the meta GET
+  const enableDisableButton = page.getByRole('button', { name: /Disable|Enable/i }).first();
+  await enableDisableButton.waitFor({ state: 'visible' });
 
   const response = configPage.waitForSettingsResponse();
-  await page.getByRole('button', { name: /Disable|Enable/i }).first().click();
+  await enableDisableButton.click();
   await expect(response).toBeOK();
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

The plugin-e2e `appConfig` settings test broke against Grafana 13.1.0 (nightly). 13.1.0 moved plugin settings to the new `@grafana/runtime` cached pluginSettings service, so the plugin meta GET now fires after navigation. The test's method-agnostic `{ times: 1 }` mock then swallowed that GET and returned an empty body, so the enable/disable button never rendered and the click timed out.

Fix: scope the mock to the save POST and let the meta GET reach the backend. The test now exercises the real flow instead of masking the failure. Verified against grafana-enterprise 13.1.0 and 11.4.0.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
