### PR TITLE
fix(plugin-e2e): correct dashboard toolbar version thresholds

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,7 @@ jobs:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
           skip-grafana-dev-image: false
-          limit: 0 # TEMPORARY (do not merge): verifying the toolbar thresholds against every supported version.
+          # limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
 
   playwright-tests:
     needs: resolve-versions

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,7 @@ jobs:
           version-resolver-type: plugin-grafana-dependency
           grafana-dependency: '>=8.5.0'
           skip-grafana-dev-image: false
-          # limit: 0 # Uncomment to test all versions since 8.5.0. Useful when testing compatibility for new APIs.
+          limit: 0 # TEMPORARY (do not merge): verifying the toolbar thresholds against every supported version.
 
   playwright-tests:
     needs: resolve-versions

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.test.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DashboardPage } from './DashboardPage';
+import { PluginTestCtx } from '../../types';
+
+const NAV_TOOLBAR = 'data-testid Nav toolbar';
+const DASHBOARD_CONTROLS = 'data-testid dashboard controls';
+
+/**
+ * Returns the selector `toolbar` passes to `page.locator`, by standing in a locator factory that
+ * hands back the selector it was given.
+ */
+function resolveToolbarSelector(grafanaVersion: string): string {
+  const ctx = {
+    page: { locator: vi.fn((selector: string) => selector) },
+    grafanaVersion,
+    selectors: {
+      components: { NavToolbar: { container: NAV_TOOLBAR } },
+      pages: { Dashboard: { Controls: DASHBOARD_CONTROLS } },
+    },
+  } as unknown as PluginTestCtx;
+
+  return new DashboardPage(ctx).toolbar as unknown as string;
+}
+
+describe('DashboardPage.toolbar', () => {
+  // Each threshold is the version at which that toolbar became the default, not the version at
+  // which its selector first existed. Both toolbars shipped behind a feature toggle that stayed
+  // off by default for two more minor releases, so gating on first availability resolved to an
+  // element Grafana never renders, and a scoped locator then waited out the whole test timeout.
+  it.each([
+    ['8.5.27', '.page-toolbar'],
+    // topnav exists from 9.4.0 but is only default-on from 9.5.0
+    ['9.4.17', '.page-toolbar'],
+    ['9.5.0', `[data-testid="${NAV_TOOLBAR}"]`],
+    ['11.0.11', `[data-testid="${NAV_TOOLBAR}"]`],
+    // dashboardScene exists from 11.1.0 but is only default-on from 11.3.0
+    ['11.1.13', `[data-testid="${NAV_TOOLBAR}"]`],
+    ['11.2.10', `[data-testid="${NAV_TOOLBAR}"]`],
+    ['11.3.0', `[data-testid="${DASHBOARD_CONTROLS}"]`],
+    ['13.2.0', `[data-testid="${DASHBOARD_CONTROLS}"]`],
+  ])('resolves the toolbar on Grafana %s to %s', (grafanaVersion, expected) => {
+    expect(resolveToolbarSelector(grafanaVersion)).toBe(expected);
+  });
+});

--- a/packages/plugin-e2e/src/models/pages/DashboardPage.ts
+++ b/packages/plugin-e2e/src/models/pages/DashboardPage.ts
@@ -57,16 +57,26 @@ export class DashboardPage extends GrafanaPage {
   /**
    * Returns a locator for the dashboard toolbar area that contains the time range controls.
    *
-   * - Grafana ≥ 11.1.0: resolves to `Dashboard.Controls` (scenes-based dashboard controls bar)
-   * - Grafana 9.4.0–11.0.x: resolves to `NavToolbar.container`
-   * - Grafana < 9.4.0: falls back to `.page-toolbar`
+   * The thresholds are the versions at which each toolbar became the *default*, not the versions
+   * at which its selector first existed. Both toolbars shipped behind a feature toggle that was
+   * still off by default for two minor releases, so gating on first availability resolves to an
+   * element that Grafana never renders:
+   *
+   * - `dashboard controls` is declared from 11.1.0 but belongs to the scenes dashboard, and
+   *   `dashboardScene` is only default-on from 11.3.0.
+   * - `Nav toolbar` is declared from 9.4.0 but belongs to the top nav, and `topnav` is only
+   *   default-on from 9.5.0 — the same threshold `addPanel` already uses below.
+   *
+   * - Grafana ≥ 11.3.0: resolves to `Dashboard.Controls` (scenes-based dashboard controls bar)
+   * - Grafana 9.5.0–11.2.x: resolves to `NavToolbar.container`
+   * - Grafana < 9.5.0: falls back to `.page-toolbar`
    */
   get toolbar() {
     const { components, pages } = this.ctx.selectors;
-    if (gte(this.ctx.grafanaVersion, '11.1.0')) {
+    if (gte(this.ctx.grafanaVersion, '11.3.0')) {
       return this.getByGrafanaSelector(pages.Dashboard.Controls);
     }
-    return gte(this.ctx.grafanaVersion, '9.4.0')
+    return gte(this.ctx.grafanaVersion, '9.5.0')
       ? this.getByGrafanaSelector(components.NavToolbar.container)
       : this.ctx.page.locator('.page-toolbar');
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

`DashboardPage.toolbar` maps a Grafana version to the toolbar that holds the time range controls.
Each threshold was the version at which the selector first existed, per `@grafana/e2e-selectors`.
At each of those versions the element is still behind a default-off feature toggle, so the getter
returns a locator for an element Grafana never renders:

| Old threshold | Selector | Belongs to | Default-on from |
| --- | --- | --- | --- |
| 11.1.0 | `Dashboard.Controls` | scenes dashboard (`dashboardScene`) | 11.3.0 |
| 9.4.0 | `NavToolbar.container` | top nav (`topnav`) | 9.5.0 |

Anything scoping to `toolbar` then waits for a root that never appears. In `TimeRange.set` the
scoped click consumes the whole test budget, so its `catch` only runs during teardown and reports
`locator.click: Target page, context or browser has been closed` — which hides the real error,
`Test timeout of 30000ms exceeded`.

This moves both thresholds to the version at which each toolbar became the default. 9.5.0 is
already the threshold `addPanel` uses for the same top nav change, two branches down the same file.

**Which issue(s) this PR fixes**:

None filed — found while investigating the red `9.4.17` and `11.1.13` legs on #2832.

**Special notes for your reviewer**:

These versions reached CI for the first time this week. `playwright.yml` runs the full matrix only
on PRs that touch `packages/plugin-e2e/**`, and the resolver picks the latest patch of each minor
when it runs, so the set moves as Grafana publishes releases. The last full-matrix run before this
week resolved 9.3.16 and 11.0.11, which sit either side of both broken ranges. The nightly uses
`limit: 1`, so it only covers the latest stable and grafana-dev. Every plugin-e2e PR is affected
until this lands, including #2819.

Behaviour changes only for 9.4.x and 11.1.x–11.2.x, which are exactly the broken ranges. Every
other version resolves to the same selector as before. Verified against each version with the
compose environment from `playwright.yml`:

| Grafana | Resolves to | Before | After |
| --- | --- | --- | --- |
| 8.5.27 | `.page-toolbar` | pass | pass |
| 9.4.17 | `.page-toolbar` | fail | pass |
| 11.0.11 | `Nav toolbar` | pass | pass |
| 11.1.13 | `Nav toolbar` | fail | pass |
| 11.2.10 | `Nav toolbar` | fail | pass |
| 13.2.0 | `dashboard controls` | pass | pass |

`DashboardPage.test.ts` locks all three branches and fails on 9.4.17, 11.1.13 and 11.2.10 with the
old thresholds.
