### PR TITLE
fix(plugin-e2e): fix setVisualization race with Grafana's viz picker

### DIFF
--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -102,9 +102,13 @@ export class PanelEditPage extends GrafanaPage {
       const allVisualizationsTab = this.getByGrafanaSelector(components.Tab.title(constants.Tab.title));
       const openVizPickerButton = this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker);
 
-      // The options pane renders either the viz picker or the pane header. Wait for one of
-      // them to mount otherwise isVisible() returns false and the picker looks closed.
-      await expect(allVisualizationsTab.or(openVizPickerButton).first()).toBeVisible();
+      // don't use `allVisualizationsTab.or(openVizPickerButton).first()` here - if both elements
+      // exist in the DOM at once (one hidden via CSS rather than unmounted), `.first()` resolves to
+      // the first one in DOM order, which can be the hidden one, and then hangs forever waiting for
+      // it to become visible. Poll each locator's own visibility instead until one of them is true.
+      await expect(async () => {
+        expect((await allVisualizationsTab.isVisible()) || (await openVizPickerButton.isVisible())).toBe(true);
+      }).toPass();
 
       if (await openVizPickerButton.isVisible()) {
         await openVizPickerButton.click();

--- a/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
+++ b/packages/plugin-e2e/src/models/pages/PanelEditPage.ts
@@ -90,44 +90,51 @@ export class PanelEditPage extends GrafanaPage {
   async setVisualization(visualization: Visualization | string) {
     const { components, constants } = this.ctx.selectors;
     const showPanelEditElement = this.getByGrafanaSelector('Show options pane');
-    const showPanelEditElementCount = await showPanelEditElement.count();
-    if (showPanelEditElementCount > 0) {
-      await showPanelEditElement.click();
-    }
-
-    // when suggestions got updated in 12.4.0, it became necessary to ensure the "All Visualizations" tab is selected,
-    // and also we need to check whether we're already rendering the viz picker or not since creating a new panel shows
-    // the viz picker by default when the panel editor is opened
-    if (gte(this.ctx.grafanaVersion, '12.4.0')) {
-      const allVisualizationsTab = this.getByGrafanaSelector(components.Tab.title(constants.Tab.title));
-      const openVizPickerButton = this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker);
-
-      // don't use `allVisualizationsTab.or(openVizPickerButton).first()` here - if both elements
-      // exist in the DOM at once (one hidden via CSS rather than unmounted), `.first()` resolves to
-      // the first one in DOM order, which can be the hidden one, and then hangs forever waiting for
-      // it to become visible. Poll each locator's own visibility instead until one of them is true.
-      await expect(async () => {
-        expect((await allVisualizationsTab.isVisible()) || (await openVizPickerButton.isVisible())).toBe(true);
-      }).toPass();
-
-      if (await openVizPickerButton.isVisible()) {
-        await openVizPickerButton.click();
-      }
-
-      await allVisualizationsTab.click();
-    } else {
-      await this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker).click();
-    }
-
-    await this.getByGrafanaSelector(components.PluginVisualization.item(visualization)).click();
-
     const vizSelector = lt(this.ctx.grafanaVersion, '12.4.0')
       ? components.PanelEditor.toggleVizPicker
       : components.PanelEditor.OptionsPane.header;
-    await expect(
-      this.getByGrafanaSelector(vizSelector),
-      `Could not set visualization to ${visualization}. Ensure the panel is installed.`
-    ).toHaveText(visualization);
+    const currentViz = this.getByGrafanaSelector(vizSelector);
+    const vizItem = this.getByGrafanaSelector(components.PluginVisualization.item(visualization));
+
+    // switching quickly between panel types can leave the item grid mid-render right after the
+    // previous selection closed the picker - retry the whole open+select step rather than trusting
+    // a single click to land on the right item, so a stale click self-heals instead of leaving the
+    // panel stuck on the previous visualization.
+    await expect(async () => {
+      if ((await showPanelEditElement.count()) > 0) {
+        await showPanelEditElement.click();
+      }
+
+      // when suggestions got updated in 12.4.0, it became necessary to ensure the "All Visualizations" tab is selected,
+      // and also we need to check whether we're already rendering the viz picker or not since creating a new panel shows
+      // the viz picker by default when the panel editor is opened
+      if (gte(this.ctx.grafanaVersion, '12.4.0')) {
+        const allVisualizationsTab = this.getByGrafanaSelector(components.Tab.title(constants.Tab.title));
+        const openVizPickerButton = this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker);
+
+        // don't use `allVisualizationsTab.or(openVizPickerButton).first()` here - if both elements
+        // exist in the DOM at once (one hidden via CSS rather than unmounted), `.first()` resolves to
+        // the first one in DOM order, which can be the hidden one, and then hangs forever waiting for
+        // it to become visible. Poll each locator's own visibility instead until one of them is true.
+        await expect(async () => {
+          expect((await allVisualizationsTab.isVisible()) || (await openVizPickerButton.isVisible())).toBe(true);
+        }).toPass();
+
+        if (await openVizPickerButton.isVisible()) {
+          await openVizPickerButton.click();
+        }
+
+        await allVisualizationsTab.click();
+      } else {
+        await this.getByGrafanaSelector(components.PanelEditor.toggleVizPicker).click();
+      }
+
+      await vizItem.click();
+      await expect(
+        currentViz,
+        `Could not set visualization to ${visualization}. Ensure the panel is installed.`
+      ).toHaveText(visualization, { timeout: 2000 });
+    }).toPass({ timeout: 15000 });
   }
 
   /**

--- a/packages/plugin-e2e/tests/as-admin-user/panel/panelEdit.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/panel/panelEdit.spec.ts
@@ -165,4 +165,13 @@ test('set visualization', async ({ gotoPanelEditPage }) => {
   await expect(panelEdit.getVisualizationName()).toHaveText('Clock');
   await panelEdit.setVisualization('Table');
   await expect(panelEdit.getVisualizationName()).toHaveText('Table');
+  await panelEdit.setVisualization('Time series');
+  await expect(panelEdit.getVisualizationName()).toHaveText('Time series');
+});
+
+test('set visualization immediately after creating a new panel', async ({ panelEditPage }) => {
+  // the viz picker is open by default when a brand-new panel is created, unlike the case above
+  // where it's closed - setVisualization has to detect that correctly too
+  await panelEditPage.setVisualization('Table');
+  await expect(panelEditPage.getVisualizationName()).toHaveText('Table');
 });

--- a/packages/plugin-e2e/tests/as-admin-user/panel/panelVisualizationSmoke.spec.ts
+++ b/packages/plugin-e2e/tests/as-admin-user/panel/panelVisualizationSmoke.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '../../../src';
+
+interface PanelPluginMeta {
+  name: string;
+  hideFromList?: boolean;
+  state?: string;
+}
+
+test('cycles through every installed panel type without losing the selection', async ({ panelEditPage, page }) => {
+  test.setTimeout(120_000);
+
+  const panels = await page.evaluate(() => {
+    const win = window as unknown as {
+      grafanaBootData: { settings: { panels: Record<string, PanelPluginMeta> } };
+    };
+    return Object.values(win.grafanaBootData?.settings?.panels ?? {});
+  });
+  const eligiblePanels = panels.filter((panel) => !panel.hideFromList && panel.state !== 'deprecated');
+  expect(eligiblePanels.length).toBeGreaterThan(0);
+
+  for (const panel of eligiblePanels) {
+    await panelEditPage.setVisualization(panel.name);
+    await expect(panelEditPage.getVisualizationName(), `failed to switch to ${panel.name}`).toHaveText(panel.name);
+  }
+});


### PR DESCRIPTION
**What this PR does / why we need it**:

`setVisualization` has two races from #2857: a DOM-order check can hang forever, and a stale click can leave the wrong visualization selected when switching panel types quickly. Fixes both, adds a smoke test cycling through every installed panel type.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Failing CI: grafana/grafana#131986, run 33843630453.