### PR TITLE
docs: Replace deprecated Vector API usage in panel plugin tutorial

### DIFF
--- a/docusaurus/docs/tutorials/build-a-panel-plugin.md
+++ b/docusaurus/docs/tutorials/build-a-panel-plugin.md
@@ -244,7 +244,7 @@ Let's see how you can retrieve data from a data frame and use it in your visuali
    ```ts title="src/components/SimplePanel.tsx"
    const radii = data.series
      .map((series) => series.fields.find((field) => field.type === 'number'))
-     .map((field) => field?.values.get(field.values.length - 1));
+     .map((field) => field?.values[field.values.length - 1]);
    ```
 
    `radii` will contain the last values in each of the series that are returned from a data source query. You'll use these to set the radius for each circle.


### PR DESCRIPTION
Related issue: https://github.com/grafana/grafana/issues/66480
Related PR: https://github.com/grafana/grafana/pull/66187

### What changed?

Updated the "Build a panel plugin" tutorial to read field values with plain array indexing (`field?.values[field.values.length - 1]`) instead of the deprecated `Vector.get()` API.

### Why?

Since **Grafana 10.0**, `field.values` is a plain JavaScript array — the `Vector` interface was deprecated as part of [grafana/grafana#66480](https://github.com/grafana/grafana/issues/66480) (shipped in [grafana/grafana#66187](https://github.com/grafana/grafana/pull/66187)). Since **Grafana 11.0**, using `Vector`/`ArrayVector` produces build-time TypeScript errors ([grafana/grafana#83681](https://github.com/grafana/grafana/issues/83681)), with `.get()`/`.set()` only working at runtime through a temporary Array prototype shim. The tutorial already requires Grafana v10.0 or later, so it should show the current API.

See also our [v9.x to v10.x migration guide](https://grafana.com/developers/plugin-tools/migration-guides/update-from-grafana-versions/v9.x-v10.x).
