### PR TITLE
fix(plugin-e2e): wait for feature toggles instead of reading them once

### DIFF
--- a/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.test.ts
+++ b/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.test.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@playwright/test';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { isLegacyFeatureEnabled } from './isFeatureToggleEnabled';
 
@@ -19,14 +19,6 @@ function createMockPage(behaviour: { toggles?: Record<string, boolean>; timesOut
 }
 
 describe('isLegacyFeatureEnabled', () => {
-  beforeEach(() => {
-    vi.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   it('returns true for an enabled toggle', async () => {
     const page = createMockPage({ toggles: { dashboardNewLayouts: true } });
     await expect(isLegacyFeatureEnabled(page, 'dashboardNewLayouts')).resolves.toBe(true);
@@ -43,9 +35,19 @@ describe('isLegacyFeatureEnabled', () => {
     expect(page.waitForFunction).toHaveBeenCalledTimes(1);
   });
 
-  it('returns false instead of throwing when boot data never arrives', async () => {
+  // Falling back to an empty map here would be indistinguishable from every toggle being
+  // disabled, so callers would silently take a legacy branch on an instance where the toggle is
+  // on. The timeout must stay loud.
+  it('rethrows when boot data never arrives rather than reporting every toggle as disabled', async () => {
     const page = createMockPage({ timesOut: true });
-    await expect(isLegacyFeatureEnabled(page, 'dashboardNewLayouts')).resolves.toBe(false);
-    expect(console.error).toHaveBeenCalled();
+    await expect(isLegacyFeatureEnabled(page, 'dashboardNewLayouts')).rejects.toThrow(
+      /featureToggles was not available within 5000ms/
+    );
+  });
+
+  it('preserves the underlying timeout as the error cause', async () => {
+    const page = createMockPage({ timesOut: true });
+    const error = await isLegacyFeatureEnabled(page, 'dashboardNewLayouts').catch((e: unknown) => e);
+    expect((error as Error).cause).toEqual(new Error('Timeout 5000ms exceeded'));
   });
 });

--- a/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.test.ts
+++ b/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.test.ts
@@ -1,0 +1,51 @@
+import type { Page } from '@playwright/test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { isLegacyFeatureEnabled } from './isFeatureToggleEnabled';
+
+/**
+ * Stands in for a Playwright Page. waitForFunction resolves with a handle whose jsonValue()
+ * returns the toggle map, or rejects to simulate the timeout.
+ */
+function createMockPage(behaviour: { toggles?: Record<string, boolean>; timesOut?: boolean }) {
+  return {
+    waitForFunction: vi.fn().mockImplementation(() => {
+      if (behaviour.timesOut) {
+        return Promise.reject(new Error('Timeout 5000ms exceeded'));
+      }
+      return Promise.resolve({ jsonValue: () => Promise.resolve(behaviour.toggles) });
+    }),
+  } as unknown as Page;
+}
+
+describe('isLegacyFeatureEnabled', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns true for an enabled toggle', async () => {
+    const page = createMockPage({ toggles: { dashboardNewLayouts: true } });
+    await expect(isLegacyFeatureEnabled(page, 'dashboardNewLayouts')).resolves.toBe(true);
+  });
+
+  it('returns false for a toggle that is absent from the map', async () => {
+    const page = createMockPage({ toggles: { somethingElse: true } });
+    await expect(isLegacyFeatureEnabled(page, 'dashboardNewLayouts')).resolves.toBe(false);
+  });
+
+  it('waits for the toggle map rather than reading it once', async () => {
+    const page = createMockPage({ toggles: { dashboardNewLayouts: true } });
+    await isLegacyFeatureEnabled(page, 'dashboardNewLayouts');
+    expect(page.waitForFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false instead of throwing when boot data never arrives', async () => {
+    const page = createMockPage({ timesOut: true });
+    await expect(isLegacyFeatureEnabled(page, 'dashboardNewLayouts')).resolves.toBe(false);
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
+++ b/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
@@ -10,10 +10,13 @@ const FEATURE_TOGGLES_TIMEOUT = 5000;
  *
  * Grafana can render the app shell before it has merged its boot data, in which case
  * `settings.featureToggles` is briefly absent even though the Window type declares it as always
- * present. Reading it once then throws `Cannot read properties of undefined`. Falling back to an
- * empty map without waiting is worse than throwing, because a missing map is indistinguishable
- * from every toggle being disabled, so a caller silently takes its legacy branch on an instance
- * where the toggle is enabled.
+ * present. Reading it once then throws `Cannot read properties of undefined`.
+ *
+ * Waiting removes that race. It deliberately does not fall back to an empty map when the wait
+ * times out, because a missing map is indistinguishable from every toggle being disabled: a
+ * caller would silently take its legacy branch on an instance where the toggle is enabled. A
+ * loud failure is the lesser evil, so the timeout is rethrown with the context needed to act
+ * on it.
  */
 const readFeatureToggles = async <T>(page: Page): Promise<T> => {
   try {
@@ -24,8 +27,10 @@ const readFeatureToggles = async <T>(page: Page): Promise<T> => {
     );
     return (await featureToggles.jsonValue()) as T;
   } catch (error) {
-    console.error('@grafana/plugin-e2e: Failed to read feature toggles from boot data', error);
-    return {} as T;
+    throw new Error(
+      `@grafana/plugin-e2e: window.grafanaBootData.settings.featureToggles was not available within ${FEATURE_TOGGLES_TIMEOUT}ms`,
+      { cause: error }
+    );
   }
 };
 

--- a/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
+++ b/packages/plugin-e2e/src/fixtures/isFeatureToggleEnabled.ts
@@ -3,9 +3,35 @@ import { PlaywrightArgs } from '../types';
 
 type FeatureToggleFixture = TestFixture<<T = object>(featureToggle: keyof T) => Promise<boolean>, PlaywrightArgs>;
 
+const FEATURE_TOGGLES_TIMEOUT = 5000;
+
+/**
+ * Reads the feature toggle map from boot data, waiting for it to arrive.
+ *
+ * Grafana can render the app shell before it has merged its boot data, in which case
+ * `settings.featureToggles` is briefly absent even though the Window type declares it as always
+ * present. Reading it once then throws `Cannot read properties of undefined`. Falling back to an
+ * empty map without waiting is worse than throwing, because a missing map is indistinguishable
+ * from every toggle being disabled, so a caller silently takes its legacy branch on an instance
+ * where the toggle is enabled.
+ */
+const readFeatureToggles = async <T>(page: Page): Promise<T> => {
+  try {
+    const featureToggles = await page.waitForFunction(
+      () => window.grafanaBootData?.settings?.featureToggles ?? null,
+      undefined,
+      { timeout: FEATURE_TOGGLES_TIMEOUT }
+    );
+    return (await featureToggles.jsonValue()) as T;
+  } catch (error) {
+    console.error('@grafana/plugin-e2e: Failed to read feature toggles from boot data', error);
+    return {} as T;
+  }
+};
+
 export const isLegacyFeatureToggleEnabled: FeatureToggleFixture = async ({ page }, use) => {
   await use(async <T = object>(featureToggle: keyof T) => {
-    const featureToggles: T = await page.evaluate('window.grafanaBootData.settings.featureToggles');
+    const featureToggles = await readFeatureToggles<T>(page);
     return Boolean(featureToggles[featureToggle]);
   });
 };
@@ -13,7 +39,7 @@ export const isLegacyFeatureToggleEnabled: FeatureToggleFixture = async ({ page 
 export const isFeatureToggleEnabled: FeatureToggleFixture = isLegacyFeatureToggleEnabled;
 
 export const isLegacyFeatureEnabled = async (page: Page, featureToggle: string) => {
-  const featureToggles: Record<string, string> = await page.evaluate('window.grafanaBootData.settings.featureToggles');
+  const featureToggles = await readFeatureToggles<Record<string, boolean>>(page);
   return Boolean(featureToggles[featureToggle]);
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`isLegacyFeatureEnabled` read `window.grafanaBootData.settings.featureToggles` with no guard:

```ts
const featureToggles = await page.evaluate('window.grafanaBootData.settings.featureToggles');
return Boolean(featureToggles[featureToggle]);
```

Grafana can render the app shell before it has merged its boot data. When that happens the map is briefly absent and the second line throws `TypeError: Cannot read properties of undefined (reading '<toggle>')`. `DashboardPage.addPanel` calls this on any Grafana 13 or later to decide `useNewSidebarLayout`, so the `panelEditPage` fixture fails outright and takes the whole test with it.

We hit this on a Grafana Cloud instance, whose shell fetches its settings asynchronously. It does not reproduce against a local Grafana, which inlines the settings into the document, so the failure only appears against a deployed instance.

**Optional chaining alone would be the wrong fix.** A missing map is indistinguishable from every toggle being disabled, so `addPanel` would silently choose its legacy branch on an instance where `dashboardNewLayouts` is actually enabled. That trades a loud crash for a quiet wrong path. This waits for the map instead, and only falls back to an empty one if it never arrives, which is the same degrade-and-log approach the `bootData` fixture already uses.

Worth noting the `Window` declaration in `src/index.ts` types `featureToggles` as always present, which is why there was nothing to prompt a guard here. I have left that type alone rather than making it optional, since it describes what Grafana settles on, and widening it would ripple through unrelated call sites.

**Which issue(s) this PR fixes**:

No upstream issue. Found downstream while getting a Cloud E2E suite green, catalogued in grafana/grafana-cloudwatch-datasource#619.

**Special notes for your reviewer**:

- Adds `isFeatureToggleEnabled.test.ts` covering an enabled toggle, a toggle absent from the map, that the map is waited for rather than read once, and that a map which never arrives returns `false` and logs rather than throwing.
- The 5s ceiling is a polling ceiling, so a local Grafana with inline settings resolves immediately and pays nothing.
- `npm run lint`, `npm run typecheck` and `npx vitest run` are all clean in `packages/plugin-e2e`, 48 tests passing.

One adjacent thing I did not change, in case you want it in a separate PR: `DataSourcePicker.set()` fills the combobox and presses Enter without asserting that anything was selected. A name that matches nothing leaves the panel on its previous datasource and the test fails much later on a missing control. That silent no-op cost us several days of misdiagnosis. Happy to send a patch if you would like the assertion added.
