### PR TITLE
 feat(create-plugin): streamline codemod messaging

### DIFF
--- a/.claude/skills/write-codemod/SKILL.md
+++ b/.claude/skills/write-codemod/SKILL.md
@@ -33,13 +33,17 @@ Both kinds run through the same pipeline in `runner.ts`:
 4. Flush the context's staged changes to disk
 5. Print a summary of changes to the author
 6. Run the package manager's install when `package.json` changed
+7. The calling command prints the success line, then anything the codemod recorded with `addNextStep`
+
+A codemod that called `context.skip(...)` short-circuits steps 3 to 6 — nothing is formatted, flushed, listed or installed — and the command prints the skip in place of the success line.
 
 The pipeline explains the core rules:
 
 - **Use the Context for all file operations, never Node.js `fs`.** The runner owns disk writes; the context is an in-memory staging area, which is also what makes tests hermetic. Always `return context`, even on early returns.
 - **Don't chase perfect output formatting.** Prettier reformats every changed file afterwards using the plugin's own config.
 - **The dependency helpers are enough.** Changing `package.json` through them triggers a real install after the run.
-- **Degrade gracefully — don't throw.** A thrown error aborts the author's entire `update` sequence. When a file is missing, unparseable, or already migrated, log with the debug helper and return the context unchanged.
+- **Degrade gracefully — don't throw.** A thrown error aborts the author's entire `update` sequence. When there is nothing for the author to act on — already migrated, or the feature this touches isn't present — log with the debug helper and return the context unchanged. When the author could do something about it and would otherwise be left guessing, `context.skip(...)` — see "Talking to the author". Reserve `throw` for faults that mean the package itself is broken, such as a template missing from the published build.
+- **Never print.** Codemods record what to say; the framework renders it. Importing `output` or calling `console.*` from a codemod puts the message in the wrong place — before the change list and the install — and no codemod can fix that from where it sits.
 - **Stay inside the plugin's working directory.** Codemods run inside a user's project; the context base path is the boundary.
 - **Idempotency is non-negotiable.** Codemods re-run against already-migrated projects; every script must be safe to run repeatedly.
 - **One concern per codemod.** Don't bundle unrelated changes.
@@ -105,9 +109,66 @@ context.renameFile(from: string, to: string)           // delete old + add new
 // Inspect
 context.listChanges(): ContextFile
 context.hasChanges(): boolean
+
+// Talk to the author (rendered by the command, never by you)
+context.addNextStep(step: string)                      // what to do once this has finished
+context.listNextSteps(): string[]                      // a copy; push through addNextStep
+context.skip(reason: string, hints?: string[])         // decline; nothing is flushed, exit stays 0
+                                                       // reason completes "Skipped <name>: "
+context.getSkip(): { reason, hints } | undefined
 ```
 
 Always check `doesFileExist` before `getFile` or `updateFile`.
+
+## Talking to the author
+
+Codemods never write to the terminal. They record on the context and the calling command renders it, which is what keeps the ordering right and the wording consistent between codemods.
+
+**Next steps** — what the author should do now that the codemod has finished:
+
+```ts
+context.addNextStep(`Run \`${packageManagerName} run generate:kinds\` to generate from them`);
+```
+
+Rendered after the change list, the dependency install and the success line, so it is the last thing on screen. Only record these when you actually did something — a re-run that changes nothing should stay quiet. Gate on whether this run changed anything, the way `experimental-app-sdk.ts` does:
+
+```ts
+const changesBefore = Object.keys(context.listChanges()).length;
+// ...do the work...
+if (Object.keys(context.listChanges()).length > changesBefore) {
+  context.addNextStep('…');
+}
+```
+
+**Skipping** — the codemod does not apply here, and the author should know why:
+
+```ts
+if (pluginJson.type !== 'app') {
+  context.skip(`needs an app plugin, but this is a ${pluginJson.type} plugin.`, [
+    'The app-sdk serves Kubernetes-style resources from an app plugin.',
+  ]);
+  return context;
+}
+```
+
+Rendered as a warning; the process still exits 0 either way. In `add` the warning replaces the success line. In `update` the other migrations still run, so the command reports how many were skipped instead of claiming plain success.
+
+The reason completes the sentence `Skipped <codemod name>: `, so start it lowercase, end it with a period and leave the codemod's own name out of it — "needs an app plugin, but this is a panel plugin.", not "app-sdk needs an app plugin".
+
+Skip before staging any changes: a skipped context is never flushed, and the runner throws if this run staged something and then skipped, rather than dropping the edits silently. Calling `skip` twice keeps only the last reason, so return straight after skipping.
+
+**Migrations should rarely skip.** An addition is invoked deliberately, so "I declined, here's why" is exactly what the author asked for. A migration runs unattended against every plugin on every `update`, so a skip that fires for a whole class of plugin becomes a warning those authors see forever. Prefer the debug helper there, and skip only when the author genuinely needs to act.
+
+Four situations, four mechanisms — keep them apart:
+
+| Situation                                                       | Use                                      |
+| --------------------------------------------------------------- | ---------------------------------------- |
+| Does not apply here, and the author could do something about it | `context.skip(reason, hints)`            |
+| Applied cleanly, and there is something to do next              | `context.addNextStep(...)`               |
+| Already applied, or the thing it touches isn't there            | the debug helper, and return the context |
+| The package itself is broken                                    | `throw`                                  |
+
+The line between rows one and three is whether the author can act. A wrong plugin type or a conflicting setting is a skip. An already-migrated file or an absent optional feature is a debug log — saying nothing is the right amount to say.
 
 ## Utility functions (from `../../utils.js`)
 
@@ -131,10 +192,13 @@ migrationsDebug, additionsDebug
 
 ```ts
 import type { Context } from '../../context.js';
+import { migrationsDebug } from '../../utils.js';
 
 export default function migrate(context: Context) {
-  // 1. Guard: check the file/condition that makes this migration applicable
+  // 1. Guard: check the file/condition that makes this migration applicable. Nothing for the author
+  //    to act on here, so log and return rather than context.skip()
   if (!context.doesFileExist('some-file')) {
+    migrationsDebug('some-file not found, nothing to migrate');
     return context;
   }
 
@@ -142,6 +206,7 @@ export default function migrate(context: Context) {
 
   // 2. Guard: skip if already applied (idempotency)
   if (content.includes('already-migrated-marker')) {
+    migrationsDebug('already migrated');
     return context;
   }
 
@@ -253,7 +318,7 @@ Structured files need parser-based edits — string replacement breaks on format
 
 ## Testing requirements
 
-Every codemod ships with a colocated `.test.ts`. Cover four behaviours:
+Every codemod ships with a colocated `.test.ts`. Cover five behaviours:
 
 1. **Happy path** — the codemod applies the expected change.
 2. **Idempotency** — running twice produces the same result, via the custom matcher (defined in `packages/create-plugin/vitest.setup.ts`; it runs the codemod twice and diffs the files staged after the first run):
@@ -262,8 +327,9 @@ Every codemod ships with a colocated `.test.ts`. Cover four behaviours:
    // codemods that take options need a wrapper:
    await expect((ctx) => addFeature(ctx, options)).toBeIdempotent(context);
    ```
-3. **Already-migrated guard** — no-op when the change is already present.
+3. **Already-migrated guard** — no-op when the change is already present, and no next step recorded on the second run.
 4. **Missing file guard** — no-op when the target file doesn't exist (if applicable).
+5. **What the author is told** — assert on `context.getSkip()` and `context.listNextSteps()`, never on `output`. A codemod that prints is a codemod with a bug; there is nothing to spy on.
 
 `test-utils.ts` exports `createDefaultContext()` for a context pre-seeded with a minimal plugin; otherwise seed your own:
 

--- a/packages/create-plugin/src/codemods/AGENTS.md
+++ b/packages/create-plugin/src/codemods/AGENTS.md
@@ -9,6 +9,8 @@ This guide provides specific instructions for working with migrations and additi
 - Always refer to @./context.ts to know what methods are available on the context class
 - Always check for file existence using the @./context.ts class before attempting to do anything with it
 - Never write files with any 3rd party npm library. Use the context for all file operations
+- Never print. Do not import `output` or call `console.*` from a codemod. Record on the context instead and the calling command renders it: `context.addNextStep()` for what the author should do once the changes are on disk, and `context.skip(reason, hints)` to decline.
+- Choose the right channel. `context.skip(reason, hints)` when the codemod does not apply and the author could act on it - the reason completes "Skipped <name>: ", so start it lowercase and skip before staging any changes. The debug helper plus `return context` when it is already applied or there is nothing to say, which is the normal case for migrations. `throw` only when the package itself is broken, such as a missing template, because a throw aborts the author's whole update
 - Always return the context for the next migration
 - Test thoroughly using the provided utils in @./test-utils.ts where necessary
 - Each migration must be idempotent and must include a test case that uses the `.toBeIdempotent` custom matcher found in @../../vitest.setup.ts

--- a/packages/create-plugin/src/codemods/additions/scripts/example-addition.ts
+++ b/packages/create-plugin/src/codemods/additions/scripts/example-addition.ts
@@ -26,8 +26,14 @@ export default function exampleAddition(context: Context, options: ExampleOption
   // These options have been validated by the framework
   const { featureName, enabled, port, frameworks } = options;
 
-  const rawPkgJson = context.getFile('./package.json') ?? '{}';
-  const packageJson = JSON.parse(rawPkgJson);
+  // Decline instead of failing when a precondition isn't met. Skip before making any changes, and
+  // word the reason to complete "Skipped example-addition: ".
+  if (!context.doesFileExist('./package.json')) {
+    context.skip('there is no package.json to add the example script to.', ['Run this from the root of your plugin.']);
+    return context;
+  }
+
+  const packageJson = JSON.parse(context.getFile('./package.json') ?? '{}');
 
   if (packageJson.scripts && !packageJson.scripts['example-script']) {
     packageJson.scripts['example-script'] = `echo "Running ${featureName}"`;
@@ -48,6 +54,10 @@ export default function exampleAddition(context: Context, options: ExampleOption
 };
 `;
     context.addFile(`./src/features/${featureName}.ts`, featureCode);
+
+    // Never print from a codemod. Record it and the command renders it after the change list and
+    // the install. Inside the guard, so a re-run that changed nothing stays quiet.
+    context.addNextStep(`Wire up ./src/features/${featureName}.ts from your plugin's entry point`);
   }
 
   if (context.doesFileExist('./src/deprecated.ts')) {

--- a/packages/create-plugin/src/codemods/additions/scripts/experimental-app-sdk.test.ts
+++ b/packages/create-plugin/src/codemods/additions/scripts/experimental-app-sdk.test.ts
@@ -1,5 +1,4 @@
 import { Context } from '../../context.js';
-import { output } from '../../../utils/utils.console.js';
 import appSdk from './experimental-app-sdk.js';
 
 vi.mock(import('../../../utils/utils.plugin.js'), async (importOriginal) => {
@@ -10,15 +9,11 @@ vi.mock(import('../../../utils/utils.plugin.js'), async (importOriginal) => {
   };
 });
 
-
 vi.mock(import('../../utils.js'), async (importOriginal) => {
   const originalModule = await importOriginal();
   // Disk I/O is slow so render the templates once and key off the requested path.
   const render = (file: string) =>
-    originalModule.renderTemplate(
-      new URL(`../../../../templates/app-sdk/${file}`, import.meta.url).pathname,
-      false
-    );
+    originalModule.renderTemplate(new URL(`../../../../templates/app-sdk/${file}`, import.meta.url).pathname, false);
   const rendered: Record<string, string> = {
     '.config/app-sdk/generate-kinds.mjs': render('.config/app-sdk/generate-kinds.mjs'),
     '.config/AGENTS/app-sdk.md': render('.config/AGENTS/app-sdk.md'),
@@ -78,11 +73,7 @@ function createAppContext({
 }
 
 describe('experimental-app-sdk addition', () => {
-  // Silence terminal output, and let us assert on what the user is told.
-  beforeEach(() => {
-    vi.spyOn(output, 'log').mockImplementation(() => {});
-    vi.spyOn(output, 'warning').mockImplementation(() => {});
-  });
+  // no output spies needed - the codemod prints nothing, it records on the context
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -304,35 +295,44 @@ describe('experimental-app-sdk addition', () => {
     });
   });
 
+  // the codemod records what to say; the command renders it. see Context.addNextStep / Context.skip
   describe('user messaging', () => {
     it('explains why it skipped an unsupported plugin type', () => {
       const context = createAppContext({ pluginType: 'panel' });
 
       appSdk(context);
 
-      expect(output.warning).toHaveBeenCalledWith(
-        expect.objectContaining({ title: expect.stringContaining('needs an app plugin') })
-      );
+      expect(context.getSkip()?.reason).toContain('needs an app plugin');
     });
 
-    it('prints next steps after scaffolding', () => {
+    it('explains a missing plugin.json rather than failing silently', () => {
+      const context = new Context();
+
+      appSdk(context);
+
+      expect(context.getSkip()?.reason).toContain('src/plugin.json');
+      expect(context.getSkip()?.hints).toContain('Run this from the root of your plugin.');
+    });
+
+    it('records next steps after scaffolding', () => {
       const context = createAppContext();
 
       appSdk(context);
 
-      expect(output.log).toHaveBeenCalledWith(expect.objectContaining({ title: expect.stringContaining('Next steps') }));
+      expect(context.getSkip()).toBeUndefined();
+      expect(context.listNextSteps().join('\n')).toContain('generate:kinds');
     });
 
     it('stays quiet on a re-run', () => {
       const context = createAppContext();
       appSdk(context);
-      vi.mocked(output.log).mockClear();
+      const afterFirstRun = context.listNextSteps().length;
 
       appSdk(context);
 
-      expect(output.log).not.toHaveBeenCalled();
+      // nothing was scaffolded the second time, so nothing new to say
+      expect(context.listNextSteps()).toHaveLength(afterFirstRun);
     });
-
   });
 
   it('is idempotent', async () => {

--- a/packages/create-plugin/src/codemods/additions/scripts/experimental-app-sdk.ts
+++ b/packages/create-plugin/src/codemods/additions/scripts/experimental-app-sdk.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { parseDocument, stringify, YAMLMap, Scalar } from 'yaml';
 import type { Context } from '../../context.js';
-import { output } from '../../../utils/utils.console.js';
 import { additionsDebug, renderTemplate } from '../../utils.js';
 import { getTemplateData } from '../../../utils/utils.templates.js';
 
@@ -43,7 +42,7 @@ export default function appSdk(context: Context): Context {
 
   // Only guide the user when we actually scaffolded something; a re-run should stay quiet.
   if (Object.keys(context.listChanges()).length > changesBefore) {
-    printNextSteps();
+    addNextSteps(context);
   }
 
   return context;
@@ -57,7 +56,7 @@ function isAppPlugin(context: Context): boolean {
   const pluginJsonContent = context.getFile('src/plugin.json');
 
   if (!pluginJsonContent) {
-    skip('Could not find src/plugin.json.', ['Run this from the root of your plugin.']);
+    context.skip('could not find src/plugin.json.', ['Run this from the root of your plugin.']);
     return false;
   }
 
@@ -66,26 +65,21 @@ function isAppPlugin(context: Context): boolean {
     pluginJson = JSON.parse(pluginJsonContent);
   } catch (error) {
     additionsDebug(`Failed to parse src/plugin.json: ${error}`);
-    skip('Could not parse src/plugin.json.');
+    context.skip('could not parse src/plugin.json.');
     return false;
   }
 
   if (pluginJson.type !== 'app') {
-    skip(`grafana-app-sdk codegen needs an app plugin, but this is a ${pluginJson.type} plugin.`, [
-      'The app-sdk serves Kubernetes-style resources from an app plugin.',
-    ]);
+    context.skip(
+      pluginJson.type
+        ? `needs an app plugin, but this is a ${pluginJson.type} plugin.`
+        : 'needs an app plugin, but src/plugin.json declares no type.',
+      ['The app-sdk serves Kubernetes-style resources from an app plugin.']
+    );
     return false;
   }
 
   return true;
-}
-
-/**
- * Explains why nothing happened. The runner reports success for a no-op codemod, so without this the
- * user is left guessing.
- */
-function skip(title: string, body: string[] = []) {
-  output.warning({ title: `Skipping app-sdk: ${title}`, body });
 }
 
 function addTemplateFiles(context: Context) {
@@ -223,16 +217,11 @@ function addFeatureToggle(context: Context) {
   context.updateFile(composePath, stringify(composeData, { lineWidth: 120, singleQuote: true }));
 }
 
-/** Tells the user what to run next. */
-function printNextSteps() {
+/** Records what to run next. The command renders these once the changes are on disk. */
+function addNextSteps(context: Context) {
   const { packageManagerName } = getTemplateData();
 
-  output.log({
-    title: 'Added grafana-app-sdk code generation. Next steps:',
-    body: [
-      'Edit your kinds in ./kinds (start with kinds/example.cue), then run:',
-      `  ${packageManagerName} run generate:kinds`,
-      'See ./kinds/README.md for the full workflow.',
-    ],
-  });
+  context.addNextStep('Edit your kinds in ./kinds, starting with kinds/example.cue');
+  context.addNextStep(`Run ${packageManagerName} run generate:kinds to generate from them`);
+  context.addNextStep('See ./kinds/README.md for the full workflow');
 }

--- a/packages/create-plugin/src/codemods/context.test.ts
+++ b/packages/create-plugin/src/codemods/context.test.ts
@@ -151,4 +151,42 @@ describe('Context', () => {
       expect(context.hasChanges()).toEqual(true);
     });
   });
+
+  describe('user messaging', () => {
+    it('records next steps in the order they were added', () => {
+      const context = new Context();
+
+      context.addNextStep('first');
+      context.addNextStep('second');
+
+      expect(context.listNextSteps()).toEqual(['first', 'second']);
+    });
+
+    it('has no next steps by default', () => {
+      expect(new Context().listNextSteps()).toEqual([]);
+    });
+
+    it('is not skipped by default', () => {
+      expect(new Context().getSkip()).toBeUndefined();
+    });
+
+    it('records a skip reason and its hints', () => {
+      const context = new Context();
+
+      context.skip('needs an app plugin', ['Run this from an app plugin.']);
+
+      expect(context.getSkip()).toEqual({
+        reason: 'needs an app plugin',
+        hints: ['Run this from an app plugin.'],
+      });
+    });
+
+    it('defaults skip hints to an empty list', () => {
+      const context = new Context();
+
+      context.skip('no reason to run');
+
+      expect(context.getSkip()?.hints).toEqual([]);
+    });
+  });
 });

--- a/packages/create-plugin/src/codemods/context.ts
+++ b/packages/create-plugin/src/codemods/context.ts
@@ -12,8 +12,16 @@ export type ContextFile = Record<
   }
 >;
 
+/** Why a codemod declined to run, and what the author can do about it. */
+export type SkipNotice = {
+  reason: string;
+  hints: string[];
+};
+
 export class Context {
   private files: ContextFile = {};
+  private nextSteps: string[] = [];
+  private skipNotice: SkipNotice | undefined;
   basePath: string;
 
   constructor(basePath?: string) {
@@ -115,6 +123,45 @@ export class Context {
 
   hasChanges() {
     return Object.keys(this.files).length > 0;
+  }
+
+  /**
+   * Record something the author should do once the codemod has finished.
+   *
+   * Codemods never print. The command renders these after the change list and the install, so they
+   * are the last thing on screen rather than the first - which is where a codemod printing for
+   * itself would put them. Wrap a command in backticks and the renderer styles it as code.
+   */
+  addNextStep(step: string) {
+    this.nextSteps.push(step);
+  }
+
+  listNextSteps(): string[] {
+    return [...this.nextSteps];
+  }
+
+  /**
+   * Decline to run, with the reason and anything the author can do about it.
+   *
+   * Use this for "this codemod does not apply here" - the wrong plugin type, a conflicting setting,
+   * a precondition the author can fix. The command reports it as a warning and the process still
+   * exits 0. Keep `throw` for genuine faults, such as a missing template, which mean the package
+   * itself is broken.
+   *
+   * The reason completes the sentence "Skipped <codemod name>: ", so start it lowercase and leave
+   * the codemod's own name out of it.
+   *
+   * Skipping means nothing happened, so call it before staging any changes. The runner rejects a
+   * context that is both skipped and changed rather than silently discarding the edits. Calling
+   * this twice keeps the last reason, so guard clauses should return straight after skipping.
+   */
+  skip(reason: string, hints: string[] = []) {
+    codemodsDebug(`Context.skip() - ${reason}`);
+    this.skipNotice = { reason, hints };
+  }
+
+  getSkip(): SkipNotice | undefined {
+    return this.skipNotice;
   }
 
   renameFile(from: string, to: string) {

--- a/packages/create-plugin/src/codemods/migrations/manager.test.ts
+++ b/packages/create-plugin/src/codemods/migrations/manager.test.ts
@@ -25,7 +25,9 @@ vi.mock('../../utils/utils.console.js', () => ({
     log: vi.fn(),
     addHorizontalLine: vi.fn(),
     logSingleLine: vi.fn(),
+    warning: vi.fn(),
     bulletList: vi.fn().mockReturnValue(['']),
+    formatCode: vi.fn((code: string) => code),
   },
 }));
 
@@ -202,6 +204,48 @@ describe('Migrations', () => {
 
       // 2 migration commits + 1 version update commit = 3 total
       expect(gitCommitNoVerify).toHaveBeenCalledTimes(3);
+    });
+
+    it('should skip a migration that declined to run, without flushing or committing it', async () => {
+      migrationOneFn.mockImplementation((context: Context) => {
+        context.skip('this plugin has no backend.', ['Add a backend first.']);
+        return context;
+      });
+
+      const { skipped } = await runMigrations(migrations, { commitEachMigration: true });
+
+      // only migration-two did any work
+      expect(flushChanges).toHaveBeenCalledTimes(1);
+      expect(gitCommitNoVerify).toHaveBeenCalledTimes(2); // migration-two, plus the .cprc.json bump
+      // reported back so the command can avoid claiming plain success
+      expect(skipped).toEqual(['migration-one']);
+    });
+
+    it('should keep next steps recorded by a migration that then skipped', async () => {
+      migrationOneFn.mockImplementation((context: Context) => {
+        context.addNextStep('add a backend, then run update again');
+        context.skip('this plugin has no backend.');
+        return context;
+      });
+
+      const { nextSteps } = await runMigrations(migrations);
+
+      expect(nextSteps).toContain('add a backend, then run update again');
+    });
+
+    it('should collect next steps across migrations for the caller to render', async () => {
+      migrationOneFn.mockImplementation((context: Context) => {
+        context.addNextStep('do the first thing');
+        return context;
+      });
+      migrationTwoFn.mockImplementation((context: Context) => {
+        context.addNextStep('then the second');
+        return context;
+      });
+
+      const { nextSteps } = await runMigrations(migrations);
+
+      expect(nextSteps).toEqual(['do the first thing', 'then the second']);
     });
 
     it('should not create a commit for a migration that has no changes', async () => {

--- a/packages/create-plugin/src/codemods/migrations/manager.ts
+++ b/packages/create-plugin/src/codemods/migrations/manager.ts
@@ -32,9 +32,25 @@ export async function runMigrations(migrations: Migration[], options: RunMigrati
 
   output.log({ title: 'Running the following migrations:', body: migrationListBody });
 
+  // an update runs many migrations, so their next steps are gathered here and rendered once by the
+  // caller rather than interleaved with each migration's change list
+  const nextSteps: string[] = [];
+  const skipped: string[] = [];
+
   // run migrations sequentially in version order where lowest version runs first
   for (const migration of migrations) {
     const context = await runCodemod(migration, options.codemodOptions);
+
+    // a skipped migration made no changes, so there is nothing to commit. next steps still count -
+    // a migration that recorded one before deciding it could not finish has something worth saying.
+    nextSteps.push(...context.listNextSteps());
+
+    // the runner has already explained the skip. record it so the caller can avoid claiming success
+    if (context.getSkip()) {
+      skipped.push(migration.name);
+      continue;
+    }
+
     const shouldCommit = options.commitEachMigration && context.hasChanges();
 
     if (shouldCommit) {
@@ -48,4 +64,6 @@ export async function runMigrations(migrations: Migration[], options: RunMigrati
   if (options.commitEachMigration) {
     await gitCommitNoVerify(`chore: update .config/.cprc.json to version ${CURRENT_APP_VERSION}.`);
   }
+
+  return { nextSteps, skipped };
 }

--- a/packages/create-plugin/src/codemods/runner.test.ts
+++ b/packages/create-plugin/src/codemods/runner.test.ts
@@ -1,0 +1,101 @@
+import { flushChanges, formatFiles, installNPMDependencies, printChanges } from './utils.js';
+import { Context } from './context.js';
+import { Codemod } from './types.js';
+import { output } from '../utils/utils.console.js';
+import { runCodemod } from './runner.js';
+import { vi } from 'vitest';
+
+vi.mock('./utils.js', async (importOriginal) => {
+  const actual: typeof import('./utils.js') = await importOriginal();
+  return {
+    ...actual,
+    flushChanges: vi.fn(),
+    formatFiles: vi.fn(),
+    installNPMDependencies: vi.fn(),
+    printChanges: vi.fn(),
+  };
+});
+
+const codemodFn = vi.fn();
+
+vi.doMock('virtual-runner-codemod.js', async () => ({ default: codemodFn }));
+
+const codemod: Codemod = {
+  name: 'virtual-codemod',
+  description: 'a codemod that exists only for these tests',
+  scriptPath: 'virtual-runner-codemod.js',
+};
+
+describe('runCodemod', () => {
+  beforeEach(() => {
+    vi.spyOn(output, 'warning').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('runs the post-processing pipeline for a codemod that did work', async () => {
+    codemodFn.mockImplementation((context: Context) => {
+      context.addFile('added.ts', '');
+      return context;
+    });
+
+    const context = await runCodemod(codemod);
+
+    expect(context.getSkip()).toBeUndefined();
+    expect(formatFiles).toHaveBeenCalledOnce();
+    expect(flushChanges).toHaveBeenCalledOnce();
+    expect(printChanges).toHaveBeenCalledOnce();
+    expect(installNPMDependencies).toHaveBeenCalledOnce();
+  });
+
+  describe('when the codemod skips', () => {
+    beforeEach(() => {
+      codemodFn.mockImplementation((context: Context) => {
+        context.skip('this is not an app plugin.', ['Run it against an app plugin.']);
+        return context;
+      });
+    });
+
+    it('hands the skip back to the caller', async () => {
+      const context = await runCodemod(codemod);
+
+      expect(context.getSkip()).toEqual({
+        reason: 'this is not an app plugin.',
+        hints: ['Run it against an app plugin.'],
+      });
+    });
+
+    it('touches nothing on disk', async () => {
+      await runCodemod(codemod);
+
+      expect(formatFiles).not.toHaveBeenCalled();
+      expect(flushChanges).not.toHaveBeenCalled();
+      expect(printChanges).not.toHaveBeenCalled();
+      expect(installNPMDependencies).not.toHaveBeenCalled();
+    });
+
+    // explained here rather than in each command, so `add` and `update` word it the same way
+    it('explains the skip where the change list would have gone', async () => {
+      await runCodemod(codemod);
+
+      expect(output.warning).toHaveBeenCalledWith({
+        title: 'Skipped virtual-codemod: this is not an app plugin.',
+        body: ['Run it against an app plugin.'],
+      });
+    });
+  });
+
+  it('refuses to silently discard changes staged before a skip', async () => {
+    codemodFn.mockImplementation((context: Context) => {
+      context.addFile('half-done.ts', '');
+      context.skip('changed my mind.');
+      return context;
+    });
+
+    await expect(runCodemod(codemod)).rejects.toThrow('staged changes and then skipped');
+    expect(flushChanges).not.toHaveBeenCalled();
+  });
+});

--- a/packages/create-plugin/src/codemods/runner.ts
+++ b/packages/create-plugin/src/codemods/runner.ts
@@ -1,6 +1,7 @@
 import { Context } from './context.js';
 import { formatFiles, flushChanges, installNPMDependencies, printChanges } from './utils.js';
 import { parseAndValidateOptions } from './schema-parser.js';
+import { output } from '../utils/utils.console.js';
 import { Codemod } from './types.js';
 
 /**
@@ -10,10 +11,14 @@ import { Codemod } from './types.js';
  * 1. Load codemod module from scriptPath
  * 2. Parse and validate options from schema
  * 3. Execute codemod transformation
- * 4. Format files
- * 5. Flush changes to disk
- * 6. Print summary
- * 7. Install dependencies if needed
+ * 4. Stop here and hand the context back if the codemod skipped - steps 5-8 are for work that happened
+ * 5. Format files
+ * 6. Flush changes to disk
+ * 7. Print summary
+ * 8. Install dependencies if needed
+ *
+ * Next steps a codemod recorded are rendered by the calling command afterwards, which is what keeps
+ * them below the change list and the install.
  */
 export async function runCodemod(codemod: Codemod, options?: Record<string, any>): Promise<Context> {
   const codemodModule = await import(codemod.scriptPath);
@@ -31,7 +36,18 @@ export async function runCodemod(codemod: Codemod, options?: Record<string, any>
   const context = new Context(basePath);
 
   try {
+    const changesBefore = Object.keys(context.listChanges()).length;
     const updatedContext = await codemodModule.default(context, codemodOptions);
+
+    // a skip means nothing happened, so nothing is flushed, listed or installed. staging first and
+    // then skipping would drop those edits silently, so treat it as a codemod bug.
+    if (updatedContext.getSkip()) {
+      if (Object.keys(updatedContext.listChanges()).length > changesBefore) {
+        throw new Error('the codemod staged changes and then skipped. Skip before making any changes.');
+      }
+      printSkip(updatedContext, codemod.name);
+      return updatedContext;
+    }
 
     // standard post-processing pipeline
     await formatFiles(updatedContext);
@@ -48,4 +64,19 @@ export async function runCodemod(codemod: Codemod, options?: Record<string, any>
     }
     throw error;
   }
+}
+
+/**
+ * Explains why a codemod declined, in the place its change list would have gone.
+ *
+ * Done here rather than in each command so `add` and `update` word it identically.
+ */
+function printSkip(context: Context, key: string) {
+  const skip = context.getSkip();
+
+  if (!skip) {
+    return;
+  }
+
+  output.warning({ title: `Skipped ${key}: ${skip.reason}`, body: skip.hints.length > 0 ? skip.hints : undefined });
 }

--- a/packages/create-plugin/src/commands/add.command.test.ts
+++ b/packages/create-plugin/src/commands/add.command.test.ts
@@ -1,0 +1,75 @@
+import { Context } from '../codemods/context.js';
+import { add } from './add.command.js';
+import { output } from '../utils/utils.console.js';
+import { runCodemod } from '../codemods/runner.js';
+import { vi } from 'vitest';
+
+vi.mock('../codemods/runner.js', () => ({ runCodemod: vi.fn() }));
+vi.mock('../utils/utils.checks.js', () => ({ performPreCodemodChecks: vi.fn() }));
+
+// example-addition is registered in additions.ts, so `add` resolves it without a fixture
+const argv = { _: ['add', 'example-addition'], $0: 'create-plugin' };
+
+describe('add command', () => {
+  // the order these are called in is the whole point of the change, so record it rather than
+  // asserting on each in isolation
+  let calls: string[];
+
+  beforeEach(() => {
+    calls = [];
+    vi.spyOn(output, 'success').mockImplementation(({ title }) => {
+      calls.push(`success: ${title}`);
+    });
+    vi.spyOn(output, 'warning').mockImplementation(({ title }) => {
+      calls.push(`warning: ${title}`);
+    });
+    vi.spyOn(output, 'log').mockImplementation(({ title }) => {
+      calls.push(`log: ${title}`);
+    });
+    vi.spyOn(output, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reports success and then the next steps, in that order', async () => {
+    const context = new Context('/virtual');
+    context.addNextStep('do the thing');
+    vi.mocked(runCodemod).mockResolvedValue(context);
+
+    await add(argv);
+
+    expect(calls).toEqual(['success: Successfully added example-addition to your plugin.', 'log: Next steps']);
+  });
+
+  it('says nothing about next steps when the codemod recorded none', async () => {
+    vi.mocked(runCodemod).mockResolvedValue(new Context('/virtual'));
+
+    await add(argv);
+
+    expect(calls).toEqual(['success: Successfully added example-addition to your plugin.']);
+  });
+
+  // the runner explains the skip itself, so the command's only job is to stay quiet about success
+  it('does not claim success when the codemod skipped', async () => {
+    const context = new Context('/virtual');
+    context.skip('this is not an app plugin.', ['Run it against an app plugin.']);
+    vi.mocked(runCodemod).mockResolvedValue(context);
+
+    await add(argv);
+
+    expect(calls).toEqual([]);
+  });
+
+  it('keeps next steps recorded by a codemod that then skipped', async () => {
+    const context = new Context('/virtual');
+    context.addNextStep('add a backend, then run this again');
+    context.skip('this plugin has no backend.');
+    vi.mocked(runCodemod).mockResolvedValue(context);
+
+    await add(argv);
+
+    expect(calls).toEqual(['log: Next steps']);
+  });
+});

--- a/packages/create-plugin/src/commands/add.command.ts
+++ b/packages/create-plugin/src/commands/add.command.ts
@@ -24,11 +24,22 @@ export const add = async (argv: minimist.ParsedArgs) => {
 
     // filter out minimist internal properties (_ and $0) before passing to codemod
     const { _, $0, ...codemodOptions } = argv;
-    await runCodemod(addition, codemodOptions);
+    const context = await runCodemod(addition, codemodOptions);
 
-    output.success({
-      title: `Successfully added ${addition.name} to your plugin.`,
-    });
+    const nextSteps = context.listNextSteps();
+
+    // the runner has already explained the skip. declining is not failing, so don't exit non-zero -
+    // just don't follow the explanation with a success line that contradicts it.
+    if (!context.getSkip()) {
+      output.success({
+        title: `Successfully added ${addition.name} to your plugin.`,
+      });
+    }
+
+    // last, so it survives the change list and the dependency install above it
+    if (nextSteps.length > 0) {
+      output.log({ title: 'Next steps', body: output.bulletList(nextSteps) });
+    }
   } catch (error) {
     if (error instanceof Error) {
       output.error({

--- a/packages/create-plugin/src/commands/update.command.ts
+++ b/packages/create-plugin/src/commands/update.command.ts
@@ -43,13 +43,28 @@ export const update = async (argv: minimist.ParsedArgs) => {
 
     // filter out minimist internal properties (_ and $0) before passing to codemod
     const { _, $0, ...codemodOptions } = argv;
-    await runMigrations(migrations, {
+    const { nextSteps, skipped } = await runMigrations(migrations, {
       commitEachMigration: !!argv.commit,
       codemodOptions,
     });
-    output.success({
-      title: `Successfully updated create-plugin from ${version} to ${CURRENT_APP_VERSION}.`,
-    });
+
+    // don't claim plain success when part of the run declined - the warnings are further up the
+    // scroll and a green line at the bottom is what the reader takes away
+    if (skipped.length > 0) {
+      output.warning({
+        title: `Updated create-plugin from ${version} to ${CURRENT_APP_VERSION}, with ${skipped.length === 1 ? '1 migration' : `${skipped.length} migrations`} skipped.`,
+        body: output.bulletList(skipped),
+      });
+    } else {
+      output.success({
+        title: `Successfully updated create-plugin from ${version} to ${CURRENT_APP_VERSION}.`,
+      });
+    }
+
+    // one combined list, last, rather than a block per migration
+    if (nextSteps.length > 0) {
+      output.log({ title: 'Next steps', body: output.bulletList(nextSteps) });
+    }
   } catch (error) {
     if (error instanceof Error) {
       output.error({


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR streamlines how codemods talk to the author. They now record on the `Context` with `context.addNextStep()` and `context.skip()`, and the framework renders it, instead of each codemod importing `output` and printing its own way. That fixes `add` reporting a skip and a success at the same time, and puts next steps after the change list and the install rather than before them.

Also updating the `experimental-app-sdk` codemod to align with this pattern. 

Which issue(s) this PR fixes:

**Special notes for your reviewer**:

Currently in `manager.ts`, it bumps `.cprc.json` whether or not a migration skipped, so a skipped migration is marked done permanently. Not sure this is the right path forward? 

