### PR TITLE
fix: wait for options pane before the viz picker check

### DIFF
--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -99,11 +99,18 @@ export class PanelEditPage extends GrafanaPage {
     // and also we need to check whether we're already rendering the viz picker or not since creating a new panel shows
     // the viz picker by default when the panel editor is opened
     if (gte(this.ctx.grafanaVersion, '12.4.0')) {
-      const allVisualizationsTab = components.Tab.title(constants.Tab.title);
-      if (!(await this.getByGrafanaSelector(allVisualizationsTab).isVisible())) {
-        await this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker).click();
+      const allVisualizationsTab = this.getByGrafanaSelector(components.Tab.title(constants.Tab.title));
+      const openVizPickerButton = this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker);
+
+      // The options pane renders either the viz picker or the pane header. Wait for one of
+      // them to mount otherwise isVisible() returns false and the picker looks closed.
+      await expect(allVisualizationsTab.or(openVizPickerButton).first()).toBeVisible();
+
+      if (await openVizPickerButton.isVisible()) {
+        await openVizPickerButton.click();
       }
-      await this.getByGrafanaSelector(allVisualizationsTab).click();
+
+      await allVisualizationsTab.click();
     } else {
       await this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker).click();
     }
@@ -179,8 +186,8 @@ export class PanelEditPage extends GrafanaPage {
 
   /**
    * Clicks the "Refresh" button in the panel editor. Returns the response promise for the data query
-   * 
-   * By default, this method will wait for any response that has the url '/api/ds/query'. 
+   *
+   * By default, this method will wait for any response that has the url '/api/ds/query'.
    * If you need to wait for a specific response, you can pass a callback to the `waitForResponsePredicateCallback` option.
    * e.g
    * panelEditPage.refreshPanel({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
setVisualization works out whether the viz picker is already open by calling isVisible() on the picker's tab. That check doesn't wait - if the element isn't in the DOM yet it just returns false.

The Grafana panel editor has to wait for a lot of lazy chunks before the options pane renders, so for a few hundred milliseconds neither the tab nor the toggle button exists. `isVisible()` returns false, the method decides the picker must be closed, and clicks `toggle-viz-picker`. Except a new panel opens with the picker already open, and that toggle button only renders when the picker is closed - so it never render, and the click sits there until it times out.

This PR waits with locator.or() for whichever of the two appears first. One of them should always be there once the pane has rendered, so by the time we check open vs closed we should have something to work with.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
