### PR TITLE
ci: revert temporarily disable update command tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
   test-updates:
     name: Test create-plugin update command
     runs-on: ubuntu-x64
-    if: false
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     needs: [test]
     env:
       WORKING_DIR: 'myorg-nobackend-panel'


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that `@grafana/schema@12.4.9` has been published to npm we can revert #2837, which set `if: false` on the test-updates job to work around the missing version.

Mirrors jackw's precedent: #2742 disabled the job, #2747 reverted it once the npm packages finished publishing.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Reverts #2837.