### PR TITLE
fix(create-plugin): pin @playwright/test to 1.61.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,13 @@ jobs:
         run: npx create-plugin update --force
         working-directory: ./${{ env.WORKING_DIR }}
 
+      # Temporarily pin playwright to match the template: the scaffolded plugin has a caret range
+      # that resolves to 1.62, which crashes on tsconfigs extending @grafana/tsconfig.
+      # Remove once playwright ships a fix and the template pin is lifted.
+      - name: Pin playwright version
+        run: npm install --no-audit --save-dev @playwright/test@~1.61.1
+        working-directory: ./${{ env.WORKING_DIR }}
+
       - name: Lint plugin frontend
         run: npm run lint
         working-directory: ./${{ env.WORKING_DIR }}

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -20,7 +20,7 @@
     "@grafana/plugin-e2e": "^3.10.0",
     "@grafana/sign-plugin": "^3.3.3",
     "@grafana/tsconfig": "^2.2.0",
-    "@playwright/test": "^1.57.0",{{#if useExperimentalRspack}}
+    "@playwright/test": "~1.61.1",{{#if useExperimentalRspack}}
     "@rspack/core": "^1.6.0",
     "@rspack/cli": "^1.6.0",{{/if}}
     "@stylistic/eslint-plugin-ts": "^4.4.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

Playwright 1.62 made unresolvable tsconfig `extends` paths a fatal error (microsoft/playwright#41571). Its config loader can't resolve the package specifier in the scaffolded `"extends": "@grafana/tsconfig"`, it only probes paths relative to the extending file, so `playwright test` now crashes on startup for every scaffolded plugin that floats to 1.62. Before 1.62 the unresolved extends was silently swallowed, which is why this never surfaced.

This pins `@playwright/test` to `~1.61.1` in the template. Existing plugins manage their own playwright version through renovate/dependabot and won't merge a broken bump, so no migration.

Upstream regression report: microsoft/playwright#41989, fixed by microsoft/playwright#42005 which hasn't shipped in a release yet. The pin comes off once it does, tracked in #2805.

**Which issue(s) this PR fixes**:

Part of #2805 (stays open to track removing the pin)

**Special notes for your reviewer**:

First seen in grafana/grafana-plugin-examples#721 where all five e2e matrix jobs fail with `Failed to resolve "extends" path "@grafana/tsconfig"`. Verified by scaffolding a plugin from this branch: `@playwright/test` resolves to 1.61.1 and `playwright test --list` loads the config and tests cleanly.