### PR TITLE
feat(plugin-docs-cli): add writing-style validation rules

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,5 @@
 
 # Renovate config should not be formatted by prettier
 /.github/renovate.json
+
+/packages/plugin-docs-cli/src/validation/rules/style.ts

--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -23,8 +23,7 @@ async function main() {
     console.error('  serve      Start the local docs preview server');
     console.error('  build      Build docs for publishing (generates manifest, copies to dist/)');
     console.error('  validate   Validate documentation (--json for machine-readable output,');
-    console.error('             --allow-unfilled-stubs while docs are still being written,');
-    console.error('             --no-style to skip writing-style rules)');
+    console.error('             --allow-unfilled-stubs while docs are still being written)');
     process.exit(1);
   }
 
@@ -78,23 +77,17 @@ async function main() {
     }
     case 'validate': {
       const validateArgv = minimist(process.argv.slice(3), {
-        boolean: ['strict', 'json', 'allow-unfilled-stubs', 'style'],
-        string: ['style-level'],
+        boolean: ['strict', 'json', 'allow-unfilled-stubs'],
         default: {
           strict: true,
           json: false,
           'allow-unfilled-stubs': false,
-          style: true,
         },
       });
-      // `--no-style` turns writing-style rules off; `--style-level=error` opts into failing on
-      // them, which is off by default so house style never blocks a plugin release.
-      const style = !validateArgv.style ? 'off' : validateArgv['style-level'] === 'error' ? 'error' : 'on';
       await validateCommand(docsPath, {
         strict: validateArgv.strict,
         json: validateArgv.json,
         allowUnfilledStubs: validateArgv['allow-unfilled-stubs'],
-        style,
       });
       break;
     }

--- a/packages/plugin-docs-cli/src/bin/run.ts
+++ b/packages/plugin-docs-cli/src/bin/run.ts
@@ -23,7 +23,8 @@ async function main() {
     console.error('  serve      Start the local docs preview server');
     console.error('  build      Build docs for publishing (generates manifest, copies to dist/)');
     console.error('  validate   Validate documentation (--json for machine-readable output,');
-    console.error('             --allow-unfilled-stubs while docs are still being written)');
+    console.error('             --allow-unfilled-stubs while docs are still being written,');
+    console.error('             --no-style to skip writing-style rules)');
     process.exit(1);
   }
 
@@ -77,17 +78,23 @@ async function main() {
     }
     case 'validate': {
       const validateArgv = minimist(process.argv.slice(3), {
-        boolean: ['strict', 'json', 'allow-unfilled-stubs'],
+        boolean: ['strict', 'json', 'allow-unfilled-stubs', 'style'],
+        string: ['style-level'],
         default: {
           strict: true,
           json: false,
           'allow-unfilled-stubs': false,
+          style: true,
         },
       });
+      // `--no-style` turns writing-style rules off; `--style-level=error` opts into failing on
+      // them, which is off by default so house style never blocks a plugin release.
+      const style = !validateArgv.style ? 'off' : validateArgv['style-level'] === 'error' ? 'error' : 'on';
       await validateCommand(docsPath, {
         strict: validateArgv.strict,
         json: validateArgv.json,
         allowUnfilledStubs: validateArgv['allow-unfilled-stubs'],
+        style,
       });
       break;
     }

--- a/packages/plugin-docs-cli/src/commands/validate.command.ts
+++ b/packages/plugin-docs-cli/src/commands/validate.command.ts
@@ -7,18 +7,29 @@ const debug = createDebug('plugin-docs-cli:validate');
 
 export async function validateCommand(
   docsPath: string,
-  options: { strict: boolean; json: boolean; allowUnfilledStubs?: boolean } = { strict: true, json: false }
+  options: {
+    strict: boolean;
+    json: boolean;
+    allowUnfilledStubs?: boolean;
+    style?: 'on' | 'off' | 'error';
+  } = { strict: true, json: false }
 ): Promise<void> {
   debug(
-    'Validating docs at: %s (strict: %s, json: %s, allowUnfilledStubs: %s)',
+    'Validating docs at: %s (strict: %s, json: %s, allowUnfilledStubs: %s, style: %s)',
     docsPath,
     options.strict,
     options.json,
-    options.allowUnfilledStubs ?? false
+    options.allowUnfilledStubs ?? false,
+    options.style ?? 'on'
   );
 
   const result = await validate(
-    { docsPath, strict: options.strict, allowUnfilledStubs: options.allowUnfilledStubs },
+    {
+      docsPath,
+      strict: options.strict,
+      allowUnfilledStubs: options.allowUnfilledStubs,
+      style: options.style,
+    },
     allRules
   );
 

--- a/packages/plugin-docs-cli/src/commands/validate.command.ts
+++ b/packages/plugin-docs-cli/src/commands/validate.command.ts
@@ -11,16 +11,14 @@ export async function validateCommand(
     strict: boolean;
     json: boolean;
     allowUnfilledStubs?: boolean;
-    style?: 'on' | 'off' | 'error';
   } = { strict: true, json: false }
 ): Promise<void> {
   debug(
-    'Validating docs at: %s (strict: %s, json: %s, allowUnfilledStubs: %s, style: %s)',
+    'Validating docs at: %s (strict: %s, json: %s, allowUnfilledStubs: %s)',
     docsPath,
     options.strict,
     options.json,
-    options.allowUnfilledStubs ?? false,
-    options.style ?? 'on'
+    options.allowUnfilledStubs ?? false
   );
 
   const result = await validate(
@@ -28,7 +26,6 @@ export async function validateCommand(
       docsPath,
       strict: options.strict,
       allowUnfilledStubs: options.allowUnfilledStubs,
-      style: options.style,
     },
     allRules
   );

--- a/packages/plugin-docs-cli/src/server/server.ts
+++ b/packages/plugin-docs-cli/src/server/server.ts
@@ -44,12 +44,29 @@ export async function startServer(options: ServerOptions): Promise<Server> {
   app.set('view engine', 'ejs');
   app.set('views', join(__dirname, 'views'));
 
-  // run validation in non-strict mode and log results without blocking
+  // run validation in non-strict mode and log results without blocking. this reruns on every
+  // save, so writing-style findings are collapsed to a single line - printing all of them would
+  // bury the structural problems the author actually has to fix.
   const runValidation = async () => {
     try {
       const result = await validate({ docsPath, strict: false }, allRules);
-      if (result.diagnostics.length > 0) {
-        console.log(formatResult(result));
+      const styleFindings = result.diagnostics.filter((d) => d.rule.startsWith('style-'));
+      const rest = { ...result, diagnostics: result.diagnostics.filter((d) => !d.rule.startsWith('style-')) };
+
+      if (rest.diagnostics.length > 0) {
+        console.log(formatResult(rest));
+      }
+      if (styleFindings.length > 0) {
+        const warnings = styleFindings.filter((d) => d.severity === 'warning').length;
+        const suggestions = styleFindings.length - warnings;
+        const parts: string[] = [];
+        if (warnings > 0) {
+          parts.push(`${warnings} writing-style warning${warnings === 1 ? '' : 's'}`);
+        }
+        if (suggestions > 0) {
+          parts.push(`${suggestions} suggestion${suggestions === 1 ? '' : 's'}`);
+        }
+        console.log(`  ${parts.join(', ')} - run \`docs:validate\` to see them\n`);
       }
     } catch (error) {
       console.error('Validation failed:', error instanceof Error ? error.message : error);

--- a/packages/plugin-docs-cli/src/validation/format.test.ts
+++ b/packages/plugin-docs-cli/src/validation/format.test.ts
@@ -64,6 +64,36 @@ describe('formatResult', () => {
     expect(output).toContain('page.md:7');
   });
 
+  it('should print errors before warnings and info, regardless of collection order', () => {
+    const result: ValidationResult = {
+      valid: false,
+      diagnostics: [
+        { rule: Rule.NestedDirIndex, severity: 'warning', title: 'A warning', detail: '' },
+        { rule: Rule.AllowedFileTypes, severity: 'info', title: 'An info', detail: '' },
+        { rule: Rule.HasMarkdown, severity: 'error', title: 'An error', detail: '' },
+      ],
+    };
+    const output = formatResult(result);
+    const errorIndex = output.indexOf('An error');
+    const warningIndex = output.indexOf('A warning');
+    const infoIndex = output.indexOf('An info');
+    expect(errorIndex).toBeLessThan(warningIndex);
+    expect(warningIndex).toBeLessThan(infoIndex);
+  });
+
+  it('should keep the relative order of diagnostics within the same severity', () => {
+    const result: ValidationResult = {
+      valid: false,
+      diagnostics: [
+        { rule: Rule.NestedDirIndex, severity: 'warning', title: 'First warning', detail: '' },
+        { rule: Rule.HasMarkdown, severity: 'error', title: 'The error', detail: '' },
+        { rule: Rule.ValidSlug, severity: 'warning', title: 'Second warning', detail: '' },
+      ],
+    };
+    const output = formatResult(result);
+    expect(output.indexOf('First warning')).toBeLessThan(output.indexOf('Second warning'));
+  });
+
   it('should handle mixed severities', () => {
     const result: ValidationResult = {
       valid: false,

--- a/packages/plugin-docs-cli/src/validation/format.ts
+++ b/packages/plugin-docs-cli/src/validation/format.ts
@@ -6,6 +6,12 @@ const SEVERITY_LABEL: Record<Severity, string> = {
   info: 'info ',
 };
 
+const SEVERITY_RANK: Record<Severity, number> = {
+  error: 0,
+  warning: 1,
+  info: 2,
+};
+
 /**
  * Formats a validation result as human-readable text.
  */
@@ -46,13 +52,20 @@ export function formatResult(result: ValidationResult): string {
     lines.push('');
   }
 
-  for (const d of result.diagnostics) {
+  // errors first, so the things that actually block validation aren't buried among warnings.
+  // a stable sort keeps each severity's diagnostics in the order rules produced them.
+  const sorted = [...result.diagnostics].sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]);
+
+  for (const d of sorted) {
     const label = SEVERITY_LABEL[d.severity] ?? d.severity;
     const location = d.file ? (d.line ? `  ${d.file}:${d.line}` : `  ${d.file}`) : '';
     lines.push(`  ${label}${location}`);
     lines.push(`         ${d.title}`);
     if (d.detail) {
       lines.push(`         ${d.detail}`);
+    }
+    if (d.url) {
+      lines.push(`         ${d.url}`);
     }
     lines.push('');
   }

--- a/packages/plugin-docs-cli/src/validation/rules/index.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/index.ts
@@ -6,6 +6,7 @@ import { checkFrontmatter } from './frontmatter.js';
 import { checkManifest } from './manifest.js';
 import { checkMarkdown } from './markdown.js';
 import { checkStubContent } from './stub-content.js';
+import { checkWritingStyle } from './style.js';
 
 export const allRules: RuleRunner[] = [
   checkFilesystem,
@@ -15,4 +16,6 @@ export const allRules: RuleRunner[] = [
   checkStubContent,
   checkCrossFile,
   checkManifest,
+  // last, so writing-style advice renders below the findings an author has to act on
+  checkWritingStyle,
 ];

--- a/packages/plugin-docs-cli/src/validation/rules/markdown.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/markdown.ts
@@ -2,7 +2,7 @@ import { readFile, readdir } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
 import { join, relative } from 'node:path';
 import { type Diagnostic, type ValidationInput, Rule } from '../types.js';
-import { getCodeBlockLines, isMetaFile, maskInlineCode } from './utils.js';
+import { getCodeBlockLines, isMetaFile, matchOutsideCode } from './utils.js';
 
 // matches HTML tags like <div>, <span class="x">, </p>, <br/>, <img src="..." />
 const HTML_TAG_RE = /< *\/?([a-zA-Z][a-zA-Z0-9]*)\b[^>]*\/?>/g;
@@ -33,34 +33,6 @@ const EXTERNAL_URL_RE = /^https?:\/\//i;
 
 // matches path traversal
 const PATH_TRAVERSAL_RE = /(?:^|\/)\.\.\//;
-
-/**
- * Tests a regex against content lines, skipping code blocks.
- * Returns all matches with their line numbers.
- */
-function matchOutsideCode(
-  content: string,
-  re: RegExp,
-  codeLines: Set<number>,
-  options?: { maskInlineCode?: boolean }
-): Array<{ match: RegExpExecArray; line: number }> {
-  const results: Array<{ match: RegExpExecArray; line: number }> = [];
-  const lines = content.split('\n');
-
-  for (let i = 0; i < lines.length; i++) {
-    if (codeLines.has(i + 1)) {
-      continue;
-    }
-    const lineText = options?.maskInlineCode ? maskInlineCode(lines[i]) : lines[i];
-    const lineRe = new RegExp(re.source, re.flags);
-    let m: RegExpExecArray | null;
-    while ((m = lineRe.exec(lineText)) !== null) {
-      results.push({ match: m, line: i + 1 });
-    }
-  }
-
-  return results;
-}
 
 export async function checkMarkdown(input: ValidationInput): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];

--- a/packages/plugin-docs-cli/src/validation/rules/style.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/style.test.ts
@@ -148,18 +148,6 @@ describe('checkWritingStyle', () => {
         expect(findings.find((f) => f.rule === 'style-timeless')!.severity).toBe('info');
       }
     });
-
-    it('should skip every rule when style is off', async () => {
-      const tmp = await withDoc('Please configure the datasource!');
-      expect(await checkWritingStyle(input(tmp, { style: 'off' }))).toHaveLength(0);
-    });
-
-    it('should escalate to error only when explicitly opted in', async () => {
-      const tmp = await withDoc('Please configure the datasource!');
-      const findings = await checkWritingStyle(input(tmp, { style: 'error' }));
-      expect(findings.length).toBeGreaterThan(0);
-      expect(findings.every((f) => f.severity === 'error')).toBe(true);
-    });
   });
 
   describe('noise control', () => {

--- a/packages/plugin-docs-cli/src/validation/rules/style.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/style.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
-import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { checkWritingStyle, toStyleRuleId, ALLOWED_RULES, REJECTED_RULES, VALE_RULES } from './style.js';
 import { validate } from '../engine.js';
@@ -227,15 +227,6 @@ describe('vendored rule integrity', () => {
   it('should not both allow and reject the same rule', () => {
     for (const name of Object.keys(ALLOWED_RULES)) {
       expect(REJECTED_RULES).not.toHaveProperty(name);
-    }
-  });
-
-  it('should document every rule in docs/validation-rules.md', async () => {
-    const doc = await readFile(new URL('../../../docs/validation-rules.md', import.meta.url), 'utf-8');
-    for (const rule of VALE_RULES) {
-      expect(doc, `${toStyleRuleId(rule.name)} is missing from validation-rules.md`).toContain(
-        toStyleRuleId(rule.name)
-      );
     }
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/style.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/style.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { mkdtemp, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { checkWritingStyle, toStyleRuleId, ALLOWED_RULES, REJECTED_RULES, VALE_RULES } from './style.js';
+import { validate } from '../engine.js';
+import { allRules } from './index.js';
+import type { ValidationInput } from '../types.js';
+
+const input = (docsPath: string, overrides: Partial<ValidationInput> = {}): ValidationInput => ({
+  docsPath,
+  strict: true,
+  ...overrides,
+});
+
+const md = (body = '') => `---\ntitle: Page\ndescription: A description with enough words in it\n---\n\n${body}`;
+
+async function withDoc(body: string): Promise<string> {
+  const tmp = await mkdtemp(join(tmpdir(), 'style-test-'));
+  await writeFile(join(tmp, 'index.md'), md(body));
+  return tmp;
+}
+
+describe('checkWritingStyle', () => {
+  it('should return no findings for a nonexistent docs path', async () => {
+    expect(await checkWritingStyle(input('/nonexistent/path'))).toHaveLength(0);
+  });
+
+  it('should skip repo-meta files such as README.md', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'style-test-'));
+    await writeFile(join(tmp, 'README.md'), md('Configure the datasource.'));
+    expect(await checkWritingStyle(input(tmp))).toHaveLength(0);
+  });
+
+  describe('rule behaviour', () => {
+    // each pair is [rule id, prose that trips it, prose that must not]. the negative case is
+    // deliberately the already-correct wording, since that is what the substitution guard protects.
+    const cases: Array<[string, string, string]> = [
+      ['style-word-list', 'Configure the datasource first.', 'Configure the data source first.'],
+      ['style-word-list', 'You need a github account.', 'You need a GitHub account.'],
+      ['style-word-list', 'Do this in order to continue.', 'Do this to continue.'],
+      ['style-refer-to', 'For more, see [Options](./options.md).', 'For more, refer to [Options](./options.md).'],
+      ['style-simple', 'This is a simple change to make.', 'This is a small change to make.'],
+      ['style-please', 'Please restart the server now.', 'Restart the server now.'],
+      ['style-latin', 'Use a query, e.g. a metric query.', 'Use a query, for example a metric query.'],
+      ['style-allows-to', 'This allows to configure the panel.', 'This allows you to configure the panel.'],
+      ['style-exclamation', 'That worked great!', 'That worked great.'],
+      ['style-and-or', 'Pick tables and/or graphs here.', 'Pick tables, graphs, or both.'],
+      ['style-repeated-words', 'This will be be applied later.', 'This is applied later.'],
+      ['style-google-em-dash', 'The panel — which is new — renders.', 'The panel, which is new, renders.'],
+      ['style-end-to-end', 'Write an E2E test for this.', 'Write an end-to-end test for this.'],
+      ['style-dialog-box', 'Open the modal to continue.', 'Open the dialog box to continue.'],
+      ['style-timeless', 'This is currently unsupported here.', 'This is unsupported here.'],
+    ];
+
+    it.each(cases)('%s should fire on the bad form but not the good one', async (ruleId, bad, good) => {
+      const badFindings = await checkWritingStyle(input(await withDoc(bad)));
+      expect(badFindings.map((f) => f.rule)).toContain(ruleId);
+
+      const goodFindings = await checkWritingStyle(input(await withDoc(good)));
+      expect(goodFindings.map((f) => f.rule)).not.toContain(ruleId);
+    });
+  });
+
+  describe('scope suppression', () => {
+    const offending = 'Configure the datasource.';
+
+    it('should ignore text inside a fenced code block', async () => {
+      const tmp = await withDoc(['Some prose here.', '', '```ts', `// ${offending}`, '```'].join('\n'));
+      expect(await checkWritingStyle(input(tmp))).toHaveLength(0);
+    });
+
+    it('should ignore text inside an inline code span', async () => {
+      const tmp = await withDoc('Set the `datasource` field on the panel.');
+      expect(await checkWritingStyle(input(tmp))).toHaveLength(0);
+    });
+
+    it('should ignore text inside a link target', async () => {
+      const tmp = await withDoc('Read the [setup guide](./configure-datasource.md) first.');
+      expect(await checkWritingStyle(input(tmp))).toHaveLength(0);
+    });
+
+    it('should ignore text inside frontmatter', async () => {
+      const tmp = await mkdtemp(join(tmpdir(), 'style-test-'));
+      await writeFile(
+        join(tmp, 'index.md'),
+        `---\ntitle: Datasource setup\ndescription: How to configure the datasource for this plugin\n---\n\nAll good here.\n`
+      );
+      expect(await checkWritingStyle(input(tmp))).toHaveLength(0);
+    });
+
+    it('should ignore text inside an HTML comment, including section briefs', async () => {
+      const tmp = await withDoc(
+        ['<!-- section-brief:start -->', '', `> Fill this in: ${offending}`, '', '<!-- section-brief:end -->'].join(
+          '\n'
+        )
+      );
+      expect(await checkWritingStyle(input(tmp))).toHaveLength(0);
+    });
+
+    it('should ignore text inside an indented code block', async () => {
+      const tmp = await withDoc(['Some prose here.', '', `    const x = 'datasource';`].join('\n'));
+      expect(await checkWritingStyle(input(tmp))).toHaveLength(0);
+    });
+  });
+
+  describe('severity', () => {
+    // the invariant that keeps house style from blocking a plugin release. plugin-validator maps a
+    // CLI `error` onto analysis.Error, which fails publishing.
+    const everyRuleTripped = [
+      'Please configure the datasource, e.g. a simple one!',
+      'This allows to pick tables and/or graphs, see [Options](./o.md).',
+      'It will be be currently unsupported — for now — in the modal.',
+    ].join('\n\n');
+
+    it('should never report an error, in either strict mode', async () => {
+      const tmp = await withDoc(everyRuleTripped);
+      for (const strict of [true, false]) {
+        const findings = await checkWritingStyle(input(tmp, { strict }));
+        expect(findings.length).toBeGreaterThan(0);
+        expect(findings.every((f) => f.severity !== 'error')).toBe(true);
+      }
+    });
+
+    it('should keep a docs tree valid when its only problems are writing style', async () => {
+      // no markdown link here, so the only findings can come from the style rules
+      const styleOnly = 'Please configure the datasource, e.g. a simple one!\n\nIt will be be currently in the modal.';
+      const tmp = await withDoc(`${styleOnly}\n\n${'Body text to clear the minimum length check. '.repeat(5)}`);
+      const result = await validate(input(tmp), allRules);
+      const styleFindings = result.diagnostics.filter((d) => d.rule.startsWith('style-'));
+      expect(styleFindings.length).toBeGreaterThan(0);
+      expect(result.diagnostics.filter((d) => d.severity === 'error')).toHaveLength(0);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should keep the warn tier at warning in both modes', async () => {
+      const tmp = await withDoc('Please restart the server.');
+      for (const strict of [true, false]) {
+        const findings = await checkWritingStyle(input(tmp, { strict }));
+        expect(findings.find((f) => f.rule === 'style-please')!.severity).toBe('warning');
+      }
+    });
+
+    it('should keep the info tier at info in both modes', async () => {
+      const tmp = await withDoc('This is currently unsupported.');
+      for (const strict of [true, false]) {
+        const findings = await checkWritingStyle(input(tmp, { strict }));
+        expect(findings.find((f) => f.rule === 'style-timeless')!.severity).toBe('info');
+      }
+    });
+
+    it('should skip every rule when style is off', async () => {
+      const tmp = await withDoc('Please configure the datasource!');
+      expect(await checkWritingStyle(input(tmp, { style: 'off' }))).toHaveLength(0);
+    });
+
+    it('should escalate to error only when explicitly opted in', async () => {
+      const tmp = await withDoc('Please configure the datasource!');
+      const findings = await checkWritingStyle(input(tmp, { style: 'error' }));
+      expect(findings.length).toBeGreaterThan(0);
+      expect(findings.every((f) => f.severity === 'error')).toBe(true);
+    });
+  });
+
+  describe('noise control', () => {
+    it('should cap findings per rule per file', async () => {
+      const tmp = await withDoc(
+        Array.from({ length: 12 }, (_, i) => `Line ${i} mentions the datasource.`).join('\n\n')
+      );
+      const findings = await checkWritingStyle(input(tmp));
+      expect(findings.filter((f) => f.rule === 'style-word-list')).toHaveLength(5);
+    });
+
+    it('should apply a rule-specific lower cap', async () => {
+      const tmp = await withDoc(Array.from({ length: 4 }, (_, i) => `Please do step ${i}.`).join('\n\n'));
+      const findings = await checkWritingStyle(input(tmp));
+      expect(findings.filter((f) => f.rule === 'style-please')).toHaveLength(1);
+    });
+
+    it('should not flag future tense on a deprecation line', async () => {
+      const tmp = await withDoc('Support will be removed in 12.0.\n\nThe panel will render the series.');
+      const findings = await checkWritingStyle(input(tmp)).then((f) => f.filter((x) => x.rule === 'style-google-will'));
+      expect(findings).toHaveLength(1);
+      expect(findings[0].line).toBeGreaterThan(5);
+    });
+
+    it('should honour a rule exception list', async () => {
+      const tmp = await withDoc('Enable read-only-mode for this panel.');
+      const findings = await checkWritingStyle(input(tmp));
+      expect(findings.map((f) => f.rule)).not.toContain('style-google-ly-hyphens');
+    });
+  });
+
+  describe('diagnostic shape', () => {
+    it('should carry a toolkit url so the full rule can be looked up on demand', async () => {
+      const tmp = await withDoc('For more, see [Options](./options.md).');
+      const finding = (await checkWritingStyle(input(tmp))).find((f) => f.rule === 'style-refer-to');
+      expect(finding!.url).toContain('grafana.com/docs/writers-toolkit');
+      expect(finding!.file).toBe('index.md');
+      expect(finding!.line).toBeGreaterThan(0);
+    });
+
+    it('should name the preferred wording in the title', async () => {
+      const tmp = await withDoc('Configure the datasource.');
+      const finding = (await checkWritingStyle(input(tmp))).find((f) => f.rule === 'style-word-list');
+      expect(finding!.title).toContain('data source');
+      expect(finding!.title).not.toContain('%s');
+    });
+
+    it('should keep the title to a single line', async () => {
+      const tmp = await withDoc('Please configure the datasource, e.g. a simple one!');
+      for (const finding of await checkWritingStyle(input(tmp))) {
+        expect(finding.title).not.toContain('\n');
+      }
+    });
+  });
+});
+
+describe('vendored rule integrity', () => {
+  it('should derive style ids from the upstream rule name', () => {
+    expect(toStyleRuleId('ReferTo')).toBe('style-refer-to');
+    expect(toStyleRuleId('GoogleEmDash')).toBe('style-google-em-dash');
+    expect(toStyleRuleId('SQL')).toBe('style-sql');
+  });
+
+  it('should have a vendored definition for every allowlisted rule', () => {
+    const defined = new Set(VALE_RULES.map((r) => r.name));
+    for (const name of Object.keys(ALLOWED_RULES)) {
+      expect(defined, `${name} is allowlisted but has no vendored definition`).toContain(name);
+    }
+  });
+
+  it('should not define a rule that is absent from the allowlist', () => {
+    for (const rule of VALE_RULES) {
+      expect(ALLOWED_RULES, `${rule.name} is defined but not allowlisted`).toHaveProperty(rule.name);
+    }
+  });
+
+  it('should not both allow and reject the same rule', () => {
+    for (const name of Object.keys(ALLOWED_RULES)) {
+      expect(REJECTED_RULES).not.toHaveProperty(name);
+    }
+  });
+
+  it('should document every rule in docs/validation-rules.md', async () => {
+    const doc = await readFile(new URL('../../../docs/validation-rules.md', import.meta.url), 'utf-8');
+    for (const rule of VALE_RULES) {
+      expect(doc, `${toStyleRuleId(rule.name)} is missing from validation-rules.md`).toContain(
+        toStyleRuleId(rule.name)
+      );
+    }
+  });
+});

--- a/packages/plugin-docs-cli/src/validation/rules/style.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/style.ts
@@ -372,7 +372,14 @@ export async function checkWritingStyle(input: ValidationInput): Promise<Diagnos
     return diagnostics;
   }
 
-  const mdFiles = entries.filter((e) => e.isFile() && e.name.endsWith('.md') && !isMetaFile(e.name));
+  const mdFiles = entries.filter(
+    (e) =>
+      e.isFile() &&
+      e.name.endsWith('.md') &&
+      !isMetaFile(e.name) &&
+      !e.parentPath.includes('node_modules') &&
+      !e.parentPath.includes('dist')
+  );
 
   for (const entry of mdFiles) {
     const absPath = join(entry.parentPath, entry.name);

--- a/packages/plugin-docs-cli/src/validation/rules/style.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/style.ts
@@ -1,0 +1,450 @@
+import { readFile, readdir } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { join, relative } from 'node:path';
+import type { Diagnostic, Severity, StyleRuleId, ValidationInput } from '../types.js';
+import { getCodeBlockLines, getNonProseLines, isMetaFile, matchOutsideCode } from './utils.js';
+
+/**
+ * Applies a curated subset of the Grafana Writers' Toolkit's writing-style rules.
+ *
+ * The rule data below is copied by hand from `grafana/writers-toolkit` (Apache-2.0), which
+ * publishes Grafana's documentation style guide as Vale style files. We do not run Vale itself,
+ * or vendor its rule files: each rule we use is transcribed once into the `VALE_RULES` array
+ * below, so plugin authors get the same feedback without installing a separate binary. See
+ * `AGENTS.md` for how to add or update a rule.
+ *
+ * These are advice, never a gate. `plugin-validator` maps a CLI `error` onto a publishing block,
+ * and Grafana's in-house style is not grounds for refusing a third-party plugin release, so
+ * nothing here reaches `error` unless the caller explicitly opts in with `style: 'error'`.
+ */
+
+/**
+ * How loud a rule is. Writing style is advice, so `warn` is always `warning` and `info` is always
+ * `info`, in both `serve` and `validate`. Neither ever reaches `error`, because `plugin-validator`
+ * maps CLI `error` onto a publishing block and Grafana's house style is not grounds for refusing a
+ * third-party plugin release.
+ */
+export type StyleTier = 'warn' | 'info';
+
+export interface StyleOverride {
+  /** Defaults to `warn`. */
+  tier?: StyleTier;
+  /** Findings of this rule reported per file. Defaults to `MAX_FINDINGS_PER_RULE_PER_FILE`. */
+  limit?: number;
+  /** Matched text to ignore, compared case-sensitively against the whole match. */
+  exceptions?: readonly string[];
+  /** Lines matching this are skipped entirely, for contexts where the rule is legitimately wrong. */
+  skipLines?: RegExp;
+  /** Replaces the upstream token list. Only for rules whose upstream tokens are too broad for us. */
+  tokens?: readonly string[];
+  /** Appended to the diagnostic detail, to explain a non-obvious fix or a known false positive. */
+  note?: string;
+}
+
+/** No single rule may account for more than this many findings in one file. */
+export const MAX_FINDINGS_PER_RULE_PER_FILE = 5;
+
+/** A Vale rule definition, narrowed to the fields the Grafana style files actually use. */
+export interface ValeRule {
+  /** Upstream rule name, so `ReferTo` here is `Grafana.ReferTo` in the toolkit. */
+  name: string;
+  extends: 'existence' | 'substitution' | 'repetition';
+  level: 'error' | 'warning' | 'suggestion';
+  message: string;
+  link?: string;
+  /** `existence`: regex sources, any of which is a violation. */
+  tokens?: string[];
+  /** `substitution`: regex source mapped to the preferred wording. */
+  swap?: Record<string, string>;
+  ignorecase?: boolean;
+  /** When set, tokens are not wrapped in word boundaries. */
+  nonword?: boolean;
+  exceptions?: string[];
+  scope?: string;
+}
+
+/**
+ * Rule definitions transcribed from `grafana/writers-toolkit@457b7ca750945374d8df36328d10d0e997c82cd1`
+ * (Apache-2.0). Only rules listed in `ALLOWED_RULES` below belong here - see `AGENTS.md` for how to
+ * add or update one.
+ */
+export const VALE_RULES: readonly ValeRule[] = [
+  { name: "AllowsTo", extends: "substitution", level: "warning", message: "Did you mean '%s' instead of '%s'?\n\nAllows to is a common wording error.", swap: {"allows to":"allows you to|makes it possible to"} },
+  { name: "AndOr", extends: "existence", level: "warning", message: "Avoid writing and/or except when space is limited, such as in tables.\n\nOften, 'and' implies 'or', so you don't need to write both words.\n\nIf you need to specify both in your content, write something like \"You can export raw events, processed events, or both.\"", link: "https://developers.google.com/style/slashes#and-or", tokens: ["and/or"] },
+  { name: "Archives", extends: "substitution", level: "suggestion", message: "Use '%s' instead of '%s'.", link: "https://developers.google.com/style/word-list#extract", swap: {"[Uu]n(?:archive|compress|tar|zip)":"extract","unzip":"extract","[Zz][Ii][Pp](?: file)?":"archive|compressed file"} },
+  { name: "DialogBox", extends: "substitution", level: "warning", message: "Use '%s' rather than '%s'.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#dialog-box", swap: {"dialog box appears":"dialog box opens","modal":"dialog box","dialog(?! box)":"dialog box"} },
+  { name: "DropDown", extends: "substitution", level: "suggestion", message: "Use '%s' instead of '%s'.\n\nUse drop-down as a modifier rather than as a standalone noun. For example: _drop-down menu_.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#drop-down", swap: {"drop ?down":"drop-down"} },
+  { name: "EndToEnd", extends: "substitution", level: "warning", message: "Use '%s' instead of '%s'.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#end-to-end", swap: {"[eE]2[eE]":"end-to-end"} },
+  { name: "Exclamation", extends: "existence", level: "warning", message: "Remove the exclamation point.\n\nExclamation points make technical documentation feel informal and hyperbolic.", link: "https://developers.google.com/style/tone#some-things-to-avoid-where-possible", tokens: ["\\w+!(?:\\s|$)"], nonword: true },
+  { name: "GoogleAMPM", extends: "existence", level: "error", message: "Use 'AM' or 'PM' (preceded by a space).", link: "https://developers.google.com/style/word-list", tokens: ["\\d{1,2}[AP]M\\b","\\d{1,2} ?[ap]m\\b","\\d{1,2} ?[aApP]\\.[mM]\\."], nonword: true },
+  { name: "GoogleDateFormat", extends: "existence", level: "error", message: "Use 'July 31, 2016' format, not '%s'.", link: "https://developers.google.com/style/dates-times", tokens: ["\\d{1,2}(?:\\.|/)\\d{1,2}(?:\\.|/)\\d{4}","\\d{1,2} (?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)|May|Jun(?:e)|Jul(?:y)|Aug(?:ust)|Sep(?:tember)?|Oct(?:ober)|Nov(?:ember)?|Dec(?:ember)?) \\d{4}"], ignorecase: true, nonword: true },
+  { name: "GoogleEllipses", extends: "existence", level: "warning", message: "In general, don't use an ellipsis.", link: "https://developers.google.com/style/ellipses", tokens: ["\\.\\.\\."], nonword: true },
+  { name: "GoogleEmDash", extends: "existence", level: "error", message: "Don't put a space before or after a dash.", link: "https://developers.google.com/style/dashes", tokens: ["\\s[—–]\\s"], nonword: true },
+  { name: "GoogleEnDash", extends: "existence", level: "error", message: "Use an em dash ('—') instead of '–'.", link: "https://developers.google.com/style/dashes", tokens: ["–"], nonword: true },
+  { name: "GoogleGender", extends: "existence", level: "error", message: "Don't use '%s' as a gender-neutral pronoun.", link: "https://developers.google.com/style/pronouns#gender-neutral-pronouns", tokens: ["he/she","s/he","\\(s\\)he"], ignorecase: true },
+  { name: "GoogleGenderBias", extends: "substitution", level: "error", message: "Consider using '%s' instead of '%s'.", link: "https://developers.google.com/style/inclusive-documentation", swap: {"(?:alumnae|alumni)":"graduates","(?:alumna|alumnus)":"graduate","air(?:m[ae]n|wom[ae]n)":"pilot(s)","anchor(?:m[ae]n|wom[ae]n)":"anchor(s)","authoress":"author","camera(?:m[ae]n|wom[ae]n)":"camera operator(s)","door(?:m[ae]|wom[ae]n)":"concierge(s)","draft(?:m[ae]n|wom[ae]n)":"drafter(s)","fire(?:m[ae]n|wom[ae]n)":"firefighter(s)","fisher(?:m[ae]n|wom[ae]n)":"fisher(s)","fresh(?:m[ae]n|wom[ae]n)":"first-year student(s)","garbage(?:m[ae]n|wom[ae]n)":"waste collector(s)","lady lawyer":"lawyer","ladylike":"courteous","mail(?:m[ae]n|wom[ae]n)":"mail carriers","man and wife":"husband and wife","man enough":"strong enough","mankind":"human kind|humanity","manmade":"manufactured","manpower":"personnel","middle(?:m[ae]n|wom[ae]n)":"intermediary","news(?:m[ae]n|wom[ae]n)":"journalist(s)","ombuds(?:man|woman)":"ombuds","oneupmanship":"upstaging","poetess":"poet","police(?:m[ae]n|wom[ae]n)":"police officer(s)","repair(?:m[ae]n|wom[ae]n)":"technician(s)","sales(?:m[ae]n|wom[ae]n)":"salesperson or sales people","service(?:m[ae]n|wom[ae]n)":"soldier(s)","steward(?:ess)?":"flight attendant","tribes(?:m[ae]n|wom[ae]n)":"tribe member(s)","waitress":"waiter","woman doctor":"doctor","woman scientist[s]?":"scientist(s)","work(?:m[ae]n|wom[ae]n)":"worker(s)"}, ignorecase: true },
+  { name: "GoogleHeadingPunctuation", extends: "existence", level: "warning", message: "Don't put a period at the end of a heading.", link: "https://developers.google.com/style/capitalization#capitalization-in-titles-and-headings", tokens: ["[a-z0-9][.]\\s*$"], nonword: true, scope: "heading" },
+  { name: "GoogleLyHyphens", extends: "existence", level: "error", message: "'%s' doesn't need a hyphen.", link: "https://developers.google.com/style/hyphens", tokens: ["\\b[^\\s-]+ly-\\w+\\b"], nonword: true },
+  { name: "GoogleOptionalPlurals", extends: "existence", level: "error", message: "Don't use plurals in parentheses such as in '%s'.", link: "https://developers.google.com/style/plurals-parentheses", tokens: ["\\b\\w+\\(s\\)"], nonword: true },
+  { name: "GooglePeriods", extends: "existence", level: "error", message: "Don't use periods with acronyms or initialisms such as '%s'.", link: "https://developers.google.com/style/abbreviations", tokens: ["\\b(?:[A-Z]\\.){3,}"], nonword: true },
+  { name: "GoogleRanges", extends: "existence", level: "warning", message: "Don't add words such as 'from' or 'between' to describe a range of numbers.", link: "https://developers.google.com/style/hyphens", tokens: ["(?:from|between)\\s\\d+\\s?-\\s?\\d+"], nonword: true },
+  { name: "GoogleSlang", extends: "existence", level: "error", message: "Don't use internet slang abbreviations such as '%s'.", link: "https://developers.google.com/style/abbreviations", tokens: ["tl;dr","ymmv","rtfm","imo","fwiw"], ignorecase: true },
+  { name: "GoogleWill", extends: "existence", level: "warning", message: "Avoid using '%s'.\n\nUse present tense for statements that describe general behavior that's not associated with a particular time.", link: "https://developers.google.com/style/tense", tokens: ["will"], ignorecase: true },
+  { name: "Kubernetes", extends: "substitution", level: "warning", message: "Use '%s' instead of '%s'.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/capitalization-punctuation/#kubernetes-objects", swap: {"cron job":"CronJob","[Kk]ubernetes deployment":"Kubernetes Deployment","d[ae][ae]mon[Ss]et":"DaemonSet","replica[Ss]et":"ReplicaSet","stateful[Ss]et":"StatefulSet","pod":"Pod","[Kk]ubelet":"`kubelet`","[Kk]ubectl":"`kubectl`"} },
+  { name: "Latin", extends: "substitution", level: "error", message: "Use '%s' instead of '%s'.\n\nLatin abbreviations such as 'e.g.' and 'i.e.' are easily confused with each other and with other abbreviations.\nSpelling them out improves clarity, especially for readers who aren't native English speakers.", link: "https://developers.google.com/style/abbreviations#dont-use", swap: {"e\\.?g[,.]?":"for example","i\\.?e[,.]?":"that is"}, ignorecase: true },
+  { name: "OK", extends: "existence", level: "warning", message: "Don't use any variation of okay in prose.\nThe exceptions are when you’re referencing or quoting:\n\n- A user interface\n- HTTP status codes or other code", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#ok-okay", tokens: ["O.K.","OK","ok","Ok","Okay","okay","A-OK","hokay","k","keh","kk","M'kay","oka","okeh","Okie dokie","Okily Dokily"] },
+  { name: "Ordinal", extends: "existence", level: "error", message: "Replace this numeral ordinal with a word.\n\nWrite out ordinals from first through ninth as words, and use numerals from 10th onward.\nFor example, use 'first', 'second', and 'third', not '1st', '2nd', and '3rd'.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#numbers", tokens: ["1st","2nd","3rd","4th","5th","6th","7th","8th","9th"] },
+  { name: "Please", extends: "existence", level: "error", message: "Remove 'please' from instructions.\n\nDirect imperative sentences are clearer and more appropriate in technical documentation.\nExcessive politeness reads as filler and adds length without improving comprehension.", link: "https://developers.google.com/style/tone#politeness", tokens: ["please"], ignorecase: true },
+  { name: "Quickstart", extends: "substitution", level: "warning", message: "Use the compound adjective '%s' without a hyphen instead of '%s' whether the noun is implied or explicit. For example, you can use _quickstart guide_ or just _quickstart_.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#quickstart", swap: {"quick start":"quickstart"} },
+  { name: "React", extends: "substitution", level: "warning", message: "Use '%s' instead of '%s'.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#react", swap: {"[Rr]eact[. ]?[Jj][Ss]":"React"}, nonword: true },
+  { name: "ReferTo", extends: "substitution", level: "error", message: "When linking in Markdown, use '%s' instead of '%s'.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/style-conventions/#links-and-references", swap: {"Check out \\[":"Refer to [","See \\[":"Refer to [","check out \\[":"refer to [","see \\[":"refer to ["}, scope: "raw" },
+  { name: "RepeatedWords", extends: "repetition", level: "error", message: "'%s' is repeated.\n\nRemove the duplicate word.", tokens: ["[^\\s]+"] },
+  { name: "SQL", extends: "substitution", level: "warning", message: "Use '%s' instead of '%s'.\n\nThe article—a or an—that you use before the acronym SQL depends on how the word is pronounced.\n\nWhen referring to the product Microsoft SQL Server, SQL should be pronounced \"sequel\".\nIn this case, use the article 'a', as in \"a SQL Server analysis\".\n\nWhen referring to the term in any other context, such as SQL databases, errors, or servers, SQL should be pronounced \"ess-cue-el\".\nIn this case, use the article 'an', as in \"an SQL error\".", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#sql-structured-query-language", swap: {"[Aa] SQL server":"an SQL server|a SQL Server","[Aa] SQL(?! [Ss]erver)":"an SQL","[Aa]n SQL Server":"a SQL Server"} },
+  { name: "Simple", extends: "existence", level: "warning", message: "Avoid the word easy or simple -- what might be simple for you might not be simple for others.\n\nTry eliminating this word from the sentence because usually you can convey the same meaning without it.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/#simple", tokens: ["easy(?![ -]to[ -]understand)","easily","simple","simply"], exceptions: ["easy to understand","easy-to-understand"] },
+  { name: "Timeless", extends: "existence", level: "suggestion", message: "Avoid using '%s' to keep the documentation timeless.\n\nIn general, document the current version of a product or feature.\n\nIt reduces the maintenance required to keep documentation up to date.\nIt avoids assuming the reader is familiar with earlier versions of the product.\n\nIf you're writing procedural or time-stamped content such as press releases, blog posts, or release notes, such time-based words and phrases are OK.", link: "https://developers.google.com/style/timeless-documentation", tokens: ["as of this writing","currently","does not yet","eventually","existing","future","in the future","latest","new","newer","now","old","older","presently","at present","soon"] },
+  { name: "Wish", extends: "substitution", level: "warning", message: "Use '%s' instead of '%s'.\n\n'Wish' is informal and vague in technical writing.\nUse 'need' when the reader requires something to proceed, or 'want' when describing an optional goal.", link: "https://developers.google.com/style/word-list#wish", swap: {"wish":"need|want"} },
+  { name: "WordList", extends: "substitution", level: "warning", message: "Use '%s' instead of '%s'.", link: "https://grafana.com/docs/writers-toolkit/write/style-guide/word-list/", swap: {"(?:(?<!Data )Firehose|Kinesis Data Firehose|Kinesis Firehose)":"Data Firehose","(?:SHA-1|HAS-SHA1)":"SHA-1","(?:WiFi|wifi)":"Wi-Fi","(?:[Oo]penshift|openShift)":"OpenShift","(?:[eE]-mail)":"email","(?:[jJ][mM][eE][sS]p|jmesP)ath":"JMESPath","(?:[oO]pentelemetry|openTelemetry)":"OpenTelemetry","(?:alert[Mm]anager|[Aa]lert [Mm]anager|AlertManager)":"Alertmanager","(?:cell ?phone|smart ?phone)":"phone|mobile phone","(?:content|media)-?type":"media type","(?:file ?path|path ?name)":"path","(?:file ?path|path ?name)s":"paths","(?:github|gitHub|Github)":"GitHub","(?:gitlab|gitLab|Gitlab)":"GitLab","(?:gitleaks|gitLeaks|GitLeaks)":"Gitleaks","(?:hamburger menu|kebab menu)":"menu icon","(?:java[Ss]cript|Javascript)":"JavaScript","(?:kill|terminate|abort)":"stop|exit|cancel|end","(?<!kube-)prometheus":"Prometheus","(?<!lambda-)promtail":"Promtail","GME":"GEM","Grafana AI observability":"Grafana AI Observability","HTTPs":"HTTPS","Influx[Dd]b":"InfluxDB","Influxd[Bb]":"InfluxDB","Once":"After","Pagerduty":"PagerDuty","RCA Workbench":"RCA workbench","Rudderstack":"RudderStack","VMWare":"VMware","Vmware":"VMware","[Ww]orld [Ww]ide [Ww]eb":"web","[cC]entos":"CentOS","\\b(?:[aA]daptive metrics|adaptive Metrics)\\b":"Adaptive Metrics","ad[- ]?hoc":"free-form|user-written","back[ -]end":"backend","blacklist":"blocklist","blacklisted":"blocklisted","blacklisting":"blocklisting","blacklists":"blocklists","cadvisor":"cAdvisor","check[- ]box":"checkbox","content type":"media type","data-?source":"data source","data-?sources":"data sources","data[- ]?set":"dataset","data[- ]?sets":"datasets","datacenter":"data center","datacenters":"data centers","de-duplicate":"deduplicate","de-duplicated":"deduplicated","de-duplicates":"deduplicates","de-duplication":"deduplication","fewer data":"less data","figma":"Figma","file name":"filename","file names":"filenames","firewalls":"firewall rules","front[ -]end":"frontend","front[ -]ends":"frontends","git":"Git","grafana":"Grafana","grayed-out":"unavailable","gunicorn":"Gunicorn","in order to":"to","influx[Dd][Bb]":"InfluxDB","jsonnet":"Jsonnet","kotlin":"Kotlin","langchain":"LangChain","left[- ]hand[- ]side":"left-side","log(?:ql|QL)":"LogQL","loki":"Loki","lucene":"Lucene","markdown":"Markdown","memcached":"Memcached","meta[- ]data":"metadata","mix[- ]in":"mixin","multitenancy":"multi-tenancy","mysql":"MySQL","network IP address":"internal IP address","open-source":"open source","otel":"OTel","otlp":"OTLP","pager[dD]uty":"PagerDuty","phlare":"Phlare","postgres":"Postgres","postgresql":"PostgreSQL","prom(?:ql|QL)":"PromQL","redis":"Redis","regex[ep]?s":"regular expression","regexp?":"regular expression","repo":"repository","repos":"repositories","right[- ]hand[- ]side":"right-side","rudderstack":"RudderStack","sensu":"Sensu","sign into":"sign in to","sqlite":"SQLite","style sheet":"stylesheet","style sheets":"stylesheet","synch":"sync","synched":"synced","synching":"syncing","tempo":"Tempo","the Grafana Agent":"Grafana Agent","the RCA [Ww]orkbench":"RCA workbench","threema":"Threema","timeseries":"time series|time-series","trace(?:ql|QL)":"TraceQL","un(?:check|select)":"clear","url":"URL","urls":"URLs","vmware":"VMware","vs\\.":"versus","webex":"Webex","whitelist":"allowlist","whitelisted":"allowlisted","whitelisting":"allowlisting","whitelists":"allowlists","yugabyte":"YugabyteDB"} },
+];
+
+/**
+ * Upstream rules we deliberately do not run, with the reason. Kept as a structured record (not
+ * just a comment) so it is easy to check whether a rule has already been considered, and to search
+ * for a specific name, before adding a new one.
+ */
+export const REJECTED_RULES: Readonly<Record<string, string>> = {
+  // Hugo-specific. plugin docs are plain Markdown, so these range from unreachable to harmful.
+  Admonitions: 'Requires the Hugo admonition shortcode, which plugin docs forbid.',
+  Relref: 'Checks Hugo relref shortcodes, which cannot appear in plugin docs.',
+  Shortcodes: 'Checks Hugo shortcode syntax, which cannot appear in plugin docs.',
+  Paragraphs: 'Targets <br> in Hugo tables; no-raw-html already covers the concern.',
+
+  // Grafana-internal conventions with no meaning for a third-party plugin vendor.
+  Admin: 'Grafana role naming.',
+  Agentless: 'Grafana Alloy migration terminology.',
+  AmazonCloudWatch: 'Grafana data source naming convention.',
+  CHANGELOG: 'Grafana repository file convention.',
+  DatadogProxy: 'Grafana-internal product naming.',
+  DocumentationTeam: 'Grafana-internal team naming.',
+  MetaMonitoring: 'Grafana-internal product naming.',
+  PrometheusExporters: 'Curated vendor list that goes stale and rarely applies to one plugin.',
+  ProductPossessives: 'A 300-entry literal product list, almost none of it relevant per plugin.',
+  README: 'Grafana repository file convention.',
+  SelfManaged: 'Grafana deployment-model terminology.',
+
+  // Need data we do not ship.
+  Headings:
+    'Sentence case needs the 400-entry proper-noun list; without it we would flag Snowflake, ClickHouse and ServiceNow.',
+  GoogleSpelling: 'Needs the Grafana Hunspell dictionary.',
+  Acronyms: 'Needs the upstream acronym exception list.',
+
+  // Too many false positives, or no fix the author can act on.
+  GooglePassive: 'Config reference prose is legitimately passive ("is required", "is enabled by default").',
+  Parentheses: 'Matches every "(for example, ...)" and "(default: 30s)" with no actionable fix.',
+  GoogleFirstPerson: 'Matches region strings and sample identifiers.',
+  FirstPersonPlural: 'A plugin vendor referring to themselves is legitimate.',
+  GoogleOxfordComma: 'Suggestion-level and prone to false positives on list-like prose.',
+  GoogleContractions: 'Stylistic preference, suggestion-level upstream.',
+  GoogleSemicolons: 'Stylistic preference, suggestion-level upstream.',
+  OAuth: 'Demands "OAuth 2.0" for every mention of OAuth, which is too specific for plugin docs.',
+  GoogleSpacing: 'Its [a-z][.?!][A-Z] pattern matches every dotted identifier, such as a `log.WithContext` link label.',
+  GrafanaCom: 'About which grafana.com URL form Grafana uses internally.',
+  // Vale implements these as Tengo scripts rather than patterns, so there is nothing to interpret.
+  // AltText, CommandLinePrompts and SmartQuotes are worth reimplementing by hand later - they are
+  // high value and near-zero false positive - but they cannot come from the vendored definitions.
+  AltText: 'Script-based upstream. Worth reimplementing natively.',
+  CommandLinePrompts: 'Script-based upstream. Worth reimplementing natively.',
+  SmartQuotes: 'Script-based upstream. Worth reimplementing natively.',
+  Gerunds: 'Script-based upstream, and the task-versus-concept call needs judgement.',
+
+  // Curated third-party product name lists: large, quick to go stale and rarely relevant to any
+  // single plugin. The handful that matter for plugin docs are in WordList already.
+  AmazonProductNames: 'Curated vendor list, rarely relevant per plugin.',
+  ApacheProjectNames: 'Curated vendor list, rarely relevant per plugin.',
+  GoogleProductNames: 'Curated vendor list, rarely relevant per plugin.',
+  PalantirProductNames: 'Curated vendor list, rarely relevant per plugin.',
+
+  // Whole-document grade-level scores. They produce one number with nothing to act on, which is the
+  // wrong shape for a write-validate-fix loop.
+  ReadabilityAutomatedReadability: 'Document-level readability score with no actionable fix.',
+  ReadabilityColemanLiau: 'Document-level readability score with no actionable fix.',
+  ReadabilityFleschKincaid: 'Document-level readability score with no actionable fix.',
+  ReadabilityFleschReadingEase: 'Document-level readability score with no actionable fix.',
+  ReadabilityGunningFog: 'Document-level readability score with no actionable fix.',
+  ReadabilityLIX: 'Document-level readability score with no actionable fix.',
+  ReadabilitySMOG: 'Document-level readability score with no actionable fix.',
+
+  Spelling: 'Needs the Grafana Hunspell dictionary.',
+};
+
+/**
+ * The upstream rules we run, keyed by their Vale name. An empty object means "take the upstream
+ * definition as-is at the default `warn` tier".
+ */
+export const ALLOWED_RULES: Readonly<Record<string, StyleOverride>> = {
+  // word choice and terminology
+  WordList: {},
+  ReferTo: {},
+  AllowsTo: {},
+  DialogBox: {},
+  DropDown: {},
+  EndToEnd: {},
+  Quickstart: {},
+  Archives: { tier: 'info' },
+  Latin: {},
+  OK: {},
+  Wish: {},
+
+  // product names that come up in plugin docs
+  React: {},
+  SQL: {},
+  Kubernetes: {},
+
+  // tone
+  Simple: {},
+  Please: { limit: 1 },
+  Exclamation: {},
+  AndOr: {},
+  GoogleSlang: {},
+
+  // inclusive language
+  GoogleGender: {},
+  GoogleGenderBias: {},
+
+  // tense and time
+  GoogleWill: {
+    // future tense is correct in deprecation and roadmap notices, which is also where `will` shows
+    // up most in plugin docs. quiet enough to be worth keeping, not confident enough to warn.
+    tier: 'info',
+    limit: 3,
+    skipLines: /deprecat|\bremov|\bv?\d+\.\d+/i,
+    note: 'Future tense is fine for deprecations and roadmap notes.',
+  },
+  Timeless: {
+    // upstream also flags `new`, `newer`, `old`, `older`, `latest`, `existing`, `now` and `future`,
+    // which are correct constantly in plugin docs ("the latest version of Grafana", "your existing
+    // dashboards"). keep only the phrases that genuinely date a page.
+    tier: 'info',
+    tokens: ['as of this writing', 'at present', 'presently', 'currently', 'in the future', 'eventually', 'soon'],
+  },
+
+  // punctuation and mechanics
+  GoogleEmDash: {},
+  GoogleEnDash: {},
+  GoogleEllipses: {},
+  GooglePeriods: {},
+  GoogleRanges: {},
+  GoogleOptionalPlurals: {},
+  GoogleHeadingPunctuation: {},
+  GoogleLyHyphens: {
+    // upstream's `\b[^\s-]+ly-\w+\b` matches any word ending in "ly" before a hyphen, so compounds
+    // like `read-only-mode` trip it even though "only" is not an adverb here.
+    exceptions: ['only-', 'early-', 'family-', 'supply-', 'apply-', 'assembly-', 'anomaly-'],
+  },
+  RepeatedWords: {},
+  GoogleAMPM: {},
+  GoogleDateFormat: {},
+  Ordinal: {},
+};
+
+/** One compiled check. A substitution rule produces one of these per swap entry. */
+interface Matcher {
+  ruleId: StyleRuleId;
+  valeName: string;
+  tier: StyleTier;
+  pattern: RegExp;
+  /** Preferred wording, for substitution rules. May offer alternatives separated by `|`. */
+  suggestion?: string;
+  message: string;
+  link?: string;
+  note?: string;
+  exceptions: readonly string[];
+  skipLines?: RegExp;
+  limit: number;
+  scope?: string;
+}
+
+/** `Grafana.ReferTo` is reported as `style-refer-to`. */
+export function toStyleRuleId(valeName: string): StyleRuleId {
+  const kebab = valeName
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+  return `style-${kebab}`;
+}
+
+function wrap(source: string, nonword: boolean | undefined): string {
+  return nonword ? source : `\\b(?:${source})\\b`;
+}
+
+function compile(rule: ValeRule): Matcher[] {
+  const override = ALLOWED_RULES[rule.name] ?? {};
+  const flags = rule.ignorecase ? 'gi' : 'g';
+  const base = {
+    ruleId: toStyleRuleId(rule.name),
+    valeName: rule.name,
+    tier: override.tier ?? ('warn' as StyleTier),
+    message: rule.message,
+    link: rule.link,
+    note: override.note,
+    exceptions: override.exceptions ?? rule.exceptions ?? [],
+    skipLines: override.skipLines,
+    limit: override.limit ?? MAX_FINDINGS_PER_RULE_PER_FILE,
+    scope: rule.scope,
+  };
+
+  if (rule.extends === 'substitution') {
+    return Object.entries(rule.swap ?? {}).map(([source, suggestion]) => ({
+      ...base,
+      pattern: new RegExp(wrap(source, rule.nonword), flags),
+      suggestion,
+    }));
+  }
+
+  if (rule.extends === 'repetition') {
+    // upstream tokens are a generic word pattern plus `alpha: true`; the check itself is that a
+    // token repeats back to back, which Vale implements internally rather than in the pattern.
+    return [{ ...base, pattern: new RegExp('\\b([A-Za-z]+)\\s+\\1\\b', 'gi') }];
+  }
+
+  const tokens = override.tokens ?? rule.tokens ?? [];
+  if (tokens.length === 0) {
+    return [];
+  }
+  return [{ ...base, pattern: new RegExp(wrap(tokens.join('|'), rule.nonword), flags) }];
+}
+
+const MATCHERS: readonly Matcher[] = VALE_RULES.filter((r) => r.name in ALLOWED_RULES).flatMap(compile);
+
+function severityFor(tier: StyleTier, input: ValidationInput): Severity {
+  if (input.style === 'error') {
+    return 'error';
+  }
+  return tier === 'info' ? 'info' : 'warning';
+}
+
+/** Fills Vale's `%s` placeholders in order. */
+function fill(template: string, args: string[]): string {
+  let i = 0;
+  return template.replace(/%s/g, () => args[i++] ?? '%s');
+}
+
+/**
+ * Vale messages are a one-line summary followed by optional explanation. Splits that into the
+ * short `title` and longer `detail` the Diagnostic shape expects, keeping the title to a single
+ * sentence so it stays readable in the terminal.
+ */
+function splitMessage(message: string, note?: string): { title: string; detail: string } {
+  const [firstBlock, ...restBlocks] = message.trim().split('\n\n');
+  const firstLine = firstBlock.split('\n')[0].trim();
+
+  let title = firstLine;
+  let spilled = firstBlock.slice(firstLine.length).trim();
+
+  // a long opening line is usually a summary plus a caveat; keep the summary as the title
+  if (title.length > 90) {
+    const cut = title.search(/(?<=\.)\s/);
+    if (cut > 0) {
+      spilled = `${title.slice(cut).trim()} ${spilled}`.trim();
+      title = title.slice(0, cut).trim();
+    }
+  }
+
+  const detail = [spilled, ...restBlocks, note].filter(Boolean).join(' ').replace(/\s+/g, ' ').trim();
+  return { title, detail };
+}
+
+/** 1-based line numbers of ATX headings outside code fences. */
+function getHeadingLines(content: string, codeLines: ReadonlySet<number>): Set<number> {
+  const headings = new Set<number>();
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (!codeLines.has(i + 1) && /^#{1,6}\s/.test(lines[i])) {
+      headings.add(i + 1);
+    }
+  }
+  return headings;
+}
+
+export async function checkWritingStyle(input: ValidationInput): Promise<Diagnostic[]> {
+  if (input.style === 'off') {
+    return [];
+  }
+
+  const diagnostics: Diagnostic[] = [];
+
+  let entries: Dirent[] = [];
+  try {
+    entries = await readdir(input.docsPath, { recursive: true, withFileTypes: true });
+  } catch {
+    return diagnostics;
+  }
+
+  const mdFiles = entries.filter((e) => e.isFile() && e.name.endsWith('.md') && !isMetaFile(e.name));
+
+  for (const entry of mdFiles) {
+    const absPath = join(entry.parentPath, entry.name);
+    const relPath = relative(input.docsPath, absPath);
+
+    let content: string;
+    try {
+      content = await readFile(absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const codeLines = getCodeBlockLines(content);
+    const skipLines = getNonProseLines(content);
+    const headingLines = getHeadingLines(content, codeLines);
+    const lines = content.split('\n');
+    const counts = new Map<string, number>();
+
+    for (const matcher of MATCHERS) {
+      const raw = matcher.scope === 'raw';
+      const matches = matchOutsideCode(content, matcher.pattern, codeLines, {
+        maskInlineCode: !raw,
+        maskLinkTargets: !raw,
+        skipLines,
+      });
+
+      for (const { match, line } of matches) {
+        if (matcher.scope === 'heading' && !headingLines.has(line)) {
+          continue;
+        }
+        if (matcher.skipLines?.test(lines[line - 1] ?? '')) {
+          continue;
+        }
+
+        const matched = match[0];
+        if (matcher.exceptions.some((e) => matched.includes(e))) {
+          continue;
+        }
+        // substitution patterns often also match the already-correct wording, so do not nag when
+        // the text is already what we would suggest
+        if (matcher.suggestion?.split('|').includes(matched.trim())) {
+          continue;
+        }
+
+        const seen = counts.get(matcher.ruleId) ?? 0;
+        if (seen >= matcher.limit) {
+          continue;
+        }
+        counts.set(matcher.ruleId, seen + 1);
+
+        const args = matcher.suggestion ? [matcher.suggestion, matched.trim()] : [matched.trim()];
+        const { title, detail } = splitMessage(fill(matcher.message, args), matcher.note);
+
+        diagnostics.push({
+          rule: matcher.ruleId,
+          severity: severityFor(matcher.tier, input),
+          file: relPath,
+          line,
+          title: title.trim(),
+          detail: detail || `Grafana.${matcher.valeName}`,
+          ...(matcher.link ? { url: matcher.link } : {}),
+        });
+      }
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/plugin-docs-cli/src/validation/rules/style.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/style.ts
@@ -15,7 +15,7 @@ import { getCodeBlockLines, getNonProseLines, isMetaFile, matchOutsideCode } fro
  *
  * These are advice, never a gate. `plugin-validator` maps a CLI `error` onto a publishing block,
  * and Grafana's in-house style is not grounds for refusing a third-party plugin release, so
- * nothing here reaches `error` unless the caller explicitly opts in with `style: 'error'`.
+ * nothing here ever reaches `error`.
  */
 
 /**
@@ -315,10 +315,7 @@ function compile(rule: ValeRule): Matcher[] {
 
 const MATCHERS: readonly Matcher[] = VALE_RULES.filter((r) => r.name in ALLOWED_RULES).flatMap(compile);
 
-function severityFor(tier: StyleTier, input: ValidationInput): Severity {
-  if (input.style === 'error') {
-    return 'error';
-  }
+function severityFor(tier: StyleTier): Severity {
   return tier === 'info' ? 'info' : 'warning';
 }
 
@@ -366,10 +363,6 @@ function getHeadingLines(content: string, codeLines: ReadonlySet<number>): Set<n
 }
 
 export async function checkWritingStyle(input: ValidationInput): Promise<Diagnostic[]> {
-  if (input.style === 'off') {
-    return [];
-  }
-
   const diagnostics: Diagnostic[] = [];
 
   let entries: Dirent[] = [];
@@ -435,7 +428,7 @@ export async function checkWritingStyle(input: ValidationInput): Promise<Diagnos
 
         diagnostics.push({
           rule: matcher.ruleId,
-          severity: severityFor(matcher.tier, input),
+          severity: severityFor(matcher.tier),
           file: relPath,
           line,
           title: title.trim(),

--- a/packages/plugin-docs-cli/src/validation/rules/utils.test.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { formatBytes, isMetaFile, maskInlineCode } from './utils.js';
+import {
+  formatBytes,
+  getCodeBlockLines,
+  getNonProseLines,
+  isMetaFile,
+  maskInlineCode,
+  maskLinkTargets,
+  matchOutsideCode,
+} from './utils.js';
 
 describe('isMetaFile', () => {
   it('matches README.md regardless of case', () => {
@@ -92,5 +100,96 @@ describe('maskInlineCode', () => {
     expect(masked).not.toContain('<a>');
     expect(masked).not.toContain('<b>');
     expect(masked).toHaveLength(line.length);
+  });
+});
+
+describe('maskLinkTargets', () => {
+  it('should mask a link target but keep the visible text', () => {
+    const masked = maskLinkTargets('Read the [setup guide](./configure-datasource.md) first.');
+    expect(masked).toContain('[setup guide]');
+    expect(masked).not.toContain('datasource');
+  });
+
+  it('should mask an autolink', () => {
+    expect(maskLinkTargets('See <https://example.com/datasource> for more.')).not.toContain('datasource');
+  });
+
+  it('should preserve length, since callers index the raw line with offsets from the masked one', () => {
+    const line = 'An ![image](./a.png) and a [link](./b.md) on one line.';
+    expect(maskLinkTargets(line)).toHaveLength(line.length);
+  });
+
+  it('should leave a line with no links untouched', () => {
+    const line = 'Plain prose with no links at all.';
+    expect(maskLinkTargets(line)).toBe(line);
+  });
+});
+
+describe('getNonProseLines', () => {
+  it('should mark the frontmatter block', () => {
+    const lines = getNonProseLines('---\ntitle: A\n---\n\nBody text.\n');
+    expect(lines.has(1)).toBe(true);
+    expect(lines.has(2)).toBe(true);
+    expect(lines.has(3)).toBe(true);
+    expect(lines.has(5)).toBe(false);
+  });
+
+  it('should not treat a mid-document thematic break as frontmatter', () => {
+    const lines = getNonProseLines('Body text.\n\n---\n\nMore body text.\n');
+    expect(lines.has(1)).toBe(false);
+    expect(lines.has(5)).toBe(false);
+  });
+
+  it('should mark a multi-line HTML comment', () => {
+    const lines = getNonProseLines('Before.\n<!-- a\nb -->\nAfter.\n');
+    expect(lines.has(2)).toBe(true);
+    expect(lines.has(3)).toBe(true);
+    expect(lines.has(4)).toBe(false);
+  });
+
+  it('should mark the whole section-brief span, including the prose between the markers', () => {
+    const content = [
+      'Before.',
+      '<!-- section-brief:start -->',
+      '',
+      '> Fill this in.',
+      '',
+      '<!-- section-brief:end -->',
+      'After.',
+    ].join('\n');
+    const lines = getNonProseLines(content);
+    expect(lines.has(1)).toBe(false);
+    expect(lines.has(4)).toBe(true);
+    expect(lines.has(6)).toBe(true);
+    expect(lines.has(7)).toBe(false);
+  });
+
+  it('should mark an indented code block but not a list continuation', () => {
+    expect(getNonProseLines('Text.\n\n    const a = 1;\n').has(3)).toBe(true);
+    expect(getNonProseLines('Text.\n\n    - a nested list item\n').has(3)).toBe(false);
+  });
+});
+
+describe('matchOutsideCode', () => {
+  const content = ['Alpha here.', '```', 'Alpha in code.', '```', 'Alpha again.'].join('\n');
+
+  it('should skip fenced code blocks', () => {
+    const hits = matchOutsideCode(content, /Alpha/g, getCodeBlockLines(content));
+    expect(hits.map((h) => h.line)).toEqual([1, 5]);
+  });
+
+  it('should honour an extra skipLines set', () => {
+    const hits = matchOutsideCode(content, /Alpha/g, getCodeBlockLines(content), { skipLines: new Set([1]) });
+    expect(hits.map((h) => h.line)).toEqual([5]);
+  });
+
+  it('should optionally mask inline code and link targets', () => {
+    const line = 'Use `Alpha` and [text](./Alpha.md) and Alpha.';
+    const hits = matchOutsideCode(line, /Alpha/g, new Set(), { maskInlineCode: true, maskLinkTargets: true });
+    expect(hits).toHaveLength(1);
+  });
+
+  it('should not loop forever on a zero-length match', () => {
+    expect(matchOutsideCode('abc', /x*/g, new Set()).length).toBeGreaterThan(0);
   });
 });

--- a/packages/plugin-docs-cli/src/validation/rules/utils.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.ts
@@ -194,6 +194,10 @@ export function matchOutsideCode(
     let m: RegExpExecArray | null;
     while ((m = lineRe.exec(lineText)) !== null) {
       results.push({ match: m, line: i + 1 });
+      // Non-global, non-sticky regexes don't advance, so only report the first match.
+      if (!lineRe.global && !lineRe.sticky) {
+        break;
+      }
       // guard against a zero-length match spinning forever
       if (m[0] === '') {
         lineRe.lastIndex++;

--- a/packages/plugin-docs-cli/src/validation/rules/utils.ts
+++ b/packages/plugin-docs-cli/src/validation/rules/utils.ts
@@ -84,3 +84,122 @@ export function getCodeBlockLines(content: string): Set<number> {
 
   return codeLines;
 }
+
+/**
+ * Length-preserving mask of link and image targets, so a rule that scans prose does not match
+ * inside a URL. `[Data formats](./see-data.md)` keeps its visible text but the target becomes
+ * filler. Length must be preserved because callers index the raw line using offsets taken from
+ * the masked one.
+ */
+export function maskLinkTargets(line: string): string {
+  return line
+    .replace(/(\]\()([^)\n]*)(\))/g, (_m, open: string, target: string, close: string) => {
+      return `${open}${'#'.repeat(target.length)}${close}`;
+    })
+    .replace(/(<)(https?:[^>\n]*)(>)/g, (_m, open: string, url: string, close: string) => {
+      return `${open}${'#'.repeat(url.length)}${close}`;
+    });
+}
+
+/**
+ * Returns 1-based line numbers that are not prose and so should be skipped by content rules:
+ * the frontmatter block, HTML comment spans (which covers `<!-- section-brief -->` blocks) and
+ * indented code blocks.
+ */
+export function getNonProseLines(content: string): Set<number> {
+  const lines = content.split('\n');
+  const skip = new Set<number>();
+
+  // frontmatter, only when the file opens with a fence
+  if (lines[0]?.trim() === '---') {
+    skip.add(1);
+    for (let i = 1; i < lines.length; i++) {
+      skip.add(i + 1);
+      if (lines[i].trim() === '---') {
+        break;
+      }
+    }
+  }
+
+  let inComment = false;
+  let inSectionBrief = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // scaffolded placeholder text between the two markers. it renders, so it is not an HTML
+    // comment span, but it is ours rather than the author's and `unfilled-section-brief` already
+    // tells them to delete it - style advice on top of that would just be noise.
+    if (inSectionBrief) {
+      skip.add(i + 1);
+      if (/<!--\s*section-brief:end\s*-->/.test(line)) {
+        inSectionBrief = false;
+      }
+      continue;
+    }
+    if (/<!--\s*section-brief:start\s*-->/.test(line)) {
+      skip.add(i + 1);
+      inSectionBrief = true;
+      continue;
+    }
+
+    if (inComment) {
+      skip.add(i + 1);
+      if (line.includes('-->')) {
+        inComment = false;
+      }
+      continue;
+    }
+    if (line.includes('<!--')) {
+      skip.add(i + 1);
+      // a comment that opens and closes on one line does not carry over
+      if (!line.includes('-->')) {
+        inComment = true;
+      }
+      continue;
+    }
+    // indented code block, but not a list continuation
+    if (/^ {4,}\S/.test(line) && !/^\s*[-*+]|^\s*\d+\./.test(line)) {
+      skip.add(i + 1);
+    }
+  }
+
+  return skip;
+}
+
+/**
+ * Tests a regex against content lines, skipping code blocks.
+ * Returns all matches with their line numbers.
+ */
+export function matchOutsideCode(
+  content: string,
+  re: RegExp,
+  codeLines: ReadonlySet<number>,
+  options?: { maskInlineCode?: boolean; maskLinkTargets?: boolean; skipLines?: ReadonlySet<number> }
+): Array<{ match: RegExpExecArray; line: number }> {
+  const results: Array<{ match: RegExpExecArray; line: number }> = [];
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    if (codeLines.has(i + 1) || options?.skipLines?.has(i + 1)) {
+      continue;
+    }
+    let lineText = lines[i];
+    if (options?.maskInlineCode) {
+      lineText = maskInlineCode(lineText);
+    }
+    if (options?.maskLinkTargets) {
+      lineText = maskLinkTargets(lineText);
+    }
+    const lineRe = new RegExp(re.source, re.flags);
+    let m: RegExpExecArray | null;
+    while ((m = lineRe.exec(lineText)) !== null) {
+      results.push({ match: m, line: i + 1 });
+      // guard against a zero-length match spinning forever
+      if (m[0] === '') {
+        lineRe.lastIndex++;
+      }
+    }
+  }
+
+  return results;
+}

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -56,15 +56,28 @@ export const Rule = {
 export type Rule = (typeof Rule)[keyof typeof Rule];
 
 /**
+ * Id of a writing-style rule, always `style-` plus the kebab-case name of the Grafana Writers'
+ * Toolkit rule it comes from, so `Grafana.ReferTo` is reported as `style-refer-to`. These are
+ * derived from the vendored rule definitions rather than enumerated in `Rule`, so `ALLOWED_RULES`
+ * in `rules/style.ts` stays the single source of truth for which ones exist.
+ */
+export type StyleRuleId = `style-${string}`;
+
+/**
  * A diagnostic reported by a rule runner.
  */
 export interface Diagnostic {
-  rule: Rule;
+  rule: Rule | StyleRuleId;
   severity: Severity;
   file?: string;
   line?: number;
   title: string;
   detail: string;
+  /**
+   * Authoritative documentation for this rule. Set on writing-style diagnostics so a reader - or
+   * an agent fixing them - can look up the full guidance for a rule only once they have tripped it.
+   */
+  url?: string;
 }
 
 /**
@@ -82,6 +95,12 @@ export interface ValidationInput {
    * it, so half-written docs still cannot reach the catalog.
    */
   allowUnfilledStubs?: boolean;
+  /**
+   * How to treat Grafana Writers' Toolkit writing-style rules. `on` is the default and caps them
+   * at `warning`; `off` skips them; `error` is an explicit opt-in for teams that want style to
+   * fail their own CI. Left optional so existing callers are unaffected.
+   */
+  style?: 'on' | 'off' | 'error';
 }
 
 /**

--- a/packages/plugin-docs-cli/src/validation/types.ts
+++ b/packages/plugin-docs-cli/src/validation/types.ts
@@ -95,12 +95,6 @@ export interface ValidationInput {
    * it, so half-written docs still cannot reach the catalog.
    */
   allowUnfilledStubs?: boolean;
-  /**
-   * How to treat Grafana Writers' Toolkit writing-style rules. `on` is the default and caps them
-   * at `warning`; `off` skips them; `error` is an explicit opt-in for teams that want style to
-   * fail their own CI. Left optional so existing callers are unaffected.
-   */
-  style?: 'on' | 'off' | 'error';
 }
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:

Grafana's docs team publishes its documentation style guide as Vale rules in the [Writers' Toolkit](https://grafana.com/docs/writers-toolkit/write/style-guide/). Running Vale itself would require every plugin author and CI to install and maintain the Go binary, so this PR skips that and transcribes 35 of the toolkit's rules by hand into `plugin-docs-cli`, applying them as `style-*` findings that are always advice, never a blocking error, and always link back to the toolkit's docs page. It also fixes `formatResult()` to sort diagnostics by severity, since an error could otherwise print below unrelated warnings.

**Which issue(s) this PR fixes**:

Fixes #