### PR TITLE
fix(create-plugin): unpin @playwright/test now that 1.62.1 fixes tsconfig resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,13 +210,6 @@ jobs:
         run: npx create-plugin update --force
         working-directory: ./${{ env.WORKING_DIR }}
 
-      # Temporarily pin playwright to match the template: the scaffolded plugin has a caret range
-      # that resolves to 1.62, which crashes on tsconfigs extending @grafana/tsconfig.
-      # Remove once playwright ships a fix and the template pin is lifted.
-      - name: Pin playwright version
-        run: npm install --no-audit --save-dev @playwright/test@~1.61.1
-        working-directory: ./${{ env.WORKING_DIR }}
-
       - name: Lint plugin frontend
         run: npm run lint
         working-directory: ./${{ env.WORKING_DIR }}

--- a/packages/create-plugin/templates/common/_package.json
+++ b/packages/create-plugin/templates/common/_package.json
@@ -20,7 +20,7 @@
     "@grafana/plugin-e2e": "^3.10.0",
     "@grafana/sign-plugin": "^3.3.3",
     "@grafana/tsconfig": "^2.2.0",
-    "@playwright/test": "~1.61.1",{{#if useExperimentalRspack}}
+    "@playwright/test": "^1.62.1",{{#if useExperimentalRspack}}
     "@rspack/core": "^1.6.0",
     "@rspack/cli": "^1.6.0",{{/if}}
     "@stylistic/eslint-plugin-ts": "^4.4.0",


### PR DESCRIPTION
**What this PR does / why we need it**:

Playwright 1.62.1 shipped with the fix for the tsconfig `extends` regression (microsoft/playwright#41989), so scaffolded plugins extending `@grafana/tsconfig` load fine again. Verified locally with a minimal scaffold layout: `playwright test --list` on 1.62.1 resolves the config where 1.62.0 crashed.

This reverts the `~1.61.1` template pin from #2806 back to a caret range (`^1.62.1`, so the broken 1.62.0 can never be resolved) and removes the temporary playwright pin step from ci.yml.

**Which issue(s) this PR fixes**:

Fixes #2805

**Special notes for your reviewer**:
