### PR TITLE
ci(create-plugin): add govulncheck to scaffolded plugin CI template

### DIFF
--- a/packages/create-plugin/templates/github/workflows/ci.yml
+++ b/packages/create-plugin/templates/github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
           version: latest
           args: test
 
+      - name: Check backend for vulnerabilities
+        if: steps.check-for-backend.outputs.has-backend == 'true'
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...
+
       - name: Check for E2E
         id: check-for-e2e
         run: |


### PR DESCRIPTION
## Summary
- Add a `govulncheck` step to the scaffolded plugin `ci.yml` template for backend plugins.
- Run `go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...` after backend build and test, gated on `has-backend`.
- New plugins created with `create-plugin` will get Go vulnerability scanning in CI by default.
