### PR TITLE
fix(plugin-docs-cli): skip repo-meta files during docs scanning and validation

### DIFF
--- a/packages/plugin-docs-cli/src/scanner.ts
+++ b/packages/plugin-docs-cli/src/scanner.ts
@@ -10,6 +10,7 @@ import {
   type MarkdownFiles,
   type Frontmatter,
 } from '@grafana/plugin-docs-parser';
+import { isMetaFile } from './validation/rules/utils.js';
 
 const debug = createDebug('plugin-docs-cli:scanner');
 
@@ -122,6 +123,9 @@ async function scanMarkdownFiles(docsPath: string): Promise<ScannedFile[]> {
       if (!entry.endsWith('.md')) {
         return false;
       }
+      if (isMetaFile(entry)) {
+        return false;
+      }
       return !entry.includes('node_modules') && !entry.includes('dist');
     })
     .map((entry) => join(docsPath, entry));
@@ -212,9 +216,15 @@ function treeToPages(node: TreeNode): Page[] {
 
   // convert children to array and sort by sidebar_position; root index.md always first
   const sortedEntries = childEntries.sort((a, b) => {
-    if (a[0] === 'index.md') { return -1; }
-    if (b[0] === 'index.md') { return 1; }
-    return (a[1].file?.frontmatter.sidebar_position ?? Infinity) - (b[1].file?.frontmatter.sidebar_position ?? Infinity);
+    if (a[0] === 'index.md') {
+      return -1;
+    }
+    if (b[0] === 'index.md') {
+      return 1;
+    }
+    return (
+      (a[1].file?.frontmatter.sidebar_position ?? Infinity) - (b[1].file?.frontmatter.sidebar_position ?? Infinity)
+    );
   });
 
   for (const [name, child] of sortedEntries) {

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -3,6 +3,7 @@ import type { Dirent } from 'node:fs';
 import { join, extname, dirname, relative, normalize } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 import { ALLOWED_IMAGE_EXTENSIONS } from './filesystem.js';
+import { isMetaFile } from './utils.js';
 
 const IMAGE_FILE_NAME_RE = /^[a-zA-Z0-9\-_.]+$/;
 const MAX_STATIC_SIZE = 300 * 1024; // 300KB
@@ -51,7 +52,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
   const allFiles = entries.filter((e) => e.isFile());
   const imageFiles = allFiles.filter((e) => ALLOWED_IMAGE_EXTENSIONS.has(extname(e.name).toLowerCase()));
   const svgFiles = allFiles.filter((e) => extname(e.name).toLowerCase() === '.svg');
-  const mdFiles = allFiles.filter((e) => e.name.endsWith('.md'));
+  const mdFiles = allFiles.filter((e) => e.name.endsWith('.md') && !isMetaFile(e.name));
 
   // helper to get path relative to docsPath
   function rel(entry: Dirent): string {

--- a/packages/plugin-docs-cli/src/validation/rules/cross-file.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/cross-file.ts
@@ -3,7 +3,7 @@ import type { Dirent } from 'node:fs';
 import { join, relative, dirname, normalize } from 'node:path';
 import GithubSlugger from 'github-slugger';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
-import { getCodeBlockLines } from './utils.js';
+import { getCodeBlockLines, isMetaFile } from './utils.js';
 
 // matches markdown links: [text](url)
 const LINK_RE = /\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
@@ -83,7 +83,7 @@ export async function checkCrossFile(input: ValidationInput): Promise<Diagnostic
   const allFiles = entries.filter(
     (e) => e.isFile() && !e.parentPath.includes('node_modules') && !e.parentPath.includes('dist')
   );
-  const mdFiles = allFiles.filter((e) => e.name.endsWith('.md'));
+  const mdFiles = allFiles.filter((e) => e.name.endsWith('.md') && !isMetaFile(e.name));
   const allFilePaths = new Set(allFiles.map((e) => relative(input.docsPath, join(e.parentPath, e.name))));
 
   // build a map of relative path -> heading IDs for each markdown file

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -2,6 +2,7 @@ import { readdir } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, extname, relative, sep } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+import { isMetaFile } from './utils.js';
 
 // slug-safe: lowercase letters, digits and hyphens only
 const SLUG_SAFE_RE = /^[a-z0-9-]+$/;
@@ -25,7 +26,9 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     // docsPath doesn't exist or isn't readable
   }
 
-  const mdFiles = entries.filter((e) => e.isFile() && extname(e.name).toLowerCase() === '.md');
+  // skip repo-meta files (README.md, CONTRIBUTING.md etc.) at the source so
+  // they don't trip naming, index or has-markdown rules. They aren't pages.
+  const mdFiles = entries.filter((e) => e.isFile() && extname(e.name).toLowerCase() === '.md' && !isMetaFile(e.name));
   const dirs = entries.filter((e) => e.isDirectory());
   const symlinks = entries.filter((e) => e.isSymbolicLink());
   const nonMdFiles = entries.filter((e) => e.isFile() && extname(e.name).toLowerCase() !== '.md');

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -3,6 +3,7 @@ import type { Dirent } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import matter from 'gray-matter';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+import { isMetaFile } from './utils.js';
 
 const REQUIRED_FIELDS: Array<{ key: string; type: string }> = [
   { key: 'title', type: 'string' },
@@ -94,7 +95,11 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
 
   const mdFiles = entries.filter(
     (e) =>
-      e.isFile() && e.name.endsWith('.md') && !e.parentPath.includes('node_modules') && !e.parentPath.includes('dist')
+      e.isFile() &&
+      e.name.endsWith('.md') &&
+      !isMetaFile(e.name) &&
+      !e.parentPath.includes('node_modules') &&
+      !e.parentPath.includes('dist')
   );
 
   const records: FileRecord[] = [];

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.ts
@@ -2,7 +2,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, relative } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
-import { getCodeBlockLines } from './utils.js';
+import { getCodeBlockLines, isMetaFile } from './utils.js';
 
 // matches HTML tags like <div>, <span class="x">, </p>, <br/>, <img src="..." />
 const HTML_TAG_RE = /< *\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*\/?>/g;
@@ -72,7 +72,11 @@ export async function checkMarkdown(input: ValidationInput): Promise<Diagnostic[
 
   const mdFiles = entries.filter(
     (e) =>
-      e.isFile() && e.name.endsWith('.md') && !e.parentPath.includes('node_modules') && !e.parentPath.includes('dist')
+      e.isFile() &&
+      e.name.endsWith('.md') &&
+      !isMetaFile(e.name) &&
+      !e.parentPath.includes('node_modules') &&
+      !e.parentPath.includes('dist')
   );
 
   for (const md of mdFiles) {

--- a/packages/plugin-docs-cli/src/validation/rules/utils.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isMetaFile } from './utils.js';
+
+describe('isMetaFile', () => {
+  it('matches README.md regardless of case', () => {
+    expect(isMetaFile('README.md')).toBe(true);
+    expect(isMetaFile('readme.md')).toBe(true);
+    expect(isMetaFile('Readme.md')).toBe(true);
+  });
+
+  it('matches other common repo-meta files', () => {
+    expect(isMetaFile('CONTRIBUTING.md')).toBe(true);
+    expect(isMetaFile('LICENSE.md')).toBe(true);
+    expect(isMetaFile('CODE_OF_CONDUCT.md')).toBe(true);
+    expect(isMetaFile('SECURITY.md')).toBe(true);
+    expect(isMetaFile('CHANGELOG.md')).toBe(true);
+  });
+
+  it('matches when given a path, not just a basename', () => {
+    expect(isMetaFile('docs/README.md')).toBe(true);
+    expect(isMetaFile('/abs/path/to/docs/README.md')).toBe(true);
+    expect(isMetaFile('docs\\README.md')).toBe(true);
+  });
+
+  it('does not match regular doc pages', () => {
+    expect(isMetaFile('index.md')).toBe(false);
+    expect(isMetaFile('query-editor.md')).toBe(false);
+    expect(isMetaFile('configuration.md')).toBe(false);
+    expect(isMetaFile('docs/index.md')).toBe(false);
+  });
+
+  it('does not match non-md files', () => {
+    expect(isMetaFile('README.txt')).toBe(false);
+    expect(isMetaFile('readme')).toBe(false);
+  });
+
+  it('does not match files that merely contain a meta basename in their path component', () => {
+    expect(isMetaFile('readme-tips.md')).toBe(false);
+    expect(isMetaFile('contributing-quickstart.md')).toBe(false);
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/utils.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.ts
@@ -1,4 +1,31 @@
 /**
+ * Repo-meta filenames that may live alongside docs pages but are never
+ * themselves published as pages. Scanner and validation rules skip them so
+ * plugin authors can keep a README, contributing guide etc. in the docs
+ * folder without tripping the frontmatter or filesystem rules.
+ *
+ * Match is case-insensitive on the basename.
+ */
+const META_FILE_BASENAMES_UPPER: ReadonlySet<string> = new Set([
+  'README.MD',
+  'CONTRIBUTING.MD',
+  'LICENSE.MD',
+  'CODE_OF_CONDUCT.MD',
+  'SECURITY.MD',
+  'CHANGELOG.MD',
+]);
+
+/**
+ * Returns true when the given path's basename is a known meta file that
+ * should be excluded from docs scanning and validation.
+ */
+export function isMetaFile(filenameOrPath: string): boolean {
+  const slash = Math.max(filenameOrPath.lastIndexOf('/'), filenameOrPath.lastIndexOf('\\'));
+  const base = slash === -1 ? filenameOrPath : filenameOrPath.slice(slash + 1);
+  return META_FILE_BASENAMES_UPPER.has(base.toUpperCase());
+}
+
+/**
  * Returns a set of 1-based line numbers inside fenced code blocks.
  */
 export function getCodeBlockLines(content: string): Set<number> {


### PR DESCRIPTION
**What this PR does / why we need it**:

The docs folder within the plugin source will include meta files such as the `README.md`. This PR adds an `isMetaFile()` helper and wires it into the scanner and every validation rule that walks `docs/*.md`, so meta files are skipped instead of failing frontmatter or filesystem checks.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
