### PR TITLE
chore(deps): bump axios and brace-expansion via nx overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11489,9 +11489,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22715,19 +22715,6 @@
       "license": "MIT",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/nx/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/nx/node_modules/cli-cursor": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,11 @@
     "serialize-javascript": "7.0.7",
     "dompurify": "^3.4.12",
     "uuid": "^11.1.1",
-    "js-cookie": "^3.0.8"
+    "js-cookie": "^3.0.8",
+    "nx": {
+      "axios": "^1.18.0",
+      "brace-expansion": "^5.0.7"
+    }
   },
   "packageManager": "npm@11.16.0"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

nx 23.1.0 pins exact versions of axios and brace-expansion, so they lag behind the latest releases. This adds scoped overrides to pull them up to axios 1.18.1 and brace-expansion 5.0.7 until nx bumps its own pins. Lockfile regenerated, install and nx CLI verified.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:
