### PR TITLE
fix(plugin-e2e): support new root OFREP route

### DIFF
--- a/packages/plugin-e2e/src/fixtures/getOpenFeatureFlag.ts
+++ b/packages/plugin-e2e/src/fixtures/getOpenFeatureFlag.ts
@@ -9,27 +9,42 @@ export const getBooleanOpenFeatureFlag: GetBooleanOpenFeatureFlagFixture = async
 ) => {
   await use(async (flagKey: string) => {
     try {
-      const url = selectors.apis.OpenFeature.ofrepSinglePath(namespace, flagKey);
+      const urls = [
+        selectors.apis.OpenFeature.ofrepSinglePath(namespace, flagKey),
+        selectors.apis.OpenFeature.ofrepSinglePathWithoutNamespace(flagKey),
+      ];
+
+      let result: { error: true; status: number; statusText: string } | { error: false; value: unknown } | undefined;
 
       // make the request from within the page context to use the same authentication
-      const result = await page.evaluate(async (flagUrl) => {
-        const response = await fetch(flagUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ context: {} }),
-        });
+      for (const url of urls) {
+        result = await page.evaluate(async (flagUrl) => {
+          const response = await fetch(flagUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ context: {} }),
+          });
 
-        if (!response.ok) {
-          return {
-            error: true,
-            status: response.status,
-            statusText: response.statusText,
-          };
+          if (!response.ok) {
+            return {
+              error: true,
+              status: response.status,
+              statusText: response.statusText,
+            };
+          }
+
+          const body = await response.json();
+          return { error: false, value: body.value };
+        }, url);
+
+        if (!result.error) {
+          break;
         }
+      }
 
-        const body = await response.json();
-        return { error: false, value: body.value };
-      }, url);
+      if (!result) {
+        throw new Error(`Failed to fetch OpenFeature flag "${flagKey}"`);
+      }
 
       if (result.error) {
         throw new Error(`Failed to fetch OpenFeature flag "${flagKey}": ${result.status} ${result.statusText}`);

--- a/packages/plugin-e2e/src/selectors/versionedAPIs.test.ts
+++ b/packages/plugin-e2e/src/selectors/versionedAPIs.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { versionedAPIs } from './versionedAPIs';
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '__DOUBLE_STAR__')
+    .replace(/\*/g, '[^/]*')
+    .replace(/__DOUBLE_STAR__/g, '.*');
+
+  return new RegExp(`^${escaped}$`);
+}
+
+describe('versionedAPIs', () => {
+  describe('OpenFeature', () => {
+    it('matches namespaced and bare OFREP bulk evaluation routes', () => {
+      const pattern = versionedAPIs.OpenFeature.ofrepBulkPattern['12.1.0'];
+      const matcher = globToRegExp(pattern);
+
+      expect(matcher.test('/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags')).toBe(true);
+      expect(matcher.test('/ofrep/v1/evaluate/flags')).toBe(true);
+    });
+
+    it('provides namespaced and bare OFREP bulk evaluation paths', () => {
+      expect(versionedAPIs.OpenFeature.ofrepBulkPath['12.1.0']('default')).toBe(
+        '/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags'
+      );
+      expect(versionedAPIs.OpenFeature.ofrepBulkPathWithoutNamespace['12.1.0']()).toBe('/ofrep/v1/evaluate/flags');
+    });
+
+    it('matches namespaced and bare OFREP single flag evaluation routes', () => {
+      const pattern = versionedAPIs.OpenFeature.ofrepSinglePattern['12.1.0'];
+      const matcher = globToRegExp(pattern);
+
+      expect(
+        matcher.test('/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/myFlag')
+      ).toBe(true);
+      expect(matcher.test('/ofrep/v1/evaluate/flags/myFlag')).toBe(true);
+    });
+
+    it('provides namespaced and bare OFREP single flag evaluation paths', () => {
+      expect(versionedAPIs.OpenFeature.ofrepSinglePath['12.1.0']('default', 'myFlag')).toBe(
+        '/apis/features.grafana.app/v0alpha1/namespaces/default/ofrep/v1/evaluate/flags/myFlag'
+      );
+      expect(versionedAPIs.OpenFeature.ofrepSinglePathWithoutNamespace['12.1.0']('myFlag')).toBe(
+        '/ofrep/v1/evaluate/flags/myFlag'
+      );
+    });
+  });
+});

--- a/packages/plugin-e2e/src/selectors/versionedAPIs.ts
+++ b/packages/plugin-e2e/src/selectors/versionedAPIs.ts
@@ -45,18 +45,24 @@ export const versionedAPIs = {
   },
   OpenFeature: {
     ofrepBulkPattern: {
-      '12.1.0': '**/apis/features.grafana.app/**/ofrep/v*/evaluate/flags',
+      '12.1.0': '**/ofrep/v*/evaluate/flags',
     },
     ofrepSinglePattern: {
-      '12.1.0': '**/apis/features.grafana.app/**/ofrep/v*/evaluate/flags/*',
+      '12.1.0': '**/ofrep/v*/evaluate/flags/*',
     },
     ofrepBulkPath: {
       '12.1.0': (namespace = 'default') =>
         `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}/ofrep/v1/evaluate/flags`,
     },
+    ofrepBulkPathWithoutNamespace: {
+      '12.1.0': () => '/ofrep/v1/evaluate/flags',
+    },
     ofrepSinglePath: {
       '12.1.0': (namespace = 'default', flagKey: string) =>
         `/apis/features.grafana.app/v0alpha1/namespaces/${namespace}/ofrep/v1/evaluate/flags/${flagKey}`,
+    },
+    ofrepSinglePathWithoutNamespace: {
+      '12.1.0': (flagKey: string) => `/ofrep/v1/evaluate/flags/${flagKey}`,
     },
   },
 } satisfies VersionedSelectorGroup;


### PR DESCRIPTION
**What this PR does / why we need it**:

Grafana is switching to using a namespace-less OFREP route at the root path, which the current E2E logic does not catch to override responses.
