### PR TITLE
chore(renovate): extend shared grafana-catalog-team preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   // Renovate config options: https://docs.renovatebot.com/configuration-options/
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   // Inherit Grafana's shared preset, but opt out of the parts we configure ourselves below.
-  "extends": ["github>grafana/grafana-community-team//renovate/renovate"],
+  "extends": ["github>grafana/grafana-catalog-team//renovate/renovate"],
   "ignorePresets": [
     "github>grafana/grafana-renovate-config//presets/base",
     "github>grafana/grafana-renovate-config//presets/automerge",


### PR DESCRIPTION
Point the Renovate config at the team preset's new path. The old grafana-community-team repo was renamed to grafana-catalog-team, so extends now reads github>grafana/grafana-catalog-team//renovate/renovate. Nothing else in the config changes: the ignorePresets block and all the custom packageRules stay as they are.

Part of grafana/grafana-catalog-team#1052.