### PR TITLE
feat(plugin-e2e): expose response body from waitForQueryDataResponse

### DIFF
--- a/docusaurus/docs/e2e-test-a-plugin/test-a-data-source-plugin/query-editor.md
+++ b/docusaurus/docs/e2e-test-a-plugin/test-a-data-source-plugin/query-editor.md
@@ -99,6 +99,58 @@ test('data query should return headers  and 3', async ({ panelEditPage, readProv
 });
 ```
 
+### Assert on the query response body
+
+A panel data assertion tells you what Grafana rendered. To assert on what your data source returned, use the [`<page>.waitForQueryDataResponseWithBody`](https://github.com/grafana/plugin-tools/blob/main/packages/plugin-e2e/src/models/pages/GrafanaPage.ts) method. It waits for a query data response and resolves with both the response and its parsed JSON body. The method reads the body while the response is still available, which is more reliable than calling `.json()` on a response that has already resolved.
+
+:::note
+This method is in alpha. The shape it returns can change without a major version bump.
+:::
+
+Call the method before you trigger the query, then await the result. The `body` property is `null` when the response body is not valid JSON.
+
+```ts title="queryEditor.spec.ts"
+type QueryResponse = {
+  results: Record<string, { frames?: unknown[]; error?: string }>;
+};
+
+test('data query response should contain frames for refId A', async ({
+  panelEditPage,
+  readProvisionedDataSource,
+}) => {
+  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
+  await panelEditPage.datasource.set(ds.name);
+  await panelEditPage.getQueryEditorRow('A').getByRole('textbox', { name: 'Query Text' }).fill('SELECT * FROM dataset');
+
+  const queryResponse = panelEditPage.waitForQueryDataResponseWithBody<QueryResponse>();
+  await panelEditPage.refreshPanel();
+  const { response, body } = await queryResponse;
+
+  expect(response.ok()).toBe(true);
+  expect(body?.results.A.frames).toBeDefined();
+});
+```
+
+The method also accepts a callback that filters the responses it waits for. The callback receives the parsed body, so you can select a response by its contents instead of only by status or URL. This helps when a panel runs more than one query, because every query request goes to the same URL.
+
+```ts title="queryEditor.spec.ts"
+test('data query response for refId B should not contain an error', async ({
+  readProvisionedDashboard,
+  gotoPanelEditPage,
+}) => {
+  const dashboard = await readProvisionedDashboard({ fileName: 'dashboard.json' });
+  const panelEditPage = await gotoPanelEditPage({ dashboard, id: '3' });
+
+  const queryResponse = panelEditPage.waitForQueryDataResponseWithBody<QueryResponse>(
+    (_response, body) => body?.results.B !== undefined
+  );
+  await panelEditPage.refreshPanel();
+  const { body } = await queryResponse;
+
+  expect(body?.results.B.error).toBeUndefined();
+});
+```
+
 ### Testing a query in a provisioned dashboard
 
 Sometimes you may want to open the panel edit page for an already existing panel and run the query to make sure everything work as expected.

--- a/packages/plugin-e2e/src/models/pages/GrafanaPage.ts
+++ b/packages/plugin-e2e/src/models/pages/GrafanaPage.ts
@@ -89,4 +89,34 @@ export abstract class GrafanaPage {
       return false;
     });
   }
+
+  /**
+   * Waits for a data source query data response and returns both the response and its parsed JSON body.
+   *
+   * The body is read while the response is still live, inside the same predicate `waitForResponse` uses
+   * to find the matching response, rather than by calling `.json()` on the resolved response afterwards.
+   *
+   * @param cb optional callback to filter the response. Receives the response together with its parsed
+   * body (`null` if the body could not be parsed as JSON) so you can filter by response contents, e.g. a
+   * specific refId's frames, rather than only status or url.
+   *
+   * @alpha - the API is not yet stable and may change without a major version bump. Use with caution.
+   */
+  async waitForQueryDataResponseWithBody<T = any>(
+    cb?: (response: Response, body: T | null) => boolean | Promise<boolean>
+  ): Promise<{ response: Response; body: T | null }> {
+    let body: T | null = null;
+    const response = await this.ctx.page.waitForResponse(async (response) => {
+      if (!response.url().includes(this.ctx.selectors.apis.DataSource.query)) {
+        return false;
+      }
+      const parsedBody = (await response.json().catch(() => null)) as T | null;
+      if (cb && !(await cb(response, parsedBody))) {
+        return false;
+      }
+      body = parsedBody;
+      return true;
+    });
+    return { response, body };
+  }
 }

--- a/packages/plugin-e2e/tests/as-admin-user/datasource/explore/queryEditor.integration.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/datasource/explore/queryEditor.integration.spec.ts
@@ -22,6 +22,41 @@ test('should return an error and display panel error when query is invalid', asy
   await expect(explorePage.runQuery()).not.toBeOK();
 });
 
+test('waitForQueryDataResponseWithBody exposes the parsed response body', async ({
+  explorePage,
+  readProvisionedDataSource,
+}) => {
+  const ds = await readProvisionedDataSource({ fileName: 'testdatasource.yaml' });
+  await explorePage.datasource.set(ds.name);
+  const editorRow = await explorePage.getQueryEditorRow('A');
+  await editorRow.getByRole('textbox', { name: 'Query Text' }).fill('query');
+
+  const responseWithBody = explorePage.waitForQueryDataResponseWithBody<{ results?: Record<string, unknown> }>();
+  await explorePage.runQuery();
+  const { response, body } = await responseWithBody;
+
+  expect(response.ok()).toBe(true);
+  expect(body?.results?.A).toBeDefined();
+});
+
+test('waitForQueryDataResponseWithBody filters by the parsed body', async ({
+  explorePage,
+  readProvisionedDataSource,
+}) => {
+  const ds = await readProvisionedDataSource({ fileName: 'testdatasource.yaml' });
+  await explorePage.datasource.set(ds.name);
+  const editorRow = await explorePage.getQueryEditorRow('A');
+  await editorRow.getByRole('textbox', { name: 'Query Text' }).fill('query');
+
+  const responseWithBody = explorePage.waitForQueryDataResponseWithBody<{ results?: Record<string, unknown> }>(
+    (_response, body) => body?.results?.A !== undefined
+  );
+  await explorePage.runQuery();
+  const { body } = await responseWithBody;
+
+  expect(body?.results?.A).toBeDefined();
+});
+
 test('explore page should display table and time series panel only for certain query', async ({
   explorePage,
   grafanaVersion,


### PR DESCRIPTION
**What this PR does / why we need it**:

`GrafanaPage.waitForQueryDataResponse` only ever hands the caller a raw Playwright `Response` — its `cb` predicate is `(request: Response) => boolean | Promise<boolean>`, with no way to filter or assert on the response body without a separate `.json()` call. Reading the body after the response has resolved is unreliable in practice (the CDP buffer isn't guaranteed to still be live), so plugin authors end up re-implementing "parse the body inside the predicate, stash it in a closure" by hand — that's exactly what `grafana/clickhouse-datasource` did, and where this suggestion came from (review feedback on [clickhouse-datasource#2122](https://github.com/grafana/clickhouse-datasource/pull/2122), no existing upstream issue to link).

This PR adds a new, purely additive `waitForQueryDataResponseWithBody` method alongside the existing `waitForQueryDataResponse`, on the shared `GrafanaPage` base class so every page model (`ExplorePage`, `DashboardPage`, `PanelEditPage`, `AlertRuleEditPage`) gets it for free. It returns `{ response, body }`, and its predicate receives the parsed body so callers can filter by response contents (e.g. a specific refId's frames) rather than only status/url. Tagged `@alpha` following the precedent of `DashboardPage.waitForPanelsQueriesToComplete`, since the exact return shape may want to evolve.

The existing `waitForQueryDataResponse` is untouched — nothing about this is a breaking change.

**Which issue(s) this PR fixes**:

None filed — this came directly out of review feedback on an external plugin's PR (see above). Happy to file one first if preferred.

**Special notes for your reviewer**:

- Verified locally against `grafana-enterprise:11.4.0` via `npm run server` + `npx playwright test`: the two new tests pass, and the full existing `queryEditor.integration.spec.ts`/`queryEditor.spec.ts` suites pass unchanged.
- Ran the full package test suite (240 tests) for regressions: 3 failures under default parallelism turned out to be pre-existing flakiness unrelated to this change — I confirmed by re-running the same specs with this change *reverted* (a *different, larger* set of 6 failed) and by re-running with `--workers=1` (all passed, both with and without this change). No test that exercises `GrafanaPage`/`waitForQueryDataResponse` regressed.
- Naming: went with `waitForQueryDataResponseWithBody` to mirror `clickhouse-datasource`'s own local helper, for continuity with the code this is generalising from. Open to a different name if you'd prefer something else.
