### PR TITLE
chore(deps): track e2e-selectors nightlies by version instead of followTag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -174,20 +174,24 @@
       "matchFileNames": [".github/workflows/**"],
       "commitMessagePrefix": "chore(ci):"
     },
-    // @grafana/e2e-selectors are tracked on the nightly tag. Bumps here should release so fix(deps).
+    // @grafana/e2e-selectors tracks nightly builds (13.x-<run-id> prereleases published above the
+    // `latest` dist-tag, hence ignoreUnstable/respectLatest false). followTag: "nightly" could never
+    // pass the org-forced 3-day minimumReleaseAge (the tag always points at a <1 day old build),
+    // which froze the branch entirely (#2672). Version-based tracking lets Renovate pick the newest
+    // nightly that clears the age gate instead. Bumps here should release so fix(deps).
     {
       "automerge": true,
       "groupName": "e2e-selectors nightly",
       "groupSlug": "plugin-e2e-selectors",
       "labels": ["dependencies", "javascript"],
       "matchPackageNames": ["@grafana/e2e-selectors"],
-      "followTag": "nightly",
+      "ignoreUnstable": false,
+      "respectLatest": false,
       "rangeStrategy": "bump",
       "matchFileNames": [
         "packages/plugin-e2e/package.json",
         "package-lock.json"
       ],
-      "minimumReleaseAge": null,
       "commitMessagePrefix": "fix(deps):"
     }
   ],


### PR DESCRIPTION
#2672 has been stuck since May 27: conflicted, red CI, never rebased. The cause is org-side. The self-hosted Renovate force block applies minimumReleaseAge 3 days and internalChecksFilter strict on every config merge, so our `minimumReleaseAge: null` rule is a no-op (grafana/deployment_tools#647945 is the open PR about force{} overriding repo config, context in the comments there). With `followTag: nightly` Renovate takes exactly the tagged version, which is always less than a day old, so the update is permanently pending and branch processing bails out before rebase and automerge.

This switches e2e-selectors to normal version-based tracking: `ignoreUnstable: false` and `respectLatest: false` let Renovate see the 13.x-<run-id> builds (they're prerelease-style versions published above the `latest` dist-tag), and the 3-day age gate then picks the newest nightly that's old enough instead of blocking on the newest one. Nightlies publish often enough that there's always a passing candidate, so the PR updates and automerges again. Also drops the dead `minimumReleaseAge: null` so the age gate keeps applying if the force block gets relaxed later.

Config validated with renovate-config-validator.