### PR TITLE
fix(plugin-docs-cli): treat AGENTS.md as a repo-meta file

### DIFF
--- a/packages/plugin-docs-cli/src/validation/rules/utils.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.test.ts
@@ -14,6 +14,7 @@ describe('isMetaFile', () => {
     expect(isMetaFile('CODE_OF_CONDUCT.md')).toBe(true);
     expect(isMetaFile('SECURITY.md')).toBe(true);
     expect(isMetaFile('CHANGELOG.md')).toBe(true);
+    expect(isMetaFile('AGENTS.md')).toBe(true);
   });
 
   it('matches when given a path, not just a basename', () => {
@@ -37,6 +38,7 @@ describe('isMetaFile', () => {
   it('does not match files that merely contain a meta basename in their path component', () => {
     expect(isMetaFile('readme-tips.md')).toBe(false);
     expect(isMetaFile('contributing-quickstart.md')).toBe(false);
+    expect(isMetaFile('agents-of-shield.md')).toBe(false);
   });
 });
 

--- a/packages/plugin-docs-cli/src/validation/rules/utils.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.ts
@@ -13,6 +13,7 @@ const META_FILE_BASENAMES_UPPER: ReadonlySet<string> = new Set([
   'CODE_OF_CONDUCT.MD',
   'SECURITY.MD',
   'CHANGELOG.MD',
+  'AGENTS.MD',
 ]);
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `AGENTS.md` to the meta-file allowlist so it's excluded from docs validation, matching `README.md` and friends.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Found via a live docs:serve run against a real plugin.