### PR TITLE
docs: document the components fixture in the e2e testing docs

### DIFF
--- a/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
+++ b/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
@@ -74,7 +74,7 @@ explorePage.getQueryEditorRow('A').getByLabel('Query').fill('sum(*)');
 
 Here are some examples demonstrating how to interact with a few UI components that are common in plugins. The `InlineField` and `Field` component can be used interchangeably.
 
-For many common Grafana UI components, such as select, switch, radio group, and color picker, `@grafana/plugin-e2e` provides ready-made component models through the [`components` fixture](./use-the-api.md#components). Prefer the `components` fixture whenever it covers the component you're testing - it handles UI differences between Grafana versions and actionability quirks for you.
+For many common Grafana UI components, such as `select`, `switch`, `radio group`, or `color picker`, `@grafana/plugin-e2e` provides ready-made component models through the [`components` fixture](./use-the-api.md#components). When it covers the component you're testing, use the `components` fixture, since it handles UI differences between Grafana versions and other elements and the component you're targeting.
 
 #### Input field
 

--- a/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
+++ b/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
@@ -141,7 +141,7 @@ You can use the `InlineSwitch` component to interact with the UI.
 </div>
 ```
 
-Use the `switch` model from the [`components` fixture](./use-the-api.md#components) to interact with the component. It resolves the switch element across Grafana versions, and its `check` and `uncheck` methods are idempotent - they only click the switch when the state needs to change, which avoids races with React's re-render cycle.
+Use the `switch` model from the [`components` fixture](./use-the-api.md#components) to interact with the component. It resolves the switch element across Grafana versions, and its `check` and `uncheck` methods are idempotent, so they only click the switch when the state needs to change, which avoids races with React's re-render cycle.
 
 ```ts title="Playwright test"
 const tlsField = page.getByTestId('config-tls-field');

--- a/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
+++ b/docusaurus/docs/e2e-test-a-plugin/selecting-ui-elements.md
@@ -74,6 +74,8 @@ explorePage.getQueryEditorRow('A').getByLabel('Query').fill('sum(*)');
 
 Here are some examples demonstrating how to interact with a few UI components that are common in plugins. The `InlineField` and `Field` component can be used interchangeably.
 
+For many common Grafana UI components, such as select, switch, radio group, and color picker, `@grafana/plugin-e2e` provides ready-made component models through the [`components` fixture](./use-the-api.md#components). Prefer the `components` fixture whenever it covers the component you're testing - it handles UI differences between Grafana versions and actionability quirks for you.
+
 #### Input field
 
 You can use the `InlineField` component to interact with the UI.
@@ -93,17 +95,20 @@ await page.getByRole('textbox', { name: 'Auth key' }).fill('..');
 Unlike many other components that require you to pass an `id` prop to be able to associate the label with the form element, the `select` component requires you to pass an `inputId` prop. You can find more information about testing the `select` component [here](https://github.com/grafana/grafana/blob/401265522e584e4e71a1d92d5af311564b1ec33e/contribute/style-guides/testing.md#testing-select-components).
 
 ```tsx title="UI component"
-<InlineField label="Auth type">
-  <Select inputId="config-auth-type" value={value} options={options} onChange={handleOnChange} />
-</InlineField>
+<div data-testid="config-auth-type-field">
+  <InlineField label="Auth type">
+    <Select inputId="config-auth-type" value={value} options={options} onChange={handleOnChange} />
+  </InlineField>
+</div>
 ```
 
+Use the `select` model from the [`components` fixture](./use-the-api.md#components) to interact with the component, and the `toHaveSelected` matcher to assert the selected option:
+
 ```ts title="Playwright test"
-test('testing select component', async ({ page, selectors }) => {
-  const configPage = await createDataSourceConfigPage({ type: 'test-datasource' });
-  await page.getByRole('combobox', { name: 'Auth type' }).click();
-  const option = selectors.components.Select.option;
-  await expect(configPage.getByGrafanaSelector(option)).toHaveText(['val1', 'val2']);
+test('testing select component', async ({ page, components }) => {
+  const authTypeField = page.getByTestId('config-auth-type-field');
+  await components.select.within(authTypeField).selectOption('OAuth');
+  await expect(components.select.within(authTypeField)).toHaveSelected('OAuth');
 });
 ```
 
@@ -111,7 +116,7 @@ test('testing select component', async ({ page, selectors }) => {
 
 You can use the `Checkbox` component to interact with the UI.
 
-```tsx title="UI componevnt"
+```tsx title="UI component"
 <InlineField label="TLS Enabled">
   <Checkbox id="config-tls-enabled" value={value} onChange={handleOnChange} />
 </InlineField>
@@ -129,27 +134,23 @@ await expect(page.getByRole('checkbox', { name: 'TLS Enabled' })).not.toBeChecke
 You can use the `InlineSwitch` component to interact with the UI.
 
 ```tsx title="UI component"
-<InlineField label="TLS Enabled">
-  <InlineSwitch label="TLS Enabled" value={value} onChange={handleOnChange} />
-</InlineField>
+<div data-testid="config-tls-field">
+  <InlineField label="TLS Enabled">
+    <InlineSwitch label="TLS Enabled" value={value} onChange={handleOnChange} />
+  </InlineField>
+</div>
 ```
 
-Use `getByRole('switch', { name: /TLS Enabled/i })` rather than `getByLabel` — newer versions of Grafana add `aria-label` to the `<label>` element itself, which causes `getByLabel` to match multiple elements and fail in strict mode.
-
-Use `isChecked()` combined with `click({ force: true })` rather than `check()`/`uncheck()`. The `check()` and `uncheck()` methods assert the final state after clicking, which can race with React's re-render cycle on newer versions of Grafana and cause intermittent failures.
+Use the `switch` model from the [`components` fixture](./use-the-api.md#components) to interact with the component. It resolves the switch element across Grafana versions, and its `check` and `uncheck` methods are idempotent - they only click the switch when the state needs to change, which avoids races with React's re-render cycle.
 
 ```ts title="Playwright test"
-const switchLocator = page.getByRole('switch', { name: /TLS Enabled/i });
+const tlsField = page.getByTestId('config-tls-field');
 
 // checking
-if (!(await switchLocator.isChecked())) {
-  await switchLocator.click({ force: true });
-}
-await expect(switchLocator).toBeChecked();
+await components.switch.within(tlsField).check();
+await expect(components.switch.within(tlsField)).toBeChecked();
 
 // unchecking
-if (await switchLocator.isChecked()) {
-  await switchLocator.click({ force: true });
-}
-await expect(switchLocator).not.toBeChecked();
+await components.switch.within(tlsField).uncheck();
+await expect(components.switch.within(tlsField)).not.toBeChecked();
 ```

--- a/docusaurus/docs/e2e-test-a-plugin/use-the-api.md
+++ b/docusaurus/docs/e2e-test-a-plugin/use-the-api.md
@@ -59,7 +59,7 @@ To learn how to provision the Grafana instance with the resources that you need,
 
 ### Components
 
-Component model objects represent Grafana UI components such as the select, switch, radio group, and color picker components. Like pages, they encapsulate common UI operations in one place and handle UI deviations between different versions of Grafana. Use the `components` fixture to interact with a Grafana UI component instead of writing your own locators.
+Component model objects represent Grafana UI components such as the `select`, `switch`, `radio group`, and `color picker` components. Like pages, they encapsulate common UI operations in one place and handle UI deviations between different versions of Grafana. Use the `components` fixture to interact with a Grafana UI component instead of writing your own locators.
 
 The following example uses the `dataSourcePicker` component to select a data source:
 

--- a/docusaurus/docs/e2e-test-a-plugin/use-the-api.md
+++ b/docusaurus/docs/e2e-test-a-plugin/use-the-api.md
@@ -24,7 +24,7 @@ The package exports classes, but the classes are also exposed through the Playwr
 
 The `@grafana/plugin-e2e` package defines a set of [custom fixtures](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/src/types.ts) that facilitate the end-to-end testing of Grafana plugins.
 
-The following section explains the different types of page fixtures:
+The following sections explain the different types of fixtures:
 
 ### Pages
 
@@ -57,6 +57,65 @@ test('test annotation query', async ({ gotoAnnotationEditPage }) => {
 
 To learn how to provision the Grafana instance with the resources that you need, refer to the [Set up resources](./setup-resources.md) guide.
 
+### Components
+
+Component model objects represent Grafana UI components such as the select, switch, radio group, and color picker components. Like pages, they encapsulate common UI operations in one place and handle UI deviations between different versions of Grafana. Use the `components` fixture to interact with a Grafana UI component instead of writing your own locators.
+
+The following example uses the `dataSourcePicker` component to select a data source:
+
+```ts
+test('set data source in data source picker', async ({ components }) => {
+  await components.dataSourcePicker.set('gdev-prometheus');
+});
+```
+
+The `components` fixture exposes the following components:
+
+| Component                     | Primary methods                                             |
+| ----------------------------- | ----------------------------------------------------------- |
+| `components.dataSourcePicker` | `set(name)`                                                 |
+| `components.timeRangePicker`  | `set({ from, to, zone })`                                   |
+| `components.select`           | `selectOption(value)`                                       |
+| `components.multiSelect`      | `selectOptions([values])`                                   |
+| `components.switch`           | `check()`, `uncheck()`                                      |
+| `components.radioGroup`       | `check(labelOrValue)`                                       |
+| `components.unitPicker`       | `selectOption(path)` where `path` is like `'Misc > Pixels'` |
+| `components.colorPicker`      | `selectOption(rgbOrHex)`                                    |
+
+To see the full list of components exposed by `@grafana/plugin-e2e`, refer to the Github [repository](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e/src/models/components).
+
+#### Scoping a component to a part of the page
+
+By default, a component model resolves to the first matching element on the page. If the page contains more than one instance of a component, use the `within` method to scope the component to a Playwright [locator](https://playwright.dev/docs/locators).
+
+The following example scopes the `select` component to the timezone field in the panel editor options pane:
+
+```ts
+test('select timezone in panel options', async ({ gotoPanelEditPage, components, selectors }) => {
+  const panelEditPage = await gotoPanelEditPage({ dashboard: { uid: 'mxb-Jv4Vk' }, id: '5' });
+  const timezoneField = panelEditPage.getByGrafanaSelector(
+    selectors.components.PanelEditor.OptionsPane.fieldLabel('Timezone Timezone')
+  );
+  await components.select.within(timezoneField).selectOption('Europe/Stockholm');
+  await expect(components.select.within(timezoneField)).toHaveSelected('Europe/Stockholm');
+});
+```
+
 ## Expect matchers
 
-The Playwright API allows you to extend the default assertions by providing custom matchers. `@grafana/plugin-e2e` defines a set of custom matchers that simplify assertions for certain pages. To see the full list of matchers, refer to the Github [repository](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e/src/matchers).
+The Playwright API allows you to extend the default assertions by providing custom matchers. `@grafana/plugin-e2e` defines a set of custom matchers that simplify assertions for certain pages and components. For example, the `toHaveSelected` matcher asserts that a select component has a given option selected, and the `toBeChecked` matcher asserts the state of a switch:
+
+```ts
+await expect(components.select.within(timezoneField)).toHaveSelected('Europe/Stockholm');
+await expect(components.switch.within(monospaceField)).toBeChecked();
+await expect(components.radioGroup.within(modeField)).toHaveChecked('Countdown');
+await expect(components.colorPicker.within(backgroundField)).toHaveColor('#73bf69');
+```
+
+:::note
+
+Grafana normalizes colors to lowercase hexadecimal values, so always pass a lowercase hexadecimal value to the `toHaveColor` matcher.
+
+:::
+
+To see the full list of matchers, refer to the Github [repository](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e/src/matchers).

--- a/docusaurus/docs/e2e-test-a-plugin/use-the-api.md
+++ b/docusaurus/docs/e2e-test-a-plugin/use-the-api.md
@@ -84,7 +84,7 @@ The `components` fixture exposes the following components:
 
 To see the full list of components exposed by `@grafana/plugin-e2e`, refer to the Github [repository](https://github.com/grafana/plugin-tools/tree/main/packages/plugin-e2e/src/models/components).
 
-#### Scoping a component to a part of the page
+#### Scope a component to a part of the page
 
 By default, a component model resolves to the first matching element on the page. If the page contains more than one instance of a component, use the `within` method to scope the component to a Playwright [locator](https://playwright.dev/docs/locators).
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Documents the `components` fixture in the plugin-e2e developer docs, which was previously not covered at all. Adds a **Components** section to "Use the API" following the same pattern as the Pages section — an example, a table of the exposed components (`dataSourcePicker`, `timeRangePicker`, and the six added in #2621: `select`, `multiSelect`, `switch`, `radioGroup`, `unitPicker`, `colorPicker`), the `within()` scoping pattern, and a link to the source directory — and extends the expect-matchers section with the paired `toHaveSelected`/`toBeChecked`/`toHaveChecked`/`toHaveColor` matchers. Also reworks the manual Select and InlineSwitch recipes in "Select UI elements" to recommend the fixture, which handles version differences and the re-render race the old force-click recipe worked around.

**Which issue(s) this PR fixes**:

Follows up on #2621.

**Special notes for your reviewer**:

While writing the docs I noticed the `toBeChecked` matcher declares `options?: { on?: boolean }` but its implementation reads `options?.checked`, so the docs use `.not.toBeChecked()` for the unchecked assertion. Worth aligning in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)