### PR TITLE
fix(deps): bump e2e-selectors in plugin-e2e

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7785,33 +7785,12 @@
       "license": "0BSD"
     },
     "node_modules/@grafana/e2e-selectors": {
-      "version": "13.1.0-25893932881",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-25893932881.tgz",
-      "integrity": "sha512-wnJGnNBz1Kobhh4nRG6J4d3mUmhTbUconkhMZv79k3aA/rlFA7I3Ru6K56efwW3XF2m3B4qN3Em+AaIJUGMzoQ==",
+      "version": "13.2.0-30594044109",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.2.0-30594044109.tgz",
+      "integrity": "sha512-CRN0CTsSkAC3qQvufbR7duUzSX2Jfgc/g5ap+eSrjcFcS+vAVUDGfQVLK6y5ojN+B0gATNIbmVlCGngQxmm+eA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "semver": "^7.7.0",
-        "tslib": "2.8.1",
-        "typescript": "6.0.2"
-      }
-    },
-    "node_modules/@grafana/e2e-selectors/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
-    "node_modules/@grafana/e2e-selectors/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
+        "semver": "^7.7.0"
       }
     },
     "node_modules/@grafana/eslint-config": {
@@ -36315,7 +36294,7 @@
       "version": "3.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "13.1.0-25893932881",
+        "@grafana/e2e-selectors": "13.2.0-30594044109",
         "yaml": "^2.3.4"
       },
       "devDependencies": {

--- a/packages/plugin-e2e/package.json
+++ b/packages/plugin-e2e/package.json
@@ -49,7 +49,7 @@
     "dotenv": "^17.2.4"
   },
   "dependencies": {
-    "@grafana/e2e-selectors": "13.1.0-25893932881",
+    "@grafana/e2e-selectors": "13.2.0-30594044109",
     "yaml": "^2.3.4"
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

[This recent change](https://github.com/grafana/grafana/pull/129516) in Grafana updated the e2e-selectors. This PR manually bumps the @grafana/e2e-selectors package to pick up those new selector values.

plugin-e2e is intended to follow the nightly tag of the e2e-selectors package, allowing those updates to be picked up automatically. However, that pipeline has been broken for some time. That will be resolved by [this fix](https://github.com/grafana/plugin-tools/pull/2809) from @tolzhabayev.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
