### PR TITLE
fix(create-plugin): preserve 'add' changeType when updating a newly added file

### DIFF
--- a/packages/create-plugin/src/codemods/context.test.ts
+++ b/packages/create-plugin/src/codemods/context.test.ts
@@ -62,11 +62,15 @@ describe('Context', () => {
 
   describe('updateFile', () => {
     it('should update a file in the context', () => {
+      const context = new Context(`${__dirname}/migrations/fixtures`);
+      context.updateFile('foo/bar.ts', 'new content');
+      expect(context.listChanges()).toEqual({ 'foo/bar.ts': { content: 'new content', changeType: 'update' } });
+    });
+
+    it("should preserve the 'add' changeType when updating a file that was added in the current context", () => {
       const context = new Context();
       context.addFile('file.txt', 'content');
       context.updateFile('file.txt', 'new content');
-      // Stays 'add': the file was staged fresh in this context, so flushChanges still needs to
-      // mkdir its (possibly nonexistent) parent directory rather than treat it as an in-place update.
       expect(context.listChanges()).toEqual({ 'file.txt': { content: 'new content', changeType: 'add' } });
     });
 

--- a/packages/create-plugin/src/codemods/context.test.ts
+++ b/packages/create-plugin/src/codemods/context.test.ts
@@ -65,7 +65,9 @@ describe('Context', () => {
       const context = new Context();
       context.addFile('file.txt', 'content');
       context.updateFile('file.txt', 'new content');
-      expect(context.listChanges()).toEqual({ 'file.txt': { content: 'new content', changeType: 'update' } });
+      // Stays 'add': the file was staged fresh in this context, so flushChanges still needs to
+      // mkdir its (possibly nonexistent) parent directory rather than treat it as an in-place update.
+      expect(context.listChanges()).toEqual({ 'file.txt': { content: 'new content', changeType: 'add' } });
     });
 
     it('should not update a file if it does not exist', () => {

--- a/packages/create-plugin/src/codemods/context.ts
+++ b/packages/create-plugin/src/codemods/context.ts
@@ -58,7 +58,10 @@ export class Context {
     }
 
     if (originalContent !== content) {
-      this.files[path] = { content, changeType: 'update' };
+      // Preserve 'add' so a file added earlier in this same context (its directory may not exist on
+      // disk yet) doesn't get downgraded to 'update' and fail to write.
+      const changeType = this.files[path]?.changeType === 'add' ? 'add' : 'update';
+      this.files[path] = { content, changeType };
     } else {
       codemodsDebug(`Context.updateFile() - no updates for ${filePath}`);
     }


### PR DESCRIPTION
Context.updateFile() previously downgraded 'add' to 'update' whenever content
changed, even if the file was staged in the same context. Since flushChanges
relies on changeType to decide whether to mkdir the parent directory, this
caused writes to fail for files added and then updated before being flushed.

Part of https://github.com/grafana/plugin-tools/issues/2842