### PR TITLE
chore: Skip Vault secret steps on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,9 @@ jobs:
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
         if: ${{ github.event.pull_request.head.repo.fork != true }}
         env:
-          GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_ACCESS_POLICY_TOKEN }}
+          # Step env is evaluated even when the step is skipped, so fall back to '{}'
+          # to keep fromJSON from failing the job on fork PRs where get-secrets is skipped.
+          GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets || '{}').GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
         working-directory: ./${{ env.WORKING_DIR }}
   test-updates:
@@ -477,7 +479,9 @@ jobs:
       - name: '@grafana/sign-plugin - use GRAFANA_ACCESS_POLICY_TOKEN to sign generate-panel plugin'
         if: ${{ matrix.workingDir == 'myorg-nobackend-panel' && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork != true }}
         env:
-          GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GRAFANA_ACCESS_POLICY_TOKEN }}
+          # Step env is evaluated even when the step is skipped, so fall back to '{}'
+          # to keep fromJSON from failing the job on fork PRs where get-secrets is skipped.
+          GRAFANA_ACCESS_POLICY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets || '{}').GRAFANA_ACCESS_POLICY_TOKEN }}
         run: sign-plugin --rootUrls http://www.example.com --signatureType private
         working-directory: ./${{ matrix.workingDir }}
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,8 +62,11 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
 
+      # Fork PRs never get an OIDC id-token, so Vault secrets are unavailable there.
+      # Skipping the Docker Hub login falls back to anonymous image pulls (rate-limit risk only).
       - name: Get secrets for DockerHub login
         id: get-secrets
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: grafana/shared-workflows/actions/get-vault-secrets@9f37f656e063f0ad0b0bfc38d49894b57d363936 # v1.2.1
         with:
           common_secrets: |
@@ -72,10 +75,11 @@ jobs:
           export_env: false
 
       - name: Log in to Docker Hub
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
-          username: ${{ fromJSON(steps.get-secrets.outputs.secrets).DOCKERHUB_USERNAME }}
-          password: ${{ fromJSON(steps.get-secrets.outputs.secrets).DOCKERHUB_PASSWORD }}
+          username: ${{ fromJSON(steps.get-secrets.outputs.secrets || '{}').DOCKERHUB_USERNAME }}
+          password: ${{ fromJSON(steps.get-secrets.outputs.secrets || '{}').DOCKERHUB_PASSWORD }}
 
       - name: Start Grafana
         working-directory: ./packages/plugin-e2e


### PR DESCRIPTION
Related PR: https://github.com/grafana/plugin-tools/pull/2757 (a fork PR that was hitting this limitation)

### The problem
Currently **fork PRs** cannot get green CI for the following two reasons:
- `playwright.yml` runs the `get-vault-secrets` DockerHub step unconditionally, which fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` because fork runs never receive an OIDC id-token. 
- In `ci.yml` the secret steps are already gated (#2547), but the sign-plugin steps reference `fromJSON(steps.get-secrets.outputs.secrets)` in their `env`, which GitHub evaluates even when the step is skipped — so `fromJSON('')` fails the job with a template error.

### What changed?
The DockerHub secret + login steps in `playwright.yml` are skipped on fork PRs (anonymous image pulls, rate-limit risk only), and the `fromJSON` consumers fall back to `'{}'` so skipped secrets no longer break template evaluation. E2E tests still run on fork PRs — they never needed the secrets.

**Notes for the reviewer:**
Non-fork behavior is unchanged — this PR itself should show the secret steps running and the Docker Hub login succeeding.