### PR TITLE
fix: remove suspense boundaries from app plugin templates

### DIFF
--- a/docusaurus/docs/key-concepts/best-practices.md
+++ b/docusaurus/docs/key-concepts/best-practices.md
@@ -79,6 +79,7 @@ Is something missing from this list? [Let us know](https://github.com/grafana/pl
 - **Code split your app** - If you app contains multiple pages, make sure to use code splitting techniques to improve frontend load performance. By default Webpack will display warnings in terminal during build if any frontend assets are larger than 250kb. See the following links for more info:
   - [SurviveJs code splitting overview](https://survivejs.com/books/webpack/building/code-splitting)
   - [Official React lazy documentation](https://react.dev/reference/react/lazy)
+- **Don't wrap your root page in a `Suspense` boundary** - Grafana renders a loading state for you while a lazy root page loads, so pass the lazy component straight to `setRootPage`. Config pages registered with `addConfigPage` and other components aren't wrapped, so those still need their own `Suspense` boundary.
 - **To generate dynamic apps, consider using [Grafana Scenes](https://grafana.com/developers/scenes/).**
 - **Consider contributing a [UI extension](../how-to-guides/ui-extensions/ui-extensions-concepts)** - UI extensions can help a user to discover your app in context and continue a given workflow. Additionally, if your app provides context that can be used in other apps, then create an extension point to allow these apps to do so, with no further changes required in your app.
 

--- a/docusaurus/website/scripts/generate-markdown.sh
+++ b/docusaurus/website/scripts/generate-markdown.sh
@@ -17,7 +17,9 @@ if [ ! -s "$INPUT_FILE" ]; then
 fi
 
 # Generate markdown file
-npx --yes jsonschema2mk --partials "$PARTIALS" --schema "$INPUT_FILE" > "$OUTPUT_FILE"
+# Pinned to 2.1.x: jsonschema2mk 2.2.0 rewrote its templates (e.g. removed the
+# "mdlevel" helper) and is incompatible with the custom partials in ./partials.
+npx --yes jsonschema2mk@2.1.4 --partials "$PARTIALS" --schema "$INPUT_FILE" > "$OUTPUT_FILE"
 
 # jsonschema2mk escapes "|" as "\|" but leaves regex patterns' own backslashes in place,
 # so "\|" in a schema pattern becomes "\\|" - an escaped backslash followed by a bare pipe

--- a/packages/create-plugin/templates/app/src/module.tsx
+++ b/packages/create-plugin/templates/app/src/module.tsx
@@ -1,12 +1,12 @@
 import { lazy } from 'react';
 import { AppPlugin } from '@grafana/data';
 
-const LazyApp = lazy(() => import('./components/App/App'));
-const LazyAppConfig = lazy(() => import('./components/AppConfig/AppConfig'));
+const App = lazy(() => import('./components/App/App'));
+const AppConfig = lazy(() => import('./components/AppConfig/AppConfig'));
 
-export const plugin = new AppPlugin<{}>().setRootPage(LazyApp).addConfigPage({
+export const plugin = new AppPlugin<{}>().setRootPage(App).addConfigPage({
   title: 'Configuration',
   icon: 'cog',
-  body: LazyAppConfig,
+  body: AppConfig,
   id: 'configuration',
 });

--- a/packages/create-plugin/templates/app/src/module.tsx
+++ b/packages/create-plugin/templates/app/src/module.tsx
@@ -1,8 +1,16 @@
-import { lazy } from 'react';
-import { AppPlugin } from '@grafana/data';
+import React, { Suspense, lazy } from 'react';
+import { AppPlugin, type AppRootProps } from '@grafana/data';
+import { LoadingPlaceholder } from '@grafana/ui';
+import type { AppConfigProps } from './components/AppConfig/AppConfig';
 
 const App = lazy(() => import('./components/App/App'));
-const AppConfig = lazy(() => import('./components/AppConfig/AppConfig'));
+const LazyAppConfig = lazy(() => import('./components/AppConfig/AppConfig'));
+
+const AppConfig = (props: AppConfigProps) => (
+  <Suspense fallback={<LoadingPlaceholder text="" />}>
+    <LazyAppConfig {...props} />
+  </Suspense>
+);
 
 export const plugin = new AppPlugin<{}>().setRootPage(App).addConfigPage({
   title: 'Configuration',

--- a/packages/create-plugin/templates/app/src/module.tsx
+++ b/packages/create-plugin/templates/app/src/module.tsx
@@ -1,26 +1,12 @@
-import React, { Suspense, lazy } from 'react';
-import { AppPlugin, type AppRootProps } from '@grafana/data';
-import { LoadingPlaceholder } from '@grafana/ui';
-import type { AppConfigProps } from './components/AppConfig/AppConfig';
+import { lazy } from 'react';
+import { AppPlugin } from '@grafana/data';
 
 const LazyApp = lazy(() => import('./components/App/App'));
 const LazyAppConfig = lazy(() => import('./components/AppConfig/AppConfig'));
 
-const App = (props: AppRootProps) => (
-  <Suspense fallback={<LoadingPlaceholder text="" />}>
-    <LazyApp {...props} />
-  </Suspense>
-);
-
-const AppConfig = (props: AppConfigProps) => (
-  <Suspense fallback={<LoadingPlaceholder text="" />}>
-    <LazyAppConfig {...props} />
-  </Suspense>
-);
-
-export const plugin = new AppPlugin<{}>().setRootPage(App).addConfigPage({
+export const plugin = new AppPlugin<{}>().setRootPage(LazyApp).addConfigPage({
   title: 'Configuration',
   icon: 'cog',
-  body: AppConfig,
+  body: LazyAppConfig,
   id: 'configuration',
 });

--- a/packages/create-plugin/templates/app/src/module.tsx
+++ b/packages/create-plugin/templates/app/src/module.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { AppPlugin, type AppRootProps } from '@grafana/data';
+import { AppPlugin } from '@grafana/data';
 import { LoadingPlaceholder } from '@grafana/ui';
 import type { AppConfigProps } from './components/AppConfig/AppConfig';
 

--- a/packages/create-plugin/templates/scenes-app/src/module.tsx
+++ b/packages/create-plugin/templates/scenes-app/src/module.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy } from 'react';
-import { AppPlugin, type AppRootProps } from '@grafana/data';
+import { AppPlugin } from '@grafana/data';
 import { initPluginTranslations } from '@grafana/i18n';
 import { loadResources } from '@grafana/scenes';
 import { LoadingPlaceholder } from '@grafana/ui';
@@ -8,14 +8,8 @@ import pluginJson from 'plugin.json';
 
 await initPluginTranslations(pluginJson.id, [loadResources]);
 
-const LazyApp = lazy(() => import('./components/App/App'));
+const App = lazy(() => import('./components/App/App'));
 const LazyAppConfig = lazy(() => import('./components/AppConfig/AppConfig'));
-
-const App = (props: AppRootProps) => (
-  <Suspense fallback={<LoadingPlaceholder text="" />}>
-    <LazyApp {...props} />
-  </Suspense>
-);
 
 const AppConfig = (props: AppConfigProps) => (
   <Suspense fallback={<LoadingPlaceholder text="" />}>


### PR DESCRIPTION
**What this PR does / why we need it**:

When Grafana loads app plugins, it already wraps them in a suspense boundary at the route level (see [GrafanaRoute.tsx](https://github.com/grafana/grafana/blob/8229a35035554b678f9f01c79a80e854716aef5a/public/app/core/navigation/GrafanaRoute.tsx#L58)). This ensures that all pages across Grafana - core or from plugins - share the same initial loading state.

The App templates teaches plugin developers to wrap their app in a Suspense boundary with a LoadingPlaceholder, which is problematic for two reasons:
 - [LoadingPlaceholder](https://developers.grafana.com/ui/canary/index.html?path=/story/information-loadingplaceholder--basic) is not a suitable loading placeholder for a whole app
   - Instead, in `@grafana/ui` 13.2 we'll release [PageLoader](https://developers.grafana.com/ui/canary/index.html?path=/story/information-pageloader--basic) that is designed to be displayed full screen
 - App plugins including their own suspense boundary at the top of the app defeats the Suspense boundary the Grafana page is wrapped in, meaning they don't get the unified loading UI.

**Special notes for your reviewer**:

 - [ ] Validate all places an App component is rendered in Grafana is wrapped in `<Suspense />`
 - [ ] Validate all places an AppConfig component is rendered in Grafana is wrapped in `<Suspense />`
 - [ ] Decide what to do for all other plugin component entry points. Are they already wrapped in suspense in Grafana core? It would be great if we could tell plugin devs "you never need a top-level suspense boundary".