### PR TITLE
feat: add userPreferences k8s overrides

### DIFF
--- a/packages/plugin-e2e/src/fixtures/page.ts
+++ b/packages/plugin-e2e/src/fixtures/page.ts
@@ -37,6 +37,13 @@ export const page: PageFixture = async (
   if (hasFeatureToggles || hasUserPreferences) {
     try {
       await page.addInitScript(overrideGrafanaBootData, { featureToggles, userPreferences });
+      // override new k8s merged preferences API to ensure userPreferences are applied in the frontend
+      await page.route('**/apis/preferences.grafana.app/*/namespaces/*/preferences/merged', async (route) => {
+        const response = await route.fetch();
+        const json = await response.json();
+        json.spec = { ...json.spec, ...userPreferences };
+        await route.fulfill({ response, json });
+      });
     } catch (error) {
       console.error('Failed to set feature toggles', error);
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- we're enabling k8s preferences by default in grafana core (see https://github.com/grafana/grafana/pull/128184)
- as part of that, we will now need to override the response from the k8s endpoint when overriding preferences in tests 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
