### PR TITLE
fix(plugin-e2e): type window.grafanaBootData as @grafana/data's BootData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,7 +2112,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.1.tgz",
       "integrity": "sha512-URg8UM6lfC9ZYqFipItRSxYJdgpU5d2Z4KnjsJ+rj6tgAmGme7E+PQNCiud8g0HDaZKMovu2qjfa0f5Ge0Vlsg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@coffeeandfun/remove-pii": {
@@ -5162,7 +5161,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
       "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@formatjs/fast-memoize": "2.2.7",
@@ -5175,7 +5173,6 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
       "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -5185,7 +5182,6 @@
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-durationformat/-/intl-durationformat-0.7.6.tgz",
       "integrity": "sha512-jatAN3E84X6aP2UOGK1jTrwD1a7BiG3qWUSEDAhtyNd1BgYeS5wQPtXlnuGF1QRx0DjnwwNOIssyd7oQoRlQeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@formatjs/ecma402-abstract": "2.3.6",
@@ -5197,7 +5193,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
       "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -5208,15 +5203,14 @@
       "link": true
     },
     "node_modules/@grafana/data": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-13.1.0.tgz",
-      "integrity": "sha512-QCqBVG/sP/f2h0r93WFF+LfvdY2l0fQEAV4rCzcRQv+XLzClclKAPX+N41yIjh4zieDkB5JKlXYzCKKwLC9kWg==",
-      "dev": true,
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@grafana/data/-/data-13.1.1.tgz",
+      "integrity": "sha512-8mOs4ymGwdAwUrIWjYtofFkg8A6UakjwQ78Zw83uPM11oNQ2Xlpszz8L/238JTt7lYbOj0l8Cc5gIa2OYEJ8TQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@braintree/sanitize-url": "7.0.1",
-        "@grafana/i18n": "13.1.0",
-        "@grafana/schema": "13.1.0",
+        "@grafana/i18n": "13.1.1",
+        "@grafana/schema": "13.1.1",
         "@leeoniya/ufuzzy": "1.0.19",
         "@types/d3-interpolate": "^3.0.0",
         "@types/string-hash": "1.1.3",
@@ -5224,7 +5218,7 @@
         "d3-interpolate": "3.0.1",
         "d3-scale-chromatic": "3.1.0",
         "date-fns": "4.1.0",
-        "dompurify": "3.4.0",
+        "dompurify": "^3.4.0",
         "eventemitter3": "5.0.1",
         "history": "4.10.1",
         "lodash": "^4.17.23",
@@ -5234,7 +5228,7 @@
         "moment-timezone": "0.5.47",
         "ol": "10.7.0",
         "papaparse": "5.5.3",
-        "react-use": "17.6.0",
+        "react-use": "^17.6.0",
         "rxjs": "7.8.2",
         "string-hash": "^1.1.3",
         "tinycolor2": "1.6.0",
@@ -5251,7 +5245,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@grafana/e2e-selectors": {
@@ -5308,20 +5301,19 @@
       }
     },
     "node_modules/@grafana/i18n": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-13.1.0.tgz",
-      "integrity": "sha512-hgmfauVZvU2TbhsczicXMaT2PU0GDzfPL5v+bQWNDojRHPB2uyq/f2CWrCgpKaEGyJxA7o2HFmTRPcTwvXfjgw==",
-      "dev": true,
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@grafana/i18n/-/i18n-13.1.1.tgz",
+      "integrity": "sha512-+t2QWJ6yGK5FHaBYv2WkviGEjfeV6ppNq3AwLfaeHrdg1J2cSEuZRyhwLh5fsByO5MSJVKFP64euZAkStizkRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@formatjs/intl-durationformat": "^0.7.0",
         "@typescript-eslint/utils": "^8.33.1",
         "fast-deep-equal": "^3.1.3",
-        "i18next": "^25.0.0",
+        "i18next": "^25.10.9",
         "i18next-browser-languagedetector": "^8.0.0",
         "i18next-pseudo": "^2.2.1",
         "micro-memoize": "^4.1.2",
-        "react-i18next": "^15.0.0"
+        "react-i18next": "^16.6.6"
       },
       "peerDependencies": {
         "react": ">=18"
@@ -5480,10 +5472,9 @@
       "link": true
     },
     "node_modules/@grafana/schema": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-13.1.0.tgz",
-      "integrity": "sha512-7SPiD1sKQanTtmeZXcJ0FMcqyOvPLrXWNeWmlInE0fW+g0TSGjx05CH00hviPCEyBzG6MoW7izTWCKrgpy9iaA==",
-      "dev": true,
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@grafana/schema/-/schema-13.1.1.tgz",
+      "integrity": "sha512-2/89TWqLUJ0ffi8/qhoUtT2cZqpQ7MY3DoOWJ39sY1+nf1defi8vIDKyWp88HFAo9HJtwwlQQQowP7Jre7VRHQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@grafana/sign-plugin": {
@@ -6178,7 +6169,6 @@
       "version": "1.0.19",
       "resolved": "https://registry.npmjs.org/@leeoniya/ufuzzy/-/ufuzzy-1.0.19.tgz",
       "integrity": "sha512-0pikDeYt0IHEUPza5RTCDXc/17S1pTrYnReEMp8Aa6k1ovzw5QdZLwicW8TjljwEZRb6oYag0xmALohrcq/yOQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -7162,7 +7152,6 @@
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
@@ -9571,14 +9560,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
       "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-color": "*"
@@ -9757,7 +9744,6 @@
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
       "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/js-yaml": {
@@ -9865,7 +9851,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
       "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -9988,7 +9973,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-p6skq756fJWiA59g2Uss+cMl6tpoDGuCBuxG0SI1t0NwJmYOU66LAMS6QiCgu7cUh3/hYCaMl5phcCW1JP5wOA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/superagent": {
@@ -10026,7 +10010,6 @@
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-6.15.3.tgz",
       "integrity": "sha512-STyj2LUevlyVqEQ1wjOORLQTJbNnM2V1DNzmemxVHlOovdKBKqccALDbR9aCcTRThhcXzew88SMbN4SMm6JOcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/tmp": {
@@ -10046,7 +10029,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10617,7 +10599,6 @@
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
       "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
@@ -12941,7 +12922,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
       "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
@@ -13263,7 +13243,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
       "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
@@ -13407,7 +13386,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
       "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.14",
@@ -13421,7 +13399,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -13471,7 +13448,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cssnano": {
@@ -13647,7 +13623,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -13657,7 +13632,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3"
@@ -13670,7 +13644,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
       "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "d3-color": "1 - 3",
@@ -13744,7 +13717,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -13793,7 +13765,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -14631,7 +14602,6 @@
       "version": "3.4.12",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
       "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
-      "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -14737,7 +14707,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
       "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/eastasianwidth": {
@@ -14902,7 +14871,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
       "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
@@ -16063,8 +16031,7 @@
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
-      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==",
-      "dev": true
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
@@ -16086,7 +16053,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
       "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -16614,7 +16580,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
       "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
@@ -18196,10 +18161,9 @@
       }
     },
     "node_modules/html-parse-stringify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
-      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
+      "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
@@ -18455,14 +18419,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/i18next": {
       "version": "25.10.10",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
       "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -18494,7 +18456,6 @@
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
       "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
@@ -18504,7 +18465,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/i18next-pseudo/-/i18next-pseudo-2.2.1.tgz",
       "integrity": "sha512-wGybHZl+D7GXZLxLAWN5AhyrmVBxPd5kPpHgcgPw1yOoJcEEvxRk5+ZpbaAc8R59JHeyXLl99rWIXdg/zCvKFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "i18next": "^19.1.0"
@@ -18514,7 +18474,6 @@
       "version": "19.9.2",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
       "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0"
@@ -18686,7 +18645,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
       "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-in-js-utils": "^3.1.0"
@@ -19673,7 +19631,6 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
       "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -19856,7 +19813,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/leven": {
@@ -20651,7 +20607,6 @@
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
       "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -20664,7 +20619,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/marked-mangle/-/marked-mangle-1.1.12.tgz",
       "integrity": "sha512-bRrqNcfU9v3iRECb7YPvA+/xKZMjHojd9R92YwHbFjdPQ+Wc7vozkbGKAv4U8AUl798mNUuY3DTBQkedsV3TeQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "marked": ">=4 <18"
@@ -21033,7 +20987,6 @@
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -21139,7 +21092,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/micro-memoize/-/micro-memoize-4.2.0.tgz",
       "integrity": "sha512-dRxIsNh0XosO9sd3aASUabKOzG9dloLO41g74XUGThpHBoGm1ttakPT5in14CuW/EDedkniaShFHbymmmKGOQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/micromark": {
@@ -22167,7 +22119,6 @@
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -22177,7 +22128,6 @@
       "version": "0.5.47",
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.47.tgz",
       "integrity": "sha512-UbNt/JAWS0m/NJOebR0QMRHBk0hu03r5dx9GK8Cs0AS3I81yDcOc9k+DytPItgVvBP7J6Mf6U2n3BPAacAV9oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "moment": "^2.29.4"
@@ -22228,7 +22178,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
       "integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
-      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -23018,7 +22967,6 @@
       "version": "10.7.0",
       "resolved": "https://registry.npmjs.org/ol/-/ol-10.7.0.tgz",
       "integrity": "sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/rbush": "4.0.0",
@@ -23578,7 +23526,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
       "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -23595,7 +23542,6 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/param-case": {
@@ -23649,7 +23595,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
       "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/parse-imports-exports": {
@@ -23845,7 +23790,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
       "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "resolve-protobuf-schema": "^2.1.0"
@@ -25684,7 +25628,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
       "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -25851,7 +25794,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
       "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -25870,7 +25812,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/range-parser": {
@@ -25945,7 +25886,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
       "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quickselect": "^3.0.0"
@@ -26031,19 +25971,19 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
-      "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
-      "dev": true,
+      "version": "16.6.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
+      "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.6",
-        "html-parse-stringify": "^3.0.1"
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
-        "i18next": ">= 23.4.0",
+        "i18next": ">= 25.10.9",
         "react": ">= 16.8.0",
-        "typescript": "^5"
+        "typescript": "^5 || ^6"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -26159,7 +26099,6 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
       "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
-      "dev": true,
       "peerDependencies": {
         "react": "*",
         "tslib": "*"
@@ -26169,7 +26108,6 @@
       "version": "17.6.0",
       "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.0.tgz",
       "integrity": "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==",
-      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "@types/js-cookie": "^2.2.6",
@@ -26871,7 +26809,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -26930,7 +26867,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
@@ -27208,7 +27144,6 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
       "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.1.2"
@@ -27271,7 +27206,6 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -27449,7 +27383,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
       "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -27835,7 +27768,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
       "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
-      "dev": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=6.9"
@@ -28579,7 +28511,6 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
       "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "stackframe": "^1.3.4"
@@ -28596,14 +28527,12 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/stacktrace-gps": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
       "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "source-map": "0.5.6",
@@ -28614,7 +28543,6 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -28624,7 +28552,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
       "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "error-stack-parser": "^2.0.6",
@@ -28693,7 +28620,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/string-width": {
@@ -28985,7 +28911,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/superagent": {
@@ -29325,7 +29250,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
       "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -29360,7 +29284,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -29526,7 +29449,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/toidentifier": {
@@ -29629,7 +29551,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==",
-      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/tsconfig-paths": {
@@ -30553,7 +30474,6 @@
       "version": "1.6.32",
       "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
       "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -30608,6 +30528,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -31039,7 +30968,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -31102,7 +31030,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/webpack": {
@@ -32291,14 +32218,12 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
       "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/xss": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
       "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^2.20.3",
@@ -32315,7 +32240,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
@@ -32453,7 +32377,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -32476,7 +32399,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
       "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
-      "dev": true,
       "license": "MIT AND BSD-3-Clause"
     },
     "node_modules/zwitch": {
@@ -32778,6 +32700,7 @@
       "version": "3.10.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@grafana/data": "^13.1.1",
         "@grafana/e2e-selectors": "13.1.0-25644485979",
         "yaml": "^2.3.4"
       },

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -49,6 +49,7 @@
     "dotenv": "^17.2.4"
   },
   "dependencies": {
+    "@grafana/data": "^13.1.1",
     "@grafana/e2e-selectors": "13.1.0-25644485979",
     "yaml": "^2.3.4"
   }

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -149,15 +149,7 @@ export { selectors } from '@playwright/test';
 declare global {
   interface Window {
     monaco: any;
-    grafanaBootData: {
-      settings: {
-        featureToggles: Record<string, boolean>;
-        buildInfo: {
-          version: string;
-        };
-        namespace: string;
-      };
-    };
+    grafanaBootData: import('@grafana/data').BootData;
   }
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace PlaywrightTest {


### PR DESCRIPTION
## What this does

Types the global `Window.grafanaBootData` ambient augmentation in `plugin-e2e` as
`import('@grafana/data').BootData` instead of a hand-rolled inline subset.

Fixes: #2811

## Why

The previous inline shape was a strict subset of Grafana core's real `BootData` type. When a
single `tsc` program merges this package's ambient `Window` declaration with Grafana's own
(e.g. Grafana core's tsconfig for typechecking `e2e-playwright` alongside app source), the
merged property types must be identical or TypeScript raises TS2717. Grafana core currently
masks this via `skipLibCheck: true` and works around the resulting file-order sensitivity with
an explicit `include` array ordering (see grafana/grafana `e2e-playwright/tsconfig.json`) — a
fragile mechanism, since which declaration silently wins depends on unspecified compiler
behavior.

Using Grafana's own `BootData` type directly removes the structural mismatch at the source, so
downstream consumers no longer need to work around merge order.

## Changes

- `packages/plugin-e2e/src/index.ts`: `grafanaBootData` is now typed as
  `import('@grafana/data').BootData`.
- `packages/plugin-e2e/package.json`: adds `@grafana/data` as a `dependencies` entry (it was not
  previously a dependency of this package).

## Verification

- `npm run typecheck -w @grafana/plugin-e2e`, `npm run build -w @grafana/plugin-e2e`,
  `npm run lint -w @grafana/plugin-e2e`, and `npm run test -w @grafana/plugin-e2e` all pass.
- Packed the built package and installed it as a local `file:` dependency in a `grafana/grafana`
  checkout. With the fix installed, reversing the `include` array order in
  `e2e-playwright/tsconfig.json` (which previously reproduced 3 TS2717-driven errors in
  `packages/grafana-runtime/src/config.ts` and
  `packages/grafana-ui/src/components/DateTimePickers/WeekStartPicker.tsx`) no longer reproduces
  those errors. With the normal include order, `typecheck:e2e` stays clean.

## Note for reviewers

Raised the approach in #2811 first since this changes the package's public ambient type surface
and adds a new dependency (`@grafana/data`) that `plugin-e2e` did not previously have. Open to
an alternative shape if maintainers prefer not to take that dependency (e.g. dropping
`grafanaBootData` from the global augmentation entirely and keeping it as a package-local type).