### PR TITLE
chore: give plugin-meta-extractor and workflows explicit codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /packages/plugin-docs-parser/ @grafana/grafana-catalog
 /packages/plugin-docs-cli/ @grafana/grafana-catalog
 /packages/plugin-e2e/ @grafana/grafana-catalog
+/packages/plugin-meta-extractor/ @grafana/grafana-catalog
 /packages/plugin-types-bundler/ @grafana/grafana-frontend-platform
 /packages/react-detect/ @grafana/grafana-frontend-platform
 /packages/sign-plugin/ @grafana/grafana-catalog
@@ -15,5 +16,6 @@
 /docusaurus/website/ @grafana/grafana-frontend-platform @grafana/docs-plugins
 /docusaurus/docs/ @grafana/grafana-frontend-platform @grafana/docs-plugins
 
+/.github/workflows/ @grafana/grafana-frontend-platform
 /.github/workflows/playwright.yml @grafana/grafana-catalog
 /.github/workflows/playwright-nightly.yml @grafana/grafana-catalog


### PR DESCRIPTION
**What this PR does / why we need it**:

plugin-meta-extractor and most of the GitHub workflows had no explicit CODEOWNERS entry, so they fell through to the repo wildcard and paged both squads on every change. This assigns plugin-meta-extractor to @grafana/grafana-catalog and .github/workflows/ to @grafana/grafana-frontend-platform, keeping only playwright.yml and playwright-nightly.yml with catalog since those run the plugin-e2e suite.

**Which issue(s) this PR fixes**:

n/a, follow-up from the post-reorg ownership discussion.

**Special notes for your reviewer**:
