### PR TITLE
ci: temporarily disable update command tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
   test-updates:
     name: Test create-plugin update command
     runs-on: ubuntu-x64
-    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
+    if: false
     needs: [test]
     env:
       WORKING_DIR: 'myorg-nobackend-panel'


### PR DESCRIPTION
**What this PR does / why we need it**:

The `test-updates` job's npm install fails with ETARGET: `@grafana/data@12.4.9` (and siblings) now depend on `@grafana/schema@12.4.9` exactly, but that version was never published to npm - an upstream Grafana publishing gap. Disabling the job temporarily so it stops blocking unrelated PRs.

Same failure we've hit before, fixed the same way: #2742 disabled the job temporarily, #2747 reverted it once the npm packages finished publishing.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Temporary CI-only workaround, not a real fix. A follow-up PR should revert this once `@grafana/schema@12.4.9` is published.