### PR TITLE
fix(plugin-e2e): disable dashboardSettingsRedesign OpenFeature flag by default

### DIFF
--- a/packages/plugin-e2e/src/options.ts
+++ b/packages/plugin-e2e/src/options.ts
@@ -10,6 +10,10 @@ export const DEFAULT_ADMIN_USER: User = {
 export const DEFAULT_OPEN_FEATURE_FLAGS = {
   // disable the splash screen by default for all consumers of plugin-e2e
   splashScreen: false,
+  // keep the variables and annotations tabs on the dashboard settings page.
+  // when this flag is enabled (default since Grafana 13.2.0), the tabs only show
+  // an alert pointing to the dashboard sidebar, which breaks VariableEditPage and AnnotationEditPage
+  'grafana.dashboardSettingsRedesign': false,
 };
 
 export const options: Fixtures<{}, PluginOptions> = {


### PR DESCRIPTION
The nightly E2E runs against grafana-dev started failing across the board (88 of 215 tests). Grafana main enables the `grafana.dashboardSettingsRedesign` OpenFeature flag by default (client-side default `true`, server expression `true`), and together with `dashboardNewLayouts` it replaces the Variables and Annotations tabs on the dashboard settings page with an alert pointing to the dashboard sidebar (grafana/grafana#125966). `VariableEditPage` and `AnnotationEditPage` drive those tabs, so every test using them times out.

This disables the flag by default through the existing OFREP interception, the same way `splashScreen` is already handled, so the settings tabs keep rendering and the plugin-e2e page models keep working for all consumers. No effect on Grafana versions that don't know the flag.

Verified locally against grafana-enterprise nightly (13.2.0-28908703397): full suite goes from 88 failures to green (225 passed + 1 unrelated flake that passes on retry). Also ran the full suite on 13.1.0 and 11.0.11 to confirm no regressions.

Longer term plugin-e2e needs to support the sidebar-based variable and annotation editing flow, since the settings tabs will presumably go away entirely once the redesign ships. This buys time without breaking consumers.