### PR TITLE
ci: revert temporarily disable update command tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
   test-updates:
     name: Test create-plugin update command
     runs-on: ubuntu-x64
-    if: false
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     needs: [test]
     env:
       WORKING_DIR: 'myorg-nobackend-panel'


### PR DESCRIPTION
Now the NPM packages have published we can revert: grafana/plugin-tools#2742