### PR TITLE
feat(plugin-docs-cli): add docs-path, size and SEO length validation rules

### DIFF
--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { access } from 'node:fs/promises';
+import { stat } from 'node:fs/promises';
 import minimist from 'minimist';
 import createDebug from 'debug';
 import { resolveDocsPath } from '../utils/utils.plugin.js';
@@ -36,11 +36,16 @@ async function main() {
   }
 
   // `serve` and `build` need a real folder to do anything useful, so fail fast here with a
-  // friendly message. `validate` reports a missing docsPath as a normal diagnostic instead
-  // (the `docs-path-exists` rule), so its --json output stays well-formed either way.
+  // friendly message. `validate` reports a missing or invalid docsPath as a normal diagnostic
+  // instead (the `docs-path-exists` rule), so its --json output stays well-formed either way.
   if (command !== 'validate') {
     try {
-      await access(docsPath);
+      const st = await stat(docsPath);
+      if (!st.isDirectory()) {
+        console.error(`Error: Not a directory: ${docsPath}`);
+        console.error('Check that the "docsPath" in src/plugin.json points to a directory, not a file.');
+        process.exit(1);
+      }
     } catch {
       console.error(`Error: Path not found: ${docsPath}`);
       console.error('Check that the "docsPath" in src/plugin.json points to an existing directory.');

--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -35,12 +35,17 @@ async function main() {
     process.exit(1);
   }
 
-  try {
-    await access(docsPath);
-  } catch {
-    console.error(`Error: Path not found: ${docsPath}`);
-    console.error('Check that the "docsPath" in src/plugin.json points to an existing directory.');
-    process.exit(1);
+  // `serve` and `build` need a real folder to do anything useful, so fail fast here with a
+  // friendly message. `validate` reports a missing docsPath as a normal diagnostic instead
+  // (the `docs-path-exists` rule), so its --json output stays well-formed either way.
+  if (command !== 'validate') {
+    try {
+      await access(docsPath);
+    } catch {
+      console.error(`Error: Path not found: ${docsPath}`);
+      console.error('Check that the "docsPath" in src/plugin.json points to an existing directory.');
+      process.exit(1);
+    }
   }
 
   switch (command) {

--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -22,7 +22,8 @@ async function main() {
     console.error('Commands:');
     console.error('  serve      Start the local docs preview server');
     console.error('  build      Build docs for publishing (generates manifest, copies to dist/)');
-    console.error('  validate   Validate documentation (--json for machine-readable output)');
+    console.error('  validate   Validate documentation (--json for machine-readable output,');
+    console.error('             --allow-unfilled-stubs while docs are still being written)');
     process.exit(1);
   }
 
@@ -76,13 +77,18 @@ async function main() {
     }
     case 'validate': {
       const validateArgv = minimist(process.argv.slice(3), {
-        boolean: ['strict', 'json'],
+        boolean: ['strict', 'json', 'allow-unfilled-stubs'],
         default: {
           strict: true,
           json: false,
+          'allow-unfilled-stubs': false,
         },
       });
-      await validateCommand(docsPath, { strict: validateArgv.strict, json: validateArgv.json });
+      await validateCommand(docsPath, {
+        strict: validateArgv.strict,
+        json: validateArgv.json,
+        allowUnfilledStubs: validateArgv['allow-unfilled-stubs'],
+      });
       break;
     }
     default:

--- a/packages/plugin-docs-cli/src/commands/validate.command.ts
+++ b/packages/plugin-docs-cli/src/commands/validate.command.ts
@@ -7,11 +7,20 @@ const debug = createDebug('plugin-docs-cli:validate');
 
 export async function validateCommand(
   docsPath: string,
-  options: { strict: boolean; json: boolean } = { strict: true, json: false }
+  options: { strict: boolean; json: boolean; allowUnfilledStubs?: boolean } = { strict: true, json: false }
 ): Promise<void> {
-  debug('Validating docs at: %s (strict: %s, json: %s)', docsPath, options.strict, options.json);
+  debug(
+    'Validating docs at: %s (strict: %s, json: %s, allowUnfilledStubs: %s)',
+    docsPath,
+    options.strict,
+    options.json,
+    options.allowUnfilledStubs ?? false
+  );
 
-  const result = await validate({ docsPath, strict: options.strict }, allRules);
+  const result = await validate(
+    { docsPath, strict: options.strict, allowUnfilledStubs: options.allowUnfilledStubs },
+    allRules
+  );
 
   if (options.json) {
     console.log(JSON.stringify(result, null, 2));

--- a/packages/plugin-docs-cli/src/validation/format.test.ts
+++ b/packages/plugin-docs-cli/src/validation/format.test.ts
@@ -78,4 +78,17 @@ describe('formatResult', () => {
     expect(output).toContain('1 warning');
     expect(output).toContain('1 info');
   });
+
+  it('reports a clean bill when the only findings are informational', () => {
+    const output = formatResult({
+      valid: true,
+      diagnostics: [
+        { rule: Rule.UnfilledSectionBrief, severity: 'info', file: 'index.md', line: 7, title: 'Stub', detail: '' },
+      ],
+    });
+
+    // a freshly scaffolded docs folder is valid; "has 1 info" reads like a failure
+    expect(output).toContain('✓ Documentation is valid (1 note)');
+    expect(output).not.toContain('⚠');
+  });
 });

--- a/packages/plugin-docs-cli/src/validation/format.ts
+++ b/packages/plugin-docs-cli/src/validation/format.ts
@@ -35,9 +35,16 @@ export function formatResult(result: ValidationResult): string {
     parts.push(`${infos} info`);
   }
 
-  const icon = errors > 0 ? '✗' : '⚠';
-  lines.push(`${icon} Documentation has ${parts.join(' and ')}`);
-  lines.push('');
+  // info-only output is not a problem report - the docs are valid and these are notes. Saying
+  // "Documentation has 17 info" reads as a failure and buries the fact that nothing is wrong.
+  if (errors === 0 && warnings === 0) {
+    lines.push(`✓ Documentation is valid (${infos} note${infos !== 1 ? 's' : ''})`);
+    lines.push('');
+  } else {
+    const icon = errors > 0 ? '✗' : '⚠';
+    lines.push(`${icon} Documentation has ${parts.join(' and ')}`);
+    lines.push('');
+  }
 
   for (const d of result.diagnostics) {
     const label = SEVERITY_LABEL[d.severity] ?? d.severity;

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -111,7 +111,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
     }
   }
 
-  // max-total-images-size: only in strict mode (serve = '-')
+  // max-total-images-size: only checked under `validate` (not `serve`)
   if (input.strict && totalSize > MAX_TOTAL_SIZE) {
     diagnostics.push({
       rule: Rule.MaxTotalImagesSize,
@@ -183,7 +183,7 @@ export async function checkAssets(input: ValidationInput): Promise<Diagnostic[]>
     }
   }
 
-  // no-orphaned-images: only in strict mode (serve = '-')
+  // no-orphaned-images: only checked under `validate` (not `serve`)
   if (input.strict) {
     for (const img of imageFiles) {
       const relPath = rel(img);

--- a/packages/plugin-docs-cli/src/validation/rules/assets.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/assets.ts
@@ -3,28 +3,13 @@ import type { Dirent } from 'node:fs';
 import { join, extname, dirname, relative, normalize } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
 import { ALLOWED_IMAGE_EXTENSIONS } from './filesystem.js';
-import { isMetaFile } from './utils.js';
+import { formatBytes, isMetaFile } from './utils.js';
 
 const IMAGE_FILE_NAME_RE = /^[a-zA-Z0-9\-_.]+$/;
 const MAX_STATIC_SIZE = 300 * 1024; // 300KB
 const MAX_GIF_SIZE = 1024 * 1024; // 1MB
 const MAX_TOTAL_SIZE = 5 * 1024 * 1024; // 5MB
 const MAX_DATA_URI_SIZE = 300 * 1024; // 300KB
-
-/**
- * Formats a byte count as a human-readable string.
- */
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes}B`;
-  }
-  const kb = bytes / 1024;
-  if (kb < 1024) {
-    return `${Math.round(kb)}KB`;
-  }
-  const mb = kb / 1024;
-  return `${mb.toFixed(1)}MB`;
-}
 
 /**
  * Finds the 1-based line number of the first occurrence of a string in content.

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.test.ts
@@ -36,10 +36,13 @@ describe('checkFilesystem', () => {
     expect(findings.find((f) => f.rule === Rule.HasMarkdown)).toBeUndefined();
   });
 
-  it('should report has-markdown-files when docs path does not exist', async () => {
+  it('should report docs-path-exists (and nothing else) when docs path does not exist', async () => {
     const findings = await checkFilesystem({ docsPath: '/nonexistent/path', strict: true });
 
-    expect(findings.find((f) => f.rule === Rule.HasMarkdown)).toBeDefined();
+    const finding = findings.find((f) => f.rule === Rule.DocsPathExists);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(findings).toHaveLength(1);
   });
 
   it('should report has-markdown-files for empty directory', async () => {
@@ -335,5 +338,71 @@ describe('checkFilesystem', () => {
     expect(finding).toBeDefined();
     expect(finding!.file).toContain(join('a', 'b', 'c', 'd', 'index.md'));
     expect(finding!.title).toContain('4 levels');
+  });
+
+  it('should report max-total-pages as error in strict mode when over the limit', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    for (let i = 0; i < 50; i++) {
+      await writeFile(join(tmp, `page-${i}.md`), `---\ntitle: Page ${i}\n---\n`);
+    }
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    const finding = findings.find((f) => f.rule === Rule.MaxTotalPages);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(finding!.title).toContain('51');
+  });
+
+  it('should report max-total-pages as info in non-strict mode when over the limit', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    for (let i = 0; i < 50; i++) {
+      await writeFile(join(tmp, `page-${i}.md`), `---\ntitle: Page ${i}\n---\n`);
+    }
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: false });
+
+    const finding = findings.find((f) => f.rule === Rule.MaxTotalPages);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('info');
+  });
+
+  it('should not report max-total-pages at or under the limit', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    for (let i = 0; i < 49; i++) {
+      await writeFile(join(tmp, `page-${i}.md`), `---\ntitle: Page ${i}\n---\n`);
+    }
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    expect(findings.find((f) => f.rule === Rule.MaxTotalPages)).toBeUndefined();
+  });
+
+  it('should report max-total-docs-size only in strict mode when over the limit', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+    await mkdir(join(tmp, 'img'));
+    // one file just over the 10MB total-docs-size limit
+    await writeFile(join(tmp, 'img', 'big.png'), Buffer.alloc(11 * 1024 * 1024));
+
+    const strictFindings = await checkFilesystem({ docsPath: tmp, strict: true });
+    const finding = strictFindings.find((f) => f.rule === Rule.MaxTotalDocsSize);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('warning');
+
+    const nonStrictFindings = await checkFilesystem({ docsPath: tmp, strict: false });
+    expect(nonStrictFindings.find((f) => f.rule === Rule.MaxTotalDocsSize)).toBeUndefined();
+  });
+
+  it('should not report max-total-docs-size under the limit', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'docs-test-'));
+    await writeFile(join(tmp, 'index.md'), '---\ntitle: Home\n---\n');
+
+    const findings = await checkFilesystem({ docsPath: tmp, strict: true });
+
+    expect(findings.find((f) => f.rule === Rule.MaxTotalDocsSize)).toBeUndefined();
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -47,14 +47,23 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     // docs-path-exists: docsPath is set in plugin.json but the folder isn't there (or isn't
     // readable). Every other filesystem/frontmatter/asset check is meaningless without it, so
     // report just this and stop.
-    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
-      diagnostics.push({
-        rule: Rule.DocsPathExists,
-        severity: 'error',
-        title: 'docsPath does not exist',
-        detail: `"${input.docsPath}" does not exist. Check that "docsPath" in src/plugin.json points to an existing directory.`,
-      });
-    }
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+
+    diagnostics.push({
+      rule: Rule.DocsPathExists,
+      severity: 'error',
+      title:
+        code === 'ENOENT'
+          ? 'docsPath does not exist'
+          : code === 'ENOTDIR'
+            ? 'docsPath is not a directory'
+            : 'docsPath is not readable',
+      detail:
+        code === 'ENOENT'
+          ? `"${input.docsPath}" does not exist. Check that "docsPath" in src/plugin.json points to an existing directory.`
+          : `"${input.docsPath}" could not be read (${code ?? 'unknown error'}). Check that it is a directory and that you have permission to read it.`,
+    });
+
     return diagnostics;
   }
 

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -138,7 +138,7 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
     });
   }
 
-  // max-total-docs-size: only checked in strict mode (serve = '-')
+  // max-total-docs-size: only checked under `validate` (not `serve`)
   if (input.strict) {
     let totalSize = 0;
     for (const file of entries) {

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -1,4 +1,4 @@
-import { readdir } from 'node:fs/promises';
+import { readdir, stat } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, extname, relative, sep } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
@@ -10,11 +10,32 @@ const SLUG_SAFE_RE = /^[a-z0-9-]+$/;
 // max path segments from the docs root (e.g. `a/b/page.md` is 3)
 const MAX_NESTING_DEPTH = 3;
 
+// max total size of everything in the docs folder combined
+const MAX_TOTAL_DOCS_SIZE = 10 * 1024 * 1024; // 10MB
+
+// max number of documentation pages
+const MAX_TOTAL_PAGES = 50;
+
 // permitted image formats shared across filesystem and asset rules
 export const ALLOWED_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif']);
 
 // allowed file extensions in the docs folder (.md + permitted image formats)
 export const ALLOWED_EXTENSIONS = new Set(['.md', ...ALLOWED_IMAGE_EXTENSIONS]);
+
+/**
+ * Formats a byte count as a human-readable string.
+ */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${Math.round(kb)}KB`;
+  }
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)}MB`;
+}
 
 export async function checkFilesystem(input: ValidationInput): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];
@@ -22,8 +43,19 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
   let entries: Dirent[] = [];
   try {
     entries = await readdir(input.docsPath, { recursive: true, withFileTypes: true });
-  } catch {
-    // docsPath doesn't exist or isn't readable
+  } catch (err) {
+    // docs-path-exists: docsPath is set in plugin.json but the folder isn't there (or isn't
+    // readable). Every other filesystem/frontmatter/asset check is meaningless without it, so
+    // report just this and stop.
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      diagnostics.push({
+        rule: Rule.DocsPathExists,
+        severity: 'error',
+        title: 'docsPath does not exist',
+        detail: `"${input.docsPath}" does not exist. Check that "docsPath" in src/plugin.json points to an existing directory.`,
+      });
+    }
+    return diagnostics;
   }
 
   // skip repo-meta files (README.md, CONTRIBUTING.md etc.) at the source so
@@ -85,6 +117,40 @@ export async function checkFilesystem(input: ValidationInput): Promise<Diagnosti
       detail:
         'The docs folder must contain at least one markdown file. Add markdown files with valid frontmatter to get started.',
     });
+  }
+
+  // max-total-pages
+  if (mdFiles.length > MAX_TOTAL_PAGES) {
+    diagnostics.push({
+      rule: Rule.MaxTotalPages,
+      severity: input.strict ? 'error' : 'info',
+      title: `Too many documentation pages (${mdFiles.length}, max ${MAX_TOTAL_PAGES})`,
+      detail: `The docs folder has ${mdFiles.length} pages, which exceeds the ${MAX_TOTAL_PAGES}-page limit. Consolidate related pages or split the plugin's documentation into a linked external resource.`,
+    });
+  }
+
+  // max-total-docs-size: only checked in strict mode (serve = '-')
+  if (input.strict) {
+    let totalSize = 0;
+    for (const file of entries) {
+      if (!file.isFile()) {
+        continue;
+      }
+      try {
+        const st = await stat(join(file.parentPath, file.name));
+        totalSize += st.size;
+      } catch {
+        continue;
+      }
+    }
+    if (totalSize > MAX_TOTAL_DOCS_SIZE) {
+      diagnostics.push({
+        rule: Rule.MaxTotalDocsSize,
+        severity: 'warning',
+        title: `Docs folder exceeds ${formatBytes(MAX_TOTAL_DOCS_SIZE)} limit`,
+        detail: `The docs folder is ${formatBytes(totalSize)} in total, which exceeds the ${formatBytes(MAX_TOTAL_DOCS_SIZE)} limit. Reduce the number or size of pages and images.`,
+      });
+    }
   }
 
   // root-index-exists

--- a/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/filesystem.ts
@@ -2,7 +2,7 @@ import { readdir, stat } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, extname, relative, sep } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
-import { isMetaFile } from './utils.js';
+import { formatBytes, isMetaFile } from './utils.js';
 
 // slug-safe: lowercase letters, digits and hyphens only
 const SLUG_SAFE_RE = /^[a-z0-9-]+$/;
@@ -21,21 +21,6 @@ export const ALLOWED_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp
 
 // allowed file extensions in the docs folder (.md + permitted image formats)
 export const ALLOWED_EXTENSIONS = new Set(['.md', ...ALLOWED_IMAGE_EXTENSIONS]);
-
-/**
- * Formats a byte count as a human-readable string.
- */
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes}B`;
-  }
-  const kb = bytes / 1024;
-  if (kb < 1024) {
-    return `${Math.round(kb)}KB`;
-  }
-  const mb = kb / 1024;
-  return `${mb.toFixed(1)}MB`;
-}
 
 export async function checkFilesystem(input: ValidationInput): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
@@ -7,7 +7,7 @@ import { Rule } from '../types.js';
 
 const input = (docsPath: string) => ({ docsPath, strict: true });
 
-// a description long enough to clear the 20-char min-content-length floor introduced by
+// a description long enough to clear the 20-char min-description-length floor introduced by
 // frontmatter-description-length, so tests unrelated to that rule don't trip it incidentally
 const GOOD_DESCRIPTION = 'A page with enough detail to describe what it covers';
 

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.test.ts
@@ -7,10 +7,20 @@ import { Rule } from '../types.js';
 
 const input = (docsPath: string) => ({ docsPath, strict: true });
 
+// a description long enough to clear the 20-char min-content-length floor introduced by
+// frontmatter-description-length, so tests unrelated to that rule don't trip it incidentally
+const GOOD_DESCRIPTION = 'A page with enough detail to describe what it covers';
+
+// body content long enough to clear the 150-char min-content-length floor (with margin, since
+// some tests prepend a short heading to this), for tests that aren't themselves about page length
+const LONG_BODY =
+  'This page has enough body content to clear the minimum content length check on its own, ' +
+  'so tests that are not themselves about page length are not affected by that rule.';
+
 describe('checkFrontmatter', () => {
   it('should report missing required fields', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
-    await writeFile(join(tmp, 'page.md'), '---\ntitle: Hello\n---\n# Hi\n');
+    await writeFile(join(tmp, 'page.md'), `---\ntitle: Hello\n---\n# Hi\n\n${LONG_BODY}\n`);
 
     const findings = await checkFrontmatter(input(tmp));
     expect(findings).toHaveLength(2); // 1 missing description + 1 h1 warning
@@ -44,7 +54,7 @@ describe('checkFrontmatter', () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
     await writeFile(
       join(tmp, 'index.md'),
-      '---\ntitle: Home\ndescription: Welcome\nsidebar_position: 1\n---\n## Introduction\n'
+      `---\ntitle: Home\ndescription: ${GOOD_DESCRIPTION}\nsidebar_position: 1\n---\n## Introduction\n\n${LONG_BODY}\n`
     );
 
     const findings = await checkFrontmatter(input(tmp));
@@ -55,7 +65,7 @@ describe('checkFrontmatter', () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
     await writeFile(
       join(tmp, 'page.md'),
-      '---\ntitle: Page\ndescription: A page\nsidebar_position: 1\nslug: custom-slug\n---\n## Content\n'
+      `---\ntitle: Page\ndescription: ${GOOD_DESCRIPTION}\nsidebar_position: 1\nslug: custom-slug\n---\n## Content\n\n${LONG_BODY}\n`
     );
 
     const findings = await checkFrontmatter(input(tmp));
@@ -65,10 +75,13 @@ describe('checkFrontmatter', () => {
   it('should include line numbers for wrong field types', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
     // title on line 2, description on line 3
-    await writeFile(join(tmp, 'page.md'), '---\ntitle: 123\ndescription: Valid\nsidebar_position: 1\n---\n');
+    await writeFile(
+      join(tmp, 'page.md'),
+      `---\ntitle: 123\ndescription: Valid\nsidebar_position: 1\n---\n\n${LONG_BODY}\n`
+    );
 
     const findings = await checkFrontmatter(input(tmp));
-    expect(findings).toHaveLength(1);
+    expect(findings).toHaveLength(2); // wrong type for title + description shorter than the 20-char minimum
     const titleError = findings.find((f) => f.rule === Rule.FieldTypes && f.title.includes('title'));
     expect(titleError).toBeDefined();
     expect(titleError!.line).toBe(2);
@@ -78,7 +91,7 @@ describe('checkFrontmatter', () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
     await writeFile(
       join(tmp, 'page.md'),
-      '---\ntitle: Page\ndescription: A page\nsidebar_position: 1\n---\n\n# Big Heading\n'
+      `---\ntitle: Page\ndescription: ${GOOD_DESCRIPTION}\nsidebar_position: 1\n---\n\n# Big Heading\n\n${LONG_BODY}\n`
     );
 
     const findings = await checkFrontmatter(input(tmp));
@@ -198,7 +211,7 @@ describe('checkFrontmatter', () => {
 
   it('should report no-duplicate-sidebar-position as warning in non-strict mode', async () => {
     const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
-    const fm = (pos: number) => `---\ntitle: Page\ndescription: A page\nsidebar_position: ${pos}\n---\n`;
+    const fm = (pos: number) => `---\ntitle: Page\ndescription: ${GOOD_DESCRIPTION}\nsidebar_position: ${pos}\n---\n`;
     await writeFile(join(tmp, 'a.md'), fm(1));
     await writeFile(join(tmp, 'b.md'), fm(1));
 
@@ -248,5 +261,94 @@ describe('checkFrontmatter', () => {
 
     const findings = await checkFrontmatter(input(tmp));
     expect(findings.find((f) => f.rule === Rule.DuplicateSlug)).toBeUndefined();
+  });
+
+  it('should report frontmatter-title-length as error in strict mode for a title over 60 characters', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const longTitle = 'A'.repeat(61);
+    await writeFile(
+      join(tmp, 'page.md'),
+      `---\ntitle: ${longTitle}\ndescription: ${GOOD_DESCRIPTION}\n---\n\n${LONG_BODY}\n`
+    );
+
+    const findings = await checkFrontmatter(input(tmp));
+    const finding = findings.find((f) => f.rule === Rule.TitleLength);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+  });
+
+  it('should report frontmatter-title-length as info in non-strict mode', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const longTitle = 'A'.repeat(61);
+    await writeFile(join(tmp, 'page.md'), `---\ntitle: ${longTitle}\ndescription: ${GOOD_DESCRIPTION}\n---\n`);
+
+    const findings = await checkFrontmatter({ docsPath: tmp, strict: false });
+    const finding = findings.find((f) => f.rule === Rule.TitleLength);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('info');
+  });
+
+  it('should not report frontmatter-title-length for a title at or under 60 characters', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const title = 'A'.repeat(60);
+    await writeFile(
+      join(tmp, 'page.md'),
+      `---\ntitle: ${title}\ndescription: ${GOOD_DESCRIPTION}\n---\n\n${LONG_BODY}\n`
+    );
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings.find((f) => f.rule === Rule.TitleLength)).toBeUndefined();
+  });
+
+  it('should report frontmatter-description-length for a description under 20 characters', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(join(tmp, 'page.md'), `---\ntitle: Page\ndescription: Too short\n---\n\n${LONG_BODY}\n`);
+
+    const findings = await checkFrontmatter(input(tmp));
+    const finding = findings.find((f) => f.rule === Rule.DescriptionLength);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(finding!.title).toContain('shorter');
+  });
+
+  it('should report frontmatter-description-length for a description over 160 characters', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    const longDescription = 'A'.repeat(161);
+    await writeFile(join(tmp, 'page.md'), `---\ntitle: Page\ndescription: ${longDescription}\n---\n\n${LONG_BODY}\n`);
+
+    const findings = await checkFrontmatter(input(tmp));
+    const finding = findings.find((f) => f.rule === Rule.DescriptionLength);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('error');
+    expect(finding!.title).toContain('exceeds');
+  });
+
+  it('should not report frontmatter-description-length for a description within range', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(join(tmp, 'page.md'), `---\ntitle: Page\ndescription: ${GOOD_DESCRIPTION}\n---\n\n${LONG_BODY}\n`);
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings.find((f) => f.rule === Rule.DescriptionLength)).toBeUndefined();
+  });
+
+  it('should report min-content-length only in strict mode for a very short page', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(join(tmp, 'page.md'), `---\ntitle: Page\ndescription: ${GOOD_DESCRIPTION}\n---\n\nToo short.\n`);
+
+    const strictFindings = await checkFrontmatter(input(tmp));
+    const finding = strictFindings.find((f) => f.rule === Rule.MinContentLength);
+    expect(finding).toBeDefined();
+    expect(finding!.severity).toBe('info');
+
+    const nonStrictFindings = await checkFrontmatter({ docsPath: tmp, strict: false });
+    expect(nonStrictFindings.find((f) => f.rule === Rule.MinContentLength)).toBeUndefined();
+  });
+
+  it('should not report min-content-length for a page with enough body content', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'fm-test-'));
+    await writeFile(join(tmp, 'page.md'), `---\ntitle: Page\ndescription: ${GOOD_DESCRIPTION}\n---\n\n${LONG_BODY}\n`);
+
+    const findings = await checkFrontmatter(input(tmp));
+    expect(findings.find((f) => f.rule === Rule.MinContentLength)).toBeUndefined();
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -13,6 +13,14 @@ const REQUIRED_FIELDS: Array<{ key: string; type: string }> = [
 // optional fields: validated only when present
 const OPTIONAL_FIELDS: Array<{ key: string; type: string }> = [{ key: 'sidebar_position', type: 'number' }];
 
+// SEO conventions: search engines truncate title/description around these lengths
+const MAX_TITLE_LENGTH = 60;
+const MIN_DESCRIPTION_LENGTH = 20;
+const MAX_DESCRIPTION_LENGTH = 160;
+
+// below this, a page body is almost certainly a stub rather than real content
+const MIN_CONTENT_LENGTH = 150;
+
 /**
  * Checks whether a custom slug is safe for use in URLs.
  * Mirrors the logic in scanner.ts normalizeCustomSlug.
@@ -129,8 +137,9 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
 
     // frontmatter-valid-yaml: gray-matter throws on invalid YAML
     let data: Record<string, unknown>;
+    let body: string;
     try {
-      ({ data } = matter(raw));
+      ({ data, content: body } = matter(raw));
     } catch (err) {
       diagnostics.push({
         rule: Rule.ValidYaml,
@@ -178,6 +187,54 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
           detail: `"${key}" should be a ${type} but got ${typeof data[key]}.`,
         });
       }
+    }
+
+    // frontmatter-title-length: search engines truncate long titles in results
+    if (typeof data.title === 'string' && data.title.length > MAX_TITLE_LENGTH) {
+      diagnostics.push({
+        rule: Rule.TitleLength,
+        severity: input.strict ? 'error' : 'info',
+        file: relativePath,
+        line: findFieldLine(raw, 'title'),
+        title: `Title exceeds ${MAX_TITLE_LENGTH} characters`,
+        detail: `"title" is ${data.title.length} characters. Search engines truncate titles around ${MAX_TITLE_LENGTH} characters, so shorten it.`,
+      });
+    }
+
+    // frontmatter-description-length: search engines truncate long descriptions, and a very
+    // short one usually means it hasn't been written yet
+    if (typeof data.description === 'string') {
+      if (data.description.length < MIN_DESCRIPTION_LENGTH) {
+        diagnostics.push({
+          rule: Rule.DescriptionLength,
+          severity: input.strict ? 'error' : 'info',
+          file: relativePath,
+          line: findFieldLine(raw, 'description'),
+          title: `Description is shorter than ${MIN_DESCRIPTION_LENGTH} characters`,
+          detail: `"description" is ${data.description.length} characters. Write a fuller sentence describing what's on this page.`,
+        });
+      } else if (data.description.length > MAX_DESCRIPTION_LENGTH) {
+        diagnostics.push({
+          rule: Rule.DescriptionLength,
+          severity: input.strict ? 'error' : 'info',
+          file: relativePath,
+          line: findFieldLine(raw, 'description'),
+          title: `Description exceeds ${MAX_DESCRIPTION_LENGTH} characters`,
+          detail: `"description" is ${data.description.length} characters. Search engines truncate descriptions around ${MAX_DESCRIPTION_LENGTH} characters, so shorten it.`,
+        });
+      }
+    }
+
+    // min-content-length: only checked in strict mode (serve = '-'); catches pages stubbed
+    // out with just a title and a sentence
+    if (input.strict && body.trim().length < MIN_CONTENT_LENGTH) {
+      diagnostics.push({
+        rule: Rule.MinContentLength,
+        severity: 'info',
+        file: relativePath,
+        title: 'Page content is very short',
+        detail: `This page has ${body.trim().length} characters of content, under the ${MIN_CONTENT_LENGTH}-character guideline. Add more detail, or remove the page if it isn't needed.`,
+      });
     }
 
     // check custom slug if present

--- a/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/frontmatter.ts
@@ -225,7 +225,7 @@ export async function checkFrontmatter(input: ValidationInput): Promise<Diagnost
       }
     }
 
-    // min-content-length: only checked in strict mode (serve = '-'); catches pages stubbed
+    // min-content-length: only checked under `validate` (not `serve`); catches pages stubbed
     // out with just a title and a sentence
     if (input.strict && body.trim().length < MIN_CONTENT_LENGTH) {
       diagnostics.push({

--- a/packages/plugin-docs-cli/src/validation/rules/stub-content.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/stub-content.test.ts
@@ -88,4 +88,29 @@ describe('checkStubContent', () => {
     expect(files).toContain('index.md');
     expect(files).toContain('options.md');
   });
+
+  it('treats stubs as informational when the author opts in, so a fresh scaffold validates clean', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'stub-test-'));
+    await writeFile(
+      join(tmp, 'index.md'),
+      md('<!-- section-brief:start -->\n\n> Fill me in\n\n<!-- section-brief:end -->')
+    );
+
+    const findings = await checkStubContent({ docsPath: tmp, strict: true, allowUnfilledStubs: true });
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('info');
+  });
+
+  it('still errors for the publishing check, which never opts in', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'stub-test-'));
+    await writeFile(
+      join(tmp, 'index.md'),
+      md('<!-- section-brief:start -->\n\n> Fill me in\n\n<!-- section-brief:end -->')
+    );
+
+    const findings = await checkStubContent({ docsPath: tmp, strict: true });
+
+    expect(findings[0].severity).toBe('error');
+  });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/stub-content.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/stub-content.ts
@@ -1,13 +1,25 @@
 import { readFile, readdir } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, relative } from 'node:path';
-import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
+import { type Diagnostic, type Severity, type ValidationInput, Rule } from '../types.js';
 import { isMetaFile } from './utils.js';
 
 // matches the opening marker of a section-brief authoring-guidance block,
-// scaffolded by `create-plugin add panel-docs`/`datasource-docs` as a
-// placeholder for the author to replace with real content.
+// scaffolded by `create-plugin add docs` as a placeholder for the author to
+// replace with real content.
 const SECTION_BRIEF_START_RE = /<!--\s*section-brief:start\s*-->/;
+
+/**
+ * A stub is only a defect at the point of publishing. While the author is still writing, the count
+ * is a to-do list, so `allowUnfilledStubs` keeps it out of the error and warning tallies entirely -
+ * a freshly scaffolded docs folder should validate clean.
+ */
+function stubSeverity(input: ValidationInput): Severity {
+  if (input.allowUnfilledStubs) {
+    return 'info';
+  }
+  return input.strict ? 'error' : 'warning';
+}
 
 /**
  * Checks that no page still contains an unfilled `section-brief` block. A
@@ -50,7 +62,7 @@ export async function checkStubContent(input: ValidationInput): Promise<Diagnost
       }
       diagnostics.push({
         rule: Rule.UnfilledSectionBrief,
-        severity: input.strict ? 'error' : 'warning',
+        severity: stubSeverity(input),
         file: relativePath,
         line: i + 1,
         title: 'Unfilled documentation stub',

--- a/packages/plugin-docs-cli/src/validation/rules/utils.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isMetaFile, maskInlineCode } from './utils.js';
+import { formatBytes, isMetaFile, maskInlineCode } from './utils.js';
 
 describe('isMetaFile', () => {
   it('matches README.md regardless of case', () => {
@@ -39,6 +39,23 @@ describe('isMetaFile', () => {
     expect(isMetaFile('readme-tips.md')).toBe(false);
     expect(isMetaFile('contributing-quickstart.md')).toBe(false);
     expect(isMetaFile('agents-of-shield.md')).toBe(false);
+  });
+});
+
+describe('formatBytes', () => {
+  it('formats sub-kilobyte counts as bytes', () => {
+    expect(formatBytes(0)).toBe('0B');
+    expect(formatBytes(512)).toBe('512B');
+  });
+
+  it('formats kilobyte counts, rounded', () => {
+    expect(formatBytes(1024)).toBe('1KB');
+    expect(formatBytes(1536)).toBe('2KB');
+  });
+
+  it('formats megabyte counts to one decimal place', () => {
+    expect(formatBytes(1024 * 1024)).toBe('1.0MB');
+    expect(formatBytes(5.5 * 1024 * 1024)).toBe('5.5MB');
   });
 });
 

--- a/packages/plugin-docs-cli/src/validation/rules/utils.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.ts
@@ -49,6 +49,21 @@ export function maskInlineCode(line: string): string {
 }
 
 /**
+ * Formats a byte count as a human-readable string.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${Math.round(kb)}KB`;
+  }
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)}MB`;
+}
+
+/**
  * Returns a set of 1-based line numbers inside fenced code blocks.
  */
 export function getCodeBlockLines(content: string): Set<number> {

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -11,6 +11,9 @@ export const Rule = {
   NoSymlinks: 'no-symlinks',
   AllowedFileTypes: 'allowed-file-types',
   MaxNestingDepth: 'max-nesting-depth',
+  DocsPathExists: 'docs-path-exists',
+  MaxTotalDocsSize: 'max-total-docs-size',
+  MaxTotalPages: 'max-total-pages',
   // frontmatter rules
   BlockExists: 'frontmatter-block-exists',
   ValidYaml: 'frontmatter-valid-yaml',
@@ -20,6 +23,9 @@ export const Rule = {
   NoH1: 'no-h1-heading',
   DuplicatePosition: 'no-duplicate-sidebar-position',
   DuplicateSlug: 'no-duplicate-slugs',
+  TitleLength: 'frontmatter-title-length',
+  DescriptionLength: 'frontmatter-description-length',
+  MinContentLength: 'min-content-length',
   // content-completeness rules
   UnfilledSectionBrief: 'unfilled-section-brief',
   // asset rules

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -73,6 +73,15 @@ export interface Diagnostic {
 export interface ValidationInput {
   docsPath: string;
   strict: boolean;
+  /**
+   * Treat leftover `section-brief` scaffolding as progress rather than a defect.
+   *
+   * Docs scaffolded by `create-plugin add docs` are all stub, by design - reporting that back as
+   * errors turns "you ran the command successfully" into a red build. Authoring tools pass this so
+   * the count is informational while the pages are being written. The publishing check never passes
+   * it, so half-written docs still cannot reach the catalog.
+   */
+  allowUnfilledStubs?: boolean;
 }
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds six validation rules to `plugin-docs-cli`: `docs-path-exists` (a missing `docsPath` in `plugin.json` now reports a proper diagnostic instead of a misleading `has-markdown-files` error), `max-total-pages` (50) and `max-total-docs-size` (10MB), `frontmatter-title-length` (60 chars) and `frontmatter-description-length` (20-160 chars) following standard SEO truncation conventions, and `min-content-length` (150 chars) flagging likely-stub pages. All follow the existing `serve`/`validate` severity pattern and were verified against a real plugin's docs to produce no false positives.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
