### PR TITLE
fix(plugin-e2e): adapt alert rule advanced mode detection to Grafana 13.2

### DIFF
--- a/packages/plugin-e2e/src/fixtures/scripts/overrideGrafanaBootData.js
+++ b/packages/plugin-e2e/src/fixtures/scripts/overrideGrafanaBootData.js
@@ -14,18 +14,14 @@ export const overrideGrafanaBootData = ({ featureToggles, userPreferences }) => 
     if (Object.keys(featureToggles).length > 0) {
       console.log('@grafana/plugin-e2e: setting the following feature toggles', featureToggles);
 
-      // override feature toggles with the ones provided by the test
-      window.grafanaBootData.settings.featureToggles = {
-        ...window.grafanaBootData.settings.featureToggles,
-        ...featureToggles,
-      };
+      // override feature toggles with the ones provided by the test. Mutate the existing object
+      // instead of replacing it: the runtime config keeps a reference to it, so a replacement
+      // would not be picked up when this callback runs after the config has been constructed
+      Object.assign(window.grafanaBootData.settings.featureToggles, featureToggles);
     }
     if (Object.keys(userPreferences).length > 0) {
       console.log('@grafana/plugin-e2e: setting the following user preferences', userPreferences);
-      window.grafanaBootData.user = {
-        ...window.grafanaBootData.user,
-        ...userPreferences,
-      };
+      Object.assign(window.grafanaBootData.user, userPreferences);
     }
   });
 };

--- a/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/AlertRuleEditPage.ts
@@ -3,7 +3,6 @@ import { AlertRuleArgs, NavigateOptions, PluginTestCtx, RequestOptions } from '.
 import { GrafanaPage } from './GrafanaPage';
 import { AlertRuleQuery } from '../components/AlertRuleQuery';
 import { expect, Locator } from '@playwright/test';
-import { isLegacyFeatureEnabled } from '../../fixtures/isFeatureToggleEnabled';
 const QUERY_AND_EXPRESSION_STEP_ID = '2';
 // Alert pages render slowly on busy CI runners; give the rendering 15s headroom
 // before falling back to default 5s expect timeouts for downstream interactions.
@@ -45,20 +44,20 @@ export class AlertRuleEditPage extends GrafanaPage {
   }
 
   async isAdvancedModeSupported() {
-    const alertingQueryAndExpressionsStepMode = await isLegacyFeatureEnabled(
-      this.ctx.page,
-      'alertingQueryAndExpressionsStepMode'
-    );
-
-    if (alertingQueryAndExpressionsStepMode) {
-      await expect(this.advancedModeSwitch).toBeVisible({ timeout: ALERT_PAGE_READY_TIMEOUT });
-      await expect(this.advancedModeSwitch).toHaveCount(1, { timeout: ALERT_PAGE_READY_TIMEOUT });
-      return true;
+    // the advanced mode switch and the step container selector used below were introduced in Grafana 11.5.0
+    if (lt(this.ctx.grafanaVersion, '11.5.0')) {
+      return false;
     }
 
-    await expect(this.advancedModeSwitch).not.toBeVisible({ timeout: ALERT_PAGE_READY_TIMEOUT });
-    await expect(this.advancedModeSwitch).toHaveCount(0, { timeout: ALERT_PAGE_READY_TIMEOUT });
-    return false;
+    // Detect the mode from the DOM instead of reading the alertingQueryAndExpressionsStepMode feature
+    // toggle: since Grafana 13.2.0 the frontend no longer honors that toggle (grafana/grafana#125086),
+    // so the switch is rendered regardless of the toggle value. Wait for the query step to be mounted
+    // first, otherwise a page that is still rendering would be mistaken for a page without the switch.
+    await this.getByGrafanaSelector(
+      this.ctx.selectors.components.AlertRules.step(QUERY_AND_EXPRESSION_STEP_ID)
+    ).waitFor({ state: 'visible', timeout: ALERT_PAGE_READY_TIMEOUT });
+
+    return (await this.advancedModeSwitch.count()) > 0;
   }
 
   /*

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.basicMode.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/alerting/alerting.basicMode.spec.ts
@@ -3,6 +3,16 @@ import { test, expect } from '../../../../src';
 
 const skipMsg = 'Alerting rule test API are only compatible with Grafana 9.5.0 and later';
 test.use({ featureToggles: { alertingQueryAndExpressionsStepMode: false, alertingNotificationsStepMode: false } });
+
+// This spec covers the query and expression step without the advanced mode switch, which requires
+// disabling the alertingQueryAndExpressionsStepMode feature toggle. Since Grafana 13.2.0 the frontend
+// no longer honors that toggle (grafana/grafana#125086), so this configuration cannot be tested there.
+// alerting.advancedMode.spec.ts covers the same scenarios on those versions.
+test.skip(
+  ({ grafanaVersion }) => semver.gte(grafanaVersion, '13.2.0-0'),
+  'the alertingQueryAndExpressionsStepMode feature toggle has no effect in Grafana >= 13.2.0'
+);
+
 test.describe('Test alert rule APIs', () => {
   test('advanced mode should be disabled', async ({ grafanaVersion, alertRuleEditPage }) => {
     test.skip(semver.lt(grafanaVersion, '9.5.0'), skipMsg);


### PR DESCRIPTION
**What this PR does / why we need it**:

Grafana 13.2 removed the frontend usage of the `alertingQueryAndExpressionsStepMode` feature toggle (grafana/grafana#125086), which broke the nightly E2E run ([29000729249](https://github.com/grafana/plugin-tools/actions/runs/29000729249)) in two ways:

- `AlertRuleEditPage.isAdvancedModeSupported()` decided the editor mode by reading the toggle from boot data. On 13.2 the toggle is inert, so the page objects assumed the legacy editor while Grafana rendered the simplified step, and `getQueryRow()` timed out looking for a query row title that doesn't exist there. It now detects the mode from the DOM instead: wait for the query step to mount, then check for the advanced mode switch.
- `alerting.basicMode.spec.ts` forces the toggle off to test the legacy no-switch editor. That configuration no longer exists on >= 13.2, so the spec is skipped there. alerting.advancedMode.spec.ts covers the same scenarios on those versions.

Also makes the boot data override mutate the existing `featureToggles` and `user` objects in place instead of replacing them. The runtime config keeps a reference to the original object, so replacing it means plugins never see the override when the callback runs after config construction. This is what made `queryEditor.tlsEnabled` flaky on nightly.

Verified against grafana-enterprise nightly (13.2.0-28985753600, the build that failed in CI), 13.1.0 and 11.0.11: the alerting and feature-toggles suites are green on all three.

**Which issue(s) this PR fixes**:

n/a