### PR TITLE
fix(plugin-e2e): don't assume panel options group is expanded by default

### DIFF
--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -235,7 +235,7 @@ export class PanelEditPage extends GrafanaPage {
   }
 
   getDataLinksOptions(): PanelEditOptionsGroup {
-    return this.getCustomOptions('Data links');
+    return this.getCustomOptions(this.ctx.selectors.constants.OptionsGroup.dataLinksTitle);
   }
 
   getThresholdsOptions(): PanelEditOptionsGroup {

--- a/packages/plugin-e2e/src/selectors/versionedConstants.ts
+++ b/packages/plugin-e2e/src/selectors/versionedConstants.ts
@@ -27,6 +27,13 @@ export const versionedConstants = {
       [MIN_GRAFANA_VERSION]: 'All visualizations',
     },
   },
+  OptionsGroup: {
+    // the data links panel options category started supporting actions in 11.6.0, and was renamed accordingly
+    dataLinksTitle: {
+      '11.6.0': 'Data links and actions',
+      [MIN_GRAFANA_VERSION]: 'Data links',
+    },
+  },
 } satisfies VersionedSelectorGroup;
 
 export type VersionedConstants = typeof versionedConstants;

--- a/packages/plugin-e2e/tests/as-admin-user/panel/panelEdit.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/panel/panelEdit.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../../src';
-import { lt, lte } from 'semver';
+import { lte } from 'semver';
 
 test('selecting value in radio button group', async ({ gotoPanelEditPage }) => {
   const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'mxb-Jv4Vk' }, id: '5' });
@@ -139,22 +139,20 @@ test('select timezone in timezone picker', async ({ gotoPanelEditPage, grafanaVe
   await expect(timeZonePicker).toHaveSelected('Europe/Stockholm');
 });
 
-test('collapse expanded options group', async ({ gotoPanelEditPage, grafanaVersion }) => {
+test('collapse expanded options group', async ({ gotoPanelEditPage }) => {
   const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'be6sir7o1iccgb' }, id: '1' });
-  const datalinksLabel = lt(grafanaVersion, '11.6.0') ? 'Data links' : 'Data links and actions';
-  const dataLinksOptions = panelEdit.getCustomOptions(datalinksLabel);
+  const dataLinksOptions = panelEdit.getDataLinksOptions();
 
+  await dataLinksOptions.expand();
   expect(await dataLinksOptions.isExpanded()).toBeTruthy();
   await dataLinksOptions.collapse();
   expect(await dataLinksOptions.isExpanded()).toBeFalsy();
 });
 
-test('expand collapsed options group', async ({ gotoPanelEditPage, grafanaVersion }) => {
+test('expand collapsed options group', async ({ gotoPanelEditPage }) => {
   const panelEdit = await gotoPanelEditPage({ dashboard: { uid: 'be6sir7o1iccgb' }, id: '1' });
-  const datalinksLabel = lt(grafanaVersion, '11.6.0') ? 'Data links' : 'Data links and actions';
-  const dataLinksOptions = panelEdit.getCustomOptions(datalinksLabel);
+  const dataLinksOptions = panelEdit.getDataLinksOptions();
 
-  expect(await dataLinksOptions.isExpanded()).toBeTruthy();
   await dataLinksOptions.collapse();
   expect(await dataLinksOptions.isExpanded()).toBeFalsy();
   await dataLinksOptions.expand();


### PR DESCRIPTION
**What this PR does / why we need it**:

The nightly E2E workflow failed against Grafana's `nightly` image: [grafana/grafana@5f1776a28c](https://github.com/grafana/grafana/commit/5f1776a28c) changed panel options categories to collapse by default when they have zero items, breaking `panelEdit.spec.ts`'s "Data links" group tests. Fixes the tests to force expand/collapse state instead of assuming a default, and fixes `getDataLinksOptions()` to resolve the label per Grafana version.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Broken nightly run: https://github.com/grafana/plugin-tools/actions/runs/33056766956