### PR TITLE
feat(plugin-e2e): fetch e2e-selectors from Grafana at runtime

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -92,6 +92,9 @@ jobs:
 
       - name: Run Playwright tests
         id: run-tests
+        env:
+          # dogfood runtime e2e-selectors here before shipping the default to all consumers
+          PLUGIN_E2E_RUNTIME_SELECTORS: 'true'
         run: npm run playwright:test --w @grafana/plugin-e2e
 
       - name: Upload e2e test summary

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -93,6 +93,9 @@ jobs:
 
       - name: Run Playwright tests
         id: run-tests
+        env:
+          # dogfood runtime e2e-selectors here before shipping the default to all consumers
+          PLUGIN_E2E_RUNTIME_SELECTORS: 'true'
         run: npm run playwright:test --w @grafana/plugin-e2e
 
       - name: Upload e2e test summary

--- a/packages/plugin-e2e/src/fixtures/bootData.ts
+++ b/packages/plugin-e2e/src/fixtures/bootData.ts
@@ -3,6 +3,9 @@ import { PlaywrightTestArgs, TestFixture } from '@playwright/test';
 interface BootData {
   version: string | undefined;
   namespace: string | undefined;
+  // absolute URL where this instance serves the data-only e2e-selectors file, derived from the asset
+  // base (origin in single-binary, CDN in multi-tenant). undefined when it can't be derived.
+  selectorsUrl: string | undefined;
 }
 
 type BootDataFixture = TestFixture<BootData, PlaywrightTestArgs>;
@@ -18,20 +21,30 @@ export const bootData: BootDataFixture = async ({ context }, use) => {
   try {
     await tempPage.goto('/');
     const bootDataSettings = await tempPage.evaluate(() => {
+      // e2e-selectors.json is emitted into the frontend build output next to the JS bundles, so its
+      // URL is the bundle directory with the filename swapped. resolving against document.baseURI
+      // yields an absolute URL for both single-binary (origin-relative bundles) and multi-tenant
+      // (CDN-absolute bundles).
+      const jsFilePath = window.grafanaBootData?.assets?.jsFiles?.[0]?.filePath;
+      const selectorsUrl = jsFilePath
+        ? new URL(jsFilePath.replace(/[^/]+$/, 'e2e-selectors.json'), document.baseURI).href
+        : undefined;
       return {
         version: window.grafanaBootData.settings.buildInfo.version,
         namespace: window.grafanaBootData.settings.namespace,
+        selectorsUrl,
       };
     });
 
     await use({
       version: bootDataSettings.version,
       namespace: bootDataSettings.namespace,
+      selectorsUrl: bootDataSettings.selectorsUrl,
     });
   } catch (error) {
     console.error('@grafana/plugin-e2e: Failed to fetch boot data', error);
     // provide undefined values if fetch fails (fixtures will apply their own defaults)
-    await use({ version: undefined, namespace: undefined });
+    await use({ version: undefined, namespace: undefined, selectorsUrl: undefined });
   } finally {
     await tempPage.close();
   }

--- a/packages/plugin-e2e/src/fixtures/selectors.test.ts
+++ b/packages/plugin-e2e/src/fixtures/selectors.test.ts
@@ -26,10 +26,16 @@ function mockRequest(get: ReturnType<typeof vi.fn>) {
   return { get } as never;
 }
 
-async function runFixture(args: { grafanaVersion: string; request: never }) {
+// URL the bootData fixture would derive from the instance's asset base (origin in single-binary)
+const SELECTORS_URL = 'http://grafana.test/public/build/e2e-selectors.json';
+
+async function runFixture(args: { grafanaVersion: string; request: never; selectorsUrl?: string | undefined }) {
+  const { grafanaVersion, request } = args;
+  // key-presence, not a default, so an explicit `selectorsUrl: undefined` is honored
+  const selectorsUrl = 'selectorsUrl' in args ? args.selectorsUrl : SELECTORS_URL;
   let captured: Record<string, unknown> | undefined;
   await (selectors as unknown as (a: unknown, use: (value: Record<string, unknown>) => Promise<void>) => Promise<void>)(
-    args,
+    { grafanaVersion, request, bootData: { version: grafanaVersion, namespace: 'default', selectorsUrl } },
     async (value) => {
       captured = value;
     }
@@ -66,10 +72,24 @@ describe('selectors fixture', () => {
 
     const result = await runFixture({ grafanaVersion: '11.0.0-200', request: mockRequest(get) });
 
-    expect(get).toHaveBeenCalledWith('/public/e2e-selectors.json', { maxRedirects: 0 });
+    expect(get).toHaveBeenCalledWith(SELECTORS_URL, { maxRedirects: 0 });
     expect(result.components).toEqual({ __source: 'fetched-components' });
     expect(result.pages).toEqual({ __source: 'fetched-pages' });
     expect(result.apis).toEqual({ __source: 'local-apis' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the bundled dependency quietly when the URL cannot be derived from bootData', async () => {
+    const get = vi.fn();
+
+    const result = await runFixture({
+      grafanaVersion: '11.0.0-nourl',
+      request: mockRequest(get),
+      selectorsUrl: undefined,
+    });
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.components).toEqual({ __source: 'dep-components' });
     expect(warnSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/plugin-e2e/src/fixtures/selectors.test.ts
+++ b/packages/plugin-e2e/src/fixtures/selectors.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // identity resolveSelectors so we can assert which tree flowed through; tagged bundled data so we
 // can tell the bundled dependency apart from the fetched, reconstructed data
@@ -42,6 +42,23 @@ describe('selectors fixture', () => {
 
   beforeEach(() => {
     warnSpy.mockClear();
+    // enable the runtime path for these tests; the default (toggle off) is covered separately below
+    process.env.PLUGIN_E2E_RUNTIME_SELECTORS = 'true';
+  });
+
+  afterEach(() => {
+    delete process.env.PLUGIN_E2E_RUNTIME_SELECTORS;
+  });
+
+  it('uses the bundled selectors without fetching when the runtime toggle is off', async () => {
+    delete process.env.PLUGIN_E2E_RUNTIME_SELECTORS;
+    const get = vi.fn();
+
+    const result = await runFixture({ grafanaVersion: '11.0.0-off', request: mockRequest(get) });
+
+    expect(get).not.toHaveBeenCalled();
+    expect(result.components).toEqual({ __source: 'dep-components' });
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('uses the runtime selectors served by Grafana when present', async () => {

--- a/packages/plugin-e2e/src/fixtures/selectors.test.ts
+++ b/packages/plugin-e2e/src/fixtures/selectors.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// identity resolveSelectors so we can assert which tree flowed through; tagged bundled data so we
+// can tell the bundled dependency apart from the fetched, reconstructed data
+vi.mock('@grafana/e2e-selectors', () => ({
+  resolveSelectors: vi.fn((versioned: unknown) => versioned),
+  versionedComponents: { __source: 'dep-components' },
+  versionedPages: { __source: 'dep-pages' },
+}));
+vi.mock('../selectors/versionedConstants', () => ({ versionedConstants: { __source: 'local-constants' } }));
+vi.mock('../selectors/versionedAPIs', () => ({ versionedAPIs: { __source: 'local-apis' } }));
+
+import { selectors } from './selectors';
+
+const VALID_BODY = JSON.stringify({
+  schemaVersion: 1,
+  versionedComponents: { __source: 'fetched-components' },
+  versionedPages: { __source: 'fetched-pages' },
+});
+
+function mockResponse({ status = 200, body = '' }: { status?: number; body?: string }) {
+  return { status: () => status, ok: () => status >= 200 && status < 300, text: async () => body };
+}
+
+function mockRequest(get: ReturnType<typeof vi.fn>) {
+  return { get } as never;
+}
+
+async function runFixture(args: { grafanaVersion: string; request: never }) {
+  let captured: Record<string, unknown> | undefined;
+  await (selectors as unknown as (a: unknown, use: (value: Record<string, unknown>) => Promise<void>) => Promise<void>)(
+    args,
+    async (value) => {
+      captured = value;
+    }
+  );
+  return captured!;
+}
+
+describe('selectors fixture', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  beforeEach(() => {
+    warnSpy.mockClear();
+  });
+
+  it('uses the runtime selectors served by Grafana when present', async () => {
+    const get = vi.fn().mockResolvedValue(mockResponse({ status: 200, body: VALID_BODY }));
+
+    const result = await runFixture({ grafanaVersion: '11.0.0-200', request: mockRequest(get) });
+
+    expect(get).toHaveBeenCalledWith('/public/e2e-selectors.json', { maxRedirects: 0 });
+    expect(result.components).toEqual({ __source: 'fetched-components' });
+    expect(result.pages).toEqual({ __source: 'fetched-pages' });
+    expect(result.apis).toEqual({ __source: 'local-apis' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the bundled dependency quietly when Grafana does not serve the file (404)', async () => {
+    const get = vi.fn().mockResolvedValue(mockResponse({ status: 404 }));
+
+    const result = await runFixture({ grafanaVersion: '11.0.0-404', request: mockRequest(get) });
+
+    expect(result.components).toEqual({ __source: 'dep-components' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back with a warning on a server error', async () => {
+    const get = vi.fn().mockResolvedValue(mockResponse({ status: 503 }));
+
+    const result = await runFixture({ grafanaVersion: '11.0.0-503', request: mockRequest(get) });
+
+    expect(result.components).toEqual({ __source: 'dep-components' });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('falls back with a warning on a network error', async () => {
+    const get = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await runFixture({ grafanaVersion: '11.0.0-net', request: mockRequest(get) });
+
+    expect(result.components).toEqual({ __source: 'dep-components' });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('falls back with a warning on invalid JSON', async () => {
+    const get = vi.fn().mockResolvedValue(mockResponse({ status: 200, body: 'not json' }));
+
+    const result = await runFixture({ grafanaVersion: '11.0.0-badjson', request: mockRequest(get) });
+
+    expect(result.components).toEqual({ __source: 'dep-components' });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('falls back with a warning on an unexpected schema', async () => {
+    const body = JSON.stringify({ schemaVersion: 2, versionedComponents: {}, versionedPages: {} });
+    const get = vi.fn().mockResolvedValue(mockResponse({ status: 200, body }));
+
+    const result = await runFixture({ grafanaVersion: '11.0.0-badschema', request: mockRequest(get) });
+
+    expect(result.components).toEqual({ __source: 'dep-components' });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('shares a single fetch across concurrent fixtures for the same version', async () => {
+    const get = vi.fn().mockResolvedValue(mockResponse({ status: 200, body: VALID_BODY }));
+    const request = mockRequest(get);
+
+    const [a, b] = await Promise.all([
+      runFixture({ grafanaVersion: '11.0.0-cache', request }),
+      runFixture({ grafanaVersion: '11.0.0-cache', request }),
+    ]);
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(a.components).toEqual({ __source: 'fetched-components' });
+    expect(b.components).toEqual({ __source: 'fetched-components' });
+  });
+});

--- a/packages/plugin-e2e/src/fixtures/selectors.ts
+++ b/packages/plugin-e2e/src/fixtures/selectors.ts
@@ -1,16 +1,95 @@
-import { TestFixture } from '@playwright/test';
+import { APIRequestContext, TestFixture } from '@playwright/test';
+import {
+  resolveSelectors,
+  versionedComponents as bundledVersionedComponents,
+  versionedPages as bundledVersionedPages,
+} from '@grafana/e2e-selectors';
 import { E2ESelectorGroups, PlaywrightArgs } from '../types';
-import { resolveSelectors, versionedComponents, versionedPages } from '@grafana/e2e-selectors';
 import { versionedConstants } from '../selectors/versionedConstants';
 import { versionedAPIs } from '../selectors/versionedAPIs';
+import { reconstructSelectorTree } from '../selectors/reconstruct';
 
 type SelectorFixture = TestFixture<E2ESelectorGroups, PlaywrightArgs>;
 
-export const selectors: SelectorFixture = async ({ grafanaVersion }, use) => {
-  await use({
-    components: resolveSelectors(versionedComponents, grafanaVersion),
-    pages: resolveSelectors(versionedPages, grafanaVersion),
+type VersionedComponents = typeof bundledVersionedComponents;
+type VersionedPages = typeof bundledVersionedPages;
+
+// data-only selectors file served by the Grafana instance under test (see grafana/grafana
+// e2e-selectors build). Used when the instance serves it; otherwise the fixture falls back to the
+// selectors bundled with the installed release.
+const SELECTORS_URL = '/public/e2e-selectors.json';
+
+// per-worker cache keyed by grafanaVersion so concurrent fixtures share one in-flight fetch
+const selectorsCache = new Map<string, Promise<E2ESelectorGroups>>();
+
+function buildGroups(
+  components: VersionedComponents,
+  pages: VersionedPages,
+  grafanaVersion: string
+): E2ESelectorGroups {
+  return {
+    components: resolveSelectors(components, grafanaVersion),
+    pages: resolveSelectors(pages, grafanaVersion),
     constants: resolveSelectors(versionedConstants, grafanaVersion),
     apis: resolveSelectors(versionedAPIs, grafanaVersion),
-  });
+  };
+}
+
+// fall back to the selectors bundled with the installed @grafana/plugin-e2e release
+function bundledGroups(grafanaVersion: string): E2ESelectorGroups {
+  return buildGroups(bundledVersionedComponents, bundledVersionedPages, grafanaVersion);
+}
+
+async function fetchRuntimeGroups(request: APIRequestContext, grafanaVersion: string): Promise<E2ESelectorGroups> {
+  let response;
+  try {
+    response = await request.get(SELECTORS_URL, { maxRedirects: 0 });
+  } catch (error) {
+    console.warn(`@grafana/plugin-e2e: failed to fetch ${SELECTORS_URL}, falling back to bundled selectors.`, error);
+    return bundledGroups(grafanaVersion);
+  }
+
+  // 404 -> Grafana predates the feature; expected on older images, fall back quietly
+  if (response.status() === 404) {
+    return bundledGroups(grafanaVersion);
+  }
+
+  if (!response.ok()) {
+    console.warn(
+      `@grafana/plugin-e2e: ${SELECTORS_URL} returned ${response.status()}, falling back to bundled selectors.`
+    );
+    return bundledGroups(grafanaVersion);
+  }
+
+  try {
+    const data = JSON.parse(await response.text()) as {
+      schemaVersion?: unknown;
+      versionedComponents?: unknown;
+      versionedPages?: unknown;
+    };
+    if (
+      data?.schemaVersion !== 1 ||
+      typeof data.versionedComponents !== 'object' ||
+      typeof data.versionedPages !== 'object'
+    ) {
+      throw new Error('unexpected e2e-selectors schema');
+    }
+    const components = reconstructSelectorTree(data.versionedComponents) as VersionedComponents;
+    const pages = reconstructSelectorTree(data.versionedPages) as VersionedPages;
+    return buildGroups(components, pages, grafanaVersion);
+  } catch (error) {
+    console.warn(`@grafana/plugin-e2e: failed to read ${SELECTORS_URL}, falling back to bundled selectors.`, error);
+    return bundledGroups(grafanaVersion);
+  }
+}
+
+export const selectors: SelectorFixture = async ({ grafanaVersion, request }, use) => {
+  // use the runtime selectors served by the Grafana under test when available, otherwise fall back
+  // to the selectors bundled with the installed release
+  let groups = selectorsCache.get(grafanaVersion);
+  if (!groups) {
+    groups = fetchRuntimeGroups(request, grafanaVersion);
+    selectorsCache.set(grafanaVersion, groups);
+  }
+  await use(await groups);
 };

--- a/packages/plugin-e2e/src/fixtures/selectors.ts
+++ b/packages/plugin-e2e/src/fixtures/selectors.ts
@@ -22,6 +22,13 @@ const SELECTORS_URL = '/public/e2e-selectors.json';
 // per-worker cache keyed by grafanaVersion so concurrent fixtures share one in-flight fetch
 const selectorsCache = new Map<string, Promise<E2ESelectorGroups>>();
 
+// opt-in toggle while the runtime path is validated in plugin-tools' own Playwright workflows. when
+// unset, the fixture uses the bundled selectors as before. remove once runtime selectors ship to all
+// consumers.
+function runtimeSelectorsEnabled(): boolean {
+  return process.env.PLUGIN_E2E_RUNTIME_SELECTORS === 'true';
+}
+
 function buildGroups(
   components: VersionedComponents,
   pages: VersionedPages,
@@ -84,6 +91,13 @@ async function fetchRuntimeGroups(request: APIRequestContext, grafanaVersion: st
 }
 
 export const selectors: SelectorFixture = async ({ grafanaVersion, request }, use) => {
+  // until the runtime path is rolled out, only fetch when explicitly enabled; otherwise use the
+  // selectors bundled with the installed release
+  if (!runtimeSelectorsEnabled()) {
+    await use(bundledGroups(grafanaVersion));
+    return;
+  }
+
   // use the runtime selectors served by the Grafana under test when available, otherwise fall back
   // to the selectors bundled with the installed release
   let groups = selectorsCache.get(grafanaVersion);

--- a/packages/plugin-e2e/src/fixtures/selectors.ts
+++ b/packages/plugin-e2e/src/fixtures/selectors.ts
@@ -14,11 +14,6 @@ type SelectorFixture = TestFixture<E2ESelectorGroups, PlaywrightArgs>;
 type VersionedComponents = typeof bundledVersionedComponents;
 type VersionedPages = typeof bundledVersionedPages;
 
-// data-only selectors file served by the Grafana instance under test (see grafana/grafana
-// e2e-selectors build). Used when the instance serves it; otherwise the fixture falls back to the
-// selectors bundled with the installed release.
-const SELECTORS_URL = '/public/e2e-selectors.json';
-
 // per-worker cache keyed by grafanaVersion so concurrent fixtures share one in-flight fetch
 const selectorsCache = new Map<string, Promise<E2ESelectorGroups>>();
 
@@ -47,12 +42,21 @@ function bundledGroups(grafanaVersion: string): E2ESelectorGroups {
   return buildGroups(bundledVersionedComponents, bundledVersionedPages, grafanaVersion);
 }
 
-async function fetchRuntimeGroups(request: APIRequestContext, grafanaVersion: string): Promise<E2ESelectorGroups> {
+async function fetchRuntimeGroups(
+  request: APIRequestContext,
+  selectorsUrl: string | undefined,
+  grafanaVersion: string
+): Promise<E2ESelectorGroups> {
+  // couldn't derive where the instance serves the file (older Grafana, or assets missing) -> bundled
+  if (!selectorsUrl) {
+    return bundledGroups(grafanaVersion);
+  }
+
   let response;
   try {
-    response = await request.get(SELECTORS_URL, { maxRedirects: 0 });
+    response = await request.get(selectorsUrl, { maxRedirects: 0 });
   } catch (error) {
-    console.warn(`@grafana/plugin-e2e: failed to fetch ${SELECTORS_URL}, falling back to bundled selectors.`, error);
+    console.warn(`@grafana/plugin-e2e: failed to fetch ${selectorsUrl}, falling back to bundled selectors.`, error);
     return bundledGroups(grafanaVersion);
   }
 
@@ -63,7 +67,7 @@ async function fetchRuntimeGroups(request: APIRequestContext, grafanaVersion: st
 
   if (!response.ok()) {
     console.warn(
-      `@grafana/plugin-e2e: ${SELECTORS_URL} returned ${response.status()}, falling back to bundled selectors.`
+      `@grafana/plugin-e2e: ${selectorsUrl} returned ${response.status()}, falling back to bundled selectors.`
     );
     return bundledGroups(grafanaVersion);
   }
@@ -85,12 +89,12 @@ async function fetchRuntimeGroups(request: APIRequestContext, grafanaVersion: st
     const pages = reconstructSelectorTree(data.versionedPages) as VersionedPages;
     return buildGroups(components, pages, grafanaVersion);
   } catch (error) {
-    console.warn(`@grafana/plugin-e2e: failed to read ${SELECTORS_URL}, falling back to bundled selectors.`, error);
+    console.warn(`@grafana/plugin-e2e: failed to read ${selectorsUrl}, falling back to bundled selectors.`, error);
     return bundledGroups(grafanaVersion);
   }
 }
 
-export const selectors: SelectorFixture = async ({ grafanaVersion, request }, use) => {
+export const selectors: SelectorFixture = async ({ grafanaVersion, bootData, request }, use) => {
   // until the runtime path is rolled out, only fetch when explicitly enabled; otherwise use the
   // selectors bundled with the installed release
   if (!runtimeSelectorsEnabled()) {
@@ -102,7 +106,7 @@ export const selectors: SelectorFixture = async ({ grafanaVersion, request }, us
   // to the selectors bundled with the installed release
   let groups = selectorsCache.get(grafanaVersion);
   if (!groups) {
-    groups = fetchRuntimeGroups(request, grafanaVersion);
+    groups = fetchRuntimeGroups(request, bootData.selectorsUrl, grafanaVersion);
     selectorsCache.set(grafanaVersion, groups);
   }
   await use(await groups);

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -163,6 +163,12 @@ declare global {
         };
         namespace: string;
       };
+      // asset base for the frontend build. jsFiles paths are CDN-absolute in multi-tenant and
+      // origin-relative in single-binary, which is what lets us locate sibling build assets.
+      assets?: {
+        cdn?: string;
+        jsFiles?: Array<{ filePath?: string }>;
+      };
     };
   }
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/plugin-e2e/src/index.ts
+++ b/packages/plugin-e2e/src/index.ts
@@ -166,7 +166,6 @@ declare global {
       // asset base for the frontend build. jsFiles paths are CDN-absolute in multi-tenant and
       // origin-relative in single-binary, which is what lets us locate sibling build assets.
       assets?: {
-        cdn?: string;
         jsFiles?: Array<{ filePath?: string }>;
       };
     };

--- a/packages/plugin-e2e/src/selectors/reconstruct.test.ts
+++ b/packages/plugin-e2e/src/selectors/reconstruct.test.ts
@@ -10,7 +10,7 @@ describe('reconstructSelectorTree', () => {
 
   it('reconstructs a one-arg descriptor into an interpolating function', () => {
     const tree = reconstructSelectorTree({
-      Comp: { sel: { '8.0.0': { $template: 'data-testid option {0}', params: ['value'] } } },
+      Comp: { sel: { '8.0.0': { $template: 'data-testid option {value}', params: ['value'] } } },
     }) as any;
     const fn = tree.Comp.sel['8.0.0'];
     expect(typeof fn).toBe('function');
@@ -19,7 +19,7 @@ describe('reconstructSelectorTree', () => {
 
   it('reconstructs a two-arg descriptor', () => {
     const tree = reconstructSelectorTree({
-      s: { '8.0.0': { $template: 'range {0} to {1}', params: ['from', 'to'] } },
+      s: { '8.0.0': { $template: 'range {from} to {to}', params: ['from', 'to'] } },
     }) as any;
     expect(tree.s['8.0.0']('a', 'b')).toBe('range a to b');
   });
@@ -31,7 +31,12 @@ describe('reconstructSelectorTree', () => {
 
   it('reconstructs a conditional (present/absent) descriptor', () => {
     const tree = reconstructSelectorTree({
-      s: { '11.1.0': { $template: { whenPresent: 'Options group {0}', whenAbsent: 'Options group' }, params: ['title'] } },
+      s: {
+        '11.1.0': {
+          $template: { whenPresent: 'Options group {title}', whenAbsent: 'Options group' },
+          params: ['title'],
+        },
+      },
     }) as any;
     const fn = tree.s['11.1.0'];
     expect(fn('X')).toBe('Options group X');

--- a/packages/plugin-e2e/src/selectors/reconstruct.test.ts
+++ b/packages/plugin-e2e/src/selectors/reconstruct.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+import { reconstructSelectorTree } from './reconstruct';
+
+describe('reconstructSelectorTree', () => {
+  it('keeps string selectors unchanged', () => {
+    const tree = reconstructSelectorTree({ Comp: { sel: { '8.0.0': 'plain string' } } });
+    expect(tree).toEqual({ Comp: { sel: { '8.0.0': 'plain string' } } });
+  });
+
+  it('reconstructs a one-arg descriptor into an interpolating function', () => {
+    const tree = reconstructSelectorTree({
+      Comp: { sel: { '8.0.0': { $template: 'data-testid option {0}', params: ['value'] } } },
+    }) as any;
+    const fn = tree.Comp.sel['8.0.0'];
+    expect(typeof fn).toBe('function');
+    expect(fn('X')).toBe('data-testid option X');
+  });
+
+  it('reconstructs a two-arg descriptor', () => {
+    const tree = reconstructSelectorTree({
+      s: { '8.0.0': { $template: 'range {0} to {1}', params: ['from', 'to'] } },
+    }) as any;
+    expect(tree.s['8.0.0']('a', 'b')).toBe('range a to b');
+  });
+
+  it('reconstructs a zero-arg (css) descriptor', () => {
+    const tree = reconstructSelectorTree({ s: { '8.0.0': { $template: '.some-class', params: [] } } }) as any;
+    expect(tree.s['8.0.0']()).toBe('.some-class');
+  });
+
+  it('reconstructs a conditional (present/absent) descriptor', () => {
+    const tree = reconstructSelectorTree({
+      s: { '11.1.0': { $template: { whenPresent: 'Options group {0}', whenAbsent: 'Options group' }, params: ['title'] } },
+    }) as any;
+    const fn = tree.s['11.1.0'];
+    expect(fn('X')).toBe('Options group X');
+    expect(fn('')).toBe('Options group');
+  });
+
+  it('throws on a malformed descriptor', () => {
+    expect(() => reconstructSelectorTree({ s: { '8.0.0': { $template: 42, params: [] } } })).toThrow();
+  });
+});

--- a/packages/plugin-e2e/src/selectors/reconstruct.ts
+++ b/packages/plugin-e2e/src/selectors/reconstruct.ts
@@ -1,0 +1,49 @@
+import { VersionedSelectorGroup } from '@grafana/e2e-selectors';
+
+// Reconstructs the data-only selector tree served by Grafana (see grafana/grafana e2e-selectors
+// build) back into a versioned selector tree with functions, so it can be passed to resolveSelectors.
+// Function selectors are serialized as template descriptors; here they become fixed local functions
+// that only substitute positional {0}, {1} placeholders - no code from the fetched file is executed.
+
+type ConditionalTemplate = { whenPresent: string; whenAbsent: string };
+type TemplateDescriptor = { $template: string | ConditionalTemplate; params?: string[] };
+
+function isDescriptor(node: object): node is TemplateDescriptor {
+  return '$template' in node;
+}
+
+function fill(template: string, args: string[]): string {
+  return template.replace(/\{(\d+)\}/g, (_, index) => args[Number(index)] ?? '');
+}
+
+function reconstructDescriptor(descriptor: TemplateDescriptor): (...args: string[]) => string {
+  const template = descriptor.$template;
+  if (typeof template === 'string') {
+    return (...args: string[]) => fill(template, args);
+  }
+  if (template && typeof template === 'object' && typeof template.whenPresent === 'string' && typeof template.whenAbsent === 'string') {
+    return (...args: string[]) => (args[0] ? fill(template.whenPresent, args) : template.whenAbsent);
+  }
+  throw new Error('@grafana/plugin-e2e: malformed e2e-selectors template descriptor');
+}
+
+function reconstructNode(node: unknown): unknown {
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (!node || typeof node !== 'object') {
+    throw new Error('@grafana/plugin-e2e: unexpected e2e-selectors node');
+  }
+  if (isDescriptor(node)) {
+    return reconstructDescriptor(node);
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    result[key] = reconstructNode(value);
+  }
+  return result;
+}
+
+export function reconstructSelectorTree(data: unknown): VersionedSelectorGroup {
+  return reconstructNode(data) as VersionedSelectorGroup;
+}

--- a/packages/plugin-e2e/src/selectors/reconstruct.ts
+++ b/packages/plugin-e2e/src/selectors/reconstruct.ts
@@ -3,7 +3,7 @@ import { VersionedSelectorGroup } from '@grafana/e2e-selectors';
 // Reconstructs the data-only selector tree served by Grafana (see grafana/grafana e2e-selectors
 // build) back into a versioned selector tree with functions, so it can be passed to resolveSelectors.
 // Function selectors are serialized as template descriptors; here they become fixed local functions
-// that only substitute positional {0}, {1} placeholders - no code from the fetched file is executed.
+// that only substitute named {param} placeholders - no code from the fetched file is executed.
 
 type ConditionalTemplate = { whenPresent: string; whenAbsent: string };
 type TemplateDescriptor = { $template: string | ConditionalTemplate; params?: string[] };
@@ -12,17 +12,25 @@ function isDescriptor(node: object): node is TemplateDescriptor {
   return '$template' in node;
 }
 
-function fill(template: string, args: string[]): string {
-  return template.replace(/\{(\d+)\}/g, (_, index) => args[Number(index)] ?? '');
+// substitutes each named {param} placeholder with the positional call arg at the same index. braced
+// tokens are unique per name, so `{id}` never partially matches `{idx}` and replacement order is safe.
+function fill(template: string, params: string[], args: string[]): string {
+  return params.reduce((acc, name, index) => acc.split(`{${name}}`).join(args[index] ?? ''), template);
 }
 
 function reconstructDescriptor(descriptor: TemplateDescriptor): (...args: string[]) => string {
   const template = descriptor.$template;
+  const params = descriptor.params ?? [];
   if (typeof template === 'string') {
-    return (...args: string[]) => fill(template, args);
+    return (...args: string[]) => fill(template, params, args);
   }
-  if (template && typeof template === 'object' && typeof template.whenPresent === 'string' && typeof template.whenAbsent === 'string') {
-    return (...args: string[]) => (args[0] ? fill(template.whenPresent, args) : template.whenAbsent);
+  if (
+    template &&
+    typeof template === 'object' &&
+    typeof template.whenPresent === 'string' &&
+    typeof template.whenAbsent === 'string'
+  ) {
+    return (...args: string[]) => (args[0] ? fill(template.whenPresent, params, args) : template.whenAbsent);
   }
   throw new Error('@grafana/plugin-e2e: malformed e2e-selectors template descriptor');
 }

--- a/packages/plugin-e2e/src/types.ts
+++ b/packages/plugin-e2e/src/types.ts
@@ -493,6 +493,7 @@ export type InternalFixtures = {
   bootData: {
     version: string | undefined;
     namespace: string | undefined;
+    selectorsUrl: string | undefined;
   };
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a runtime path to the `selectors` fixture: it derives the e2e-selectors file URL from the frontend asset path in bootData (so it resolves to the origin in single-binary and the CDN in multi-tenant), fetches the data-only JSON from the Grafana under test, and reconstructs the template descriptors into selectors locally (no eval), falling back to the bundled `@grafana/e2e-selectors` when the file isn't served. This keeps selectors in sync with the Grafana under test without the nightly npm dist-tag.

While we validate the approach, the runtime path is behind a `PLUGIN_E2E_RUNTIME_SELECTORS` toggle. It defaults to off, so consumers keep using the bundled selectors, and it's enabled only in this repo's Playwright workflows so we can dogfood it before making it the default.

Pairs with [the grafana/grafana side](https://github.com/grafana/grafana/pull/127312) that emits the file as a build asset.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Reconstruction only substitutes named {param} placeholders, it never executes fetched content. Unit tests cover `reconstruct` and the fixture (toggle off uses bundled with no fetch, quiet 404 fallback, loud fallback on failures, per-version cache).
