### PR TITLE
chore(deps): match pinned @grafana versions in template renovate regex

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,7 +50,7 @@
       "customType": "regex",
       "managerFilePatterns": ["/_package.json/"],
       "matchStrings": [
-        "\"(?<depName>@grafana/.*)\"[^\"]*:\\s*\"\\^(?<currentValue>.*)\","
+        "\"(?<depName>@grafana/[^\"]+)\":\\s*\"\\^?(?<currentValue>[^\"]+)\","
       ],
       "datasourceTemplate": "npm"
     },


### PR DESCRIPTION
The custom regex manager for `_package.json` only matched versions with a caret prefix. #2577 pinned the production `@grafana/*` deps in the create-plugin template, so Renovate has been blind to `@grafana/data`, `@grafana/i18n`, `@grafana/runtime`, `@grafana/ui` and `@grafana/schema` since April. The 13.0.2 and 13.1.0 bumps (#2708, #2750) had to be done by hand, and 13.1.1 is out now with no PR for it.

This makes the caret optional so both pinned and range versions match. `@grafana/scenes` now matches too but stays untouched via `ignoreDeps`.